### PR TITLE
Rework how we start habilitations

### DIFF
--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -62,7 +62,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
   end
 
   def create_for_single_page_form
-    organizer = organizer_for_creation(authorization_request_params)
+    organizer = organizer_for_creation
 
     @authorization_request = organizer.authorization_request
 
@@ -77,11 +77,10 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
     end
   end
 
-  def organizer_for_creation(authorization_request_params = nil)
+  def organizer_for_creation
     CreateAuthorizationRequest.call(
       user: current_user,
       authorization_request_form: @authorization_request_form,
-      authorization_request_params:,
     )
   end
 

--- a/app/controllers/authorization_requests_controller.rb
+++ b/app/controllers/authorization_requests_controller.rb
@@ -1,20 +1,12 @@
 class AuthorizationRequestsController < AuthenticatedUserController
+  helper AuthorizationRequestsHelpers
+
   def index
     @authorization_definitions = AuthorizationDefinition.indexable
   end
 
   def new
     @authorization_definition = AuthorizationDefinition.find(id_sanitized)
-
-    if @authorization_definition.available_forms.one?
-      redirect_to new_authorization_request_form_path(form_uid: @authorization_definition.available_forms.first.uid)
-    else
-      begin
-        render @authorization_definition.id
-      rescue ActionView::MissingTemplate
-        render :new
-      end
-    end
   end
 
   private

--- a/app/helpers/authorization_requests_helpers.rb
+++ b/app/helpers/authorization_requests_helpers.rb
@@ -1,4 +1,10 @@
 module AuthorizationRequestsHelpers
+  def start_authorization_request_form(form)
+    authorization_request_form(form.authorization_request_class.new(form_uid: form.uid)) do |f|
+      f.submit t('start_authorization_request_form.cta'), name: :start, id: :start_authorization_request, class: %w[fr-btn fr-icon-save-line fr-btn--icon-left]
+    end
+  end
+
   def authorization_request_form(authorization_request, &)
     [
       form_with(

--- a/app/views/authorization_requests/new.html.erb
+++ b/app/views/authorization_requests/new.html.erb
@@ -4,14 +4,69 @@
   </h1>
 </div>
 
-<p>
-  <%= t('.description', authorization_name: @authorization_definition.name) %>
-</p>
+<div class="fr-mb-4w">
+  <%= t('.organization.description', organization_raison_sociale: current_organization.raison_sociale, organization_siret: current_organization.siret).html_safe %>
 
-<ol>
-  <% @authorization_definition.available_forms.each do |authorization_request_form| %>
-    <li>
-      <%= link_to authorization_request_form.name, new_authorization_request_form_path(form_uid: authorization_request_form.uid) %>
-    </li>
+  <%= form_with(url: "/auth/mon_compte_pro?prompt=select_organization", method: :post, data: { turbo: false }, class: 'inline') do |f| %>
+    <%= f.button t('.organization.change_cta'), id: 'change_current_organization', class: %w(fr-btn fr-btn--sm fr-btn--secondary) %>
   <% end %>
-</ol>
+</div>
+
+<% if current_organization.authorization_requests.where(type: @authorization_definition.authorization_request_class.name).any? %>
+  <div class="fr-alert fr-alert--warning">
+    <h3 class="fr-alert__title">
+      <%= t('authorization_request_forms.build.start.multiple_authorization_requests_warning.title') %>
+    </h3>
+    <p>
+      <%= t('authorization_request_forms.build.start.multiple_authorization_requests_warning.description') %>
+      <ul>
+        <% current_organization.authorization_requests.where(type: @authorization_definition.authorization_request_class.name).each do |another_authorization_request| %>
+          <li>
+            <%= link_to another_authorization_request.name, authorization_request_form_path(form_uid: another_authorization_request.form.uid, id: another_authorization_request.id), target: '_blank' %>
+          </li>
+        <% end %>
+      </ul>
+    </p>
+  </div>
+<% end %>
+
+<% if @authorization_definition.available_forms.one? %>
+  <% authorization_request_form = @authorization_definition.available_forms.first %>
+
+  <% if authorization_request_form.multiple_steps? %>
+    <p>
+      <%= t('.multiple_steps.description') %>
+
+      <ol>
+        <% authorization_request_form.steps.each do |step| %>
+          <li>
+            <%= authorization_request_step_name(authorization_request_form.authorization_request_class.new, step[:name]) %>
+          </li>
+        <% end %>
+      </ol>
+
+      <%= start_authorization_request_form(authorization_request_form) %>
+    </p>
+  <% else %>
+    <p>
+      <%= t('.single_form.description') %>
+
+      <br />
+
+      <%= start_authorization_request_form(authorization_request_form) %>
+    </p>
+  <% end %>
+<% else %>
+  <p>
+    <%= t('.multiple_forms.description', authorization_name: @authorization_definition.name) %>
+  </p>
+
+  <ol>
+    <% @authorization_definition.available_forms.each do |authorization_request_form| %>
+      <li>
+        <%= authorization_request_form.name %>
+        <%= start_authorization_request_form(authorization_request_form) %>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -76,7 +76,20 @@ fr:
       cta: Remplir une demande
     new:
       title: Démarrer une nouvelle habilitation pour %{authorization_name}
-      description: "Il existe plusieurs formulaires pour obtenir une habilitation à %{authorization_name}, sélectionnez celui qui correspond le mieux à votre cas d'usage :"
+      organization:
+        description: "Vous êtes sur le point de démarrer une nouvelle demande d'habilitation pour le compte de <strong>%{organization_raison_sociale}</strong> (numéro de siret: <a href=\"https://annuaire-entreprises.data.gouv.fr/etablissement/%{organization_siret}\" target=\"_blank\">%{organization_siret}</a>).
+  <br />
+  <br />
+  <strong>Attention</strong> : vous ne pourrez pas modifier ces informations dans ce formulaire une fois la demande démarrée. Si vous voulez effectuer cette demande pour le compte d'une autre organisation, veuillez cliquer sur le lien ci-dessous qui vous redirigera vers MonComptePro:"
+        change_cta: Changer d'organisation
+      multiple_forms:
+        description: "Il existe plusieurs formulaires pour obtenir une habilitation à %{authorization_name}, sélectionnez celui qui correspond le mieux à votre cas d'usage :"
+      multiple_steps:
+        description: "Cette demande s'effectue en plusieurs étapes. Vous pouvez à tout moment sauvegarder votre demande et la reprendre plus tard. Les étapes sont les suivantes :"
+      single_form:
+        description: "Cliquez sur le bouton ci-dessous pour démarrer le formulaire. Vous pourrez le sauvegarder et le reprendre plus tard."
+  start_authorization_request_form:
+    cta: Démarrer
   authorization_request_forms:
     create_for_single_page_form:
       success: La demande d'habilitation %{name} a été sauvegardée avec succès

--- a/features/habilitations/api_entreprise.feature
+++ b/features/habilitations/api_entreprise.feature
@@ -7,8 +7,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation API Entreprise
 
   Scénario: Je soumets une demande d'habilitation libre valide
     Quand je démarre une nouvelle demande d'habilitation "API Entreprise"
-    Et que je clique sur "Demande libre"
-    Et que je clique sur "Démarrer"
+    Et que je clique sur "Démarrer" pour le formulaire "Demande libre"
 
     * je renseigne les infos de bases du projet
     * je remplis "Date de mise en production" avec "25/12/2042"
@@ -40,7 +39,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation API Entreprise
 
   Scénario: Je soumets une demande d'habilitation MGDIS valide
     Quand je démarre une nouvelle demande d'habilitation "API Entreprise"
-    Et que je clique sur "MGDIS"
+    Et que je clique sur "Démarrer" pour le formulaire "MGDIS"
 
     * je renseigne les informations des contacts RGPD
     * j'adhère aux conditions générales

--- a/features/habilitations/habilitation_sur_une_page.feature
+++ b/features/habilitations/habilitation_sur_une_page.feature
@@ -8,23 +8,22 @@ Fonctionnalité: Soumission d'une demande d'habilitation simple (sur une seule p
     Sachant que je suis un demandeur
     Et que je me connecte
 
-  Scénario: Le formulaire ne possède qu'un bouton de sauvegarde au démarrage
+  Scénario: Le formulaire ne possède qu'un bouton de démarrage
     Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarche CertDC"
     Alors je suis sur la page "Portail HubEE - Démarche CertDC"
-    Et il y a un bouton "Enregistrer les modifications"
+    Et il y a un bouton "Démarrer"
     Et il n'y a pas de bouton "Soumettre la demande d'habilitation"
 
   Scénario: J'enregistre une demande d'habilitation
     Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarche CertDC"
-    Et que je clique sur "Enregistrer les modifications"
-    Alors il y a un message de succès contenant "sauvegardée avec succès"
-    Et je suis sur la page "Portail HubEE - Démarche CertDC"
+    Et que je clique sur "Démarrer"
+    Alors je suis sur la page "Portail HubEE - Démarche CertDC"
     Et il y a un bouton "Soumettre la demande d'habilitation"
     Et il y a un bouton "Enregistrer les modifications"
 
   Scénario: Je soumets une demande d'habilitation invalide
     Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarche CertDC"
-    Et que je clique sur "Enregistrer les modifications"
+    Et que je clique sur "Démarrer"
     Et que je clique sur "Soumettre la demande d'habilitation"
     Alors il y a un message d'erreur contenant "Une erreur est survenue lors de la soumission de la demande d'habilitation"
     Et il y a au moins une erreur sur un champ
@@ -32,6 +31,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation simple (sur une seule p
 
   Scénario: Je soumets une demande d'habilitation valide
     Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarche CertDC"
+    Et que je clique sur "Démarrer"
     Et que je remplis les informations du contact "Administrateur métier" avec :
       | Nom    | Prénom | Email               | Téléphone   | Fonction de l'administrateur système |
       | Dupont | Jean   | dupont.jean@gouv.fr | 0836656565  | Administrateur métier                |

--- a/features/habilitations/portail_hubee_demarche_certdc.feature
+++ b/features/habilitations/portail_hubee_demarche_certdc.feature
@@ -7,6 +7,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation Portail HubEE - Démarc
 
   Scénario: Je soumets une demande d'habilitation valide
     Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarche CertDC"
+    Et que je clique sur "Démarrer"
     Et que je remplis les informations du contact "Administrateur métier" avec :
       | Nom    | Prénom | Email               | Téléphone   | Fonction              |
       | Dupont | Jean   | dupont.jean@gouv.fr | 0836656565  | Administrateur métier |
@@ -18,6 +19,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation Portail HubEE - Démarc
 
   Scénario: Je soumets une demande d'habilitation avec un champ du contact manquant
     Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarche CertDC"
+    Et que je clique sur "Démarrer"
     Et que je remplis les informations du contact "Administrateur métier" avec :
       | Nom    | Prénom | Email               | Téléphone   | Fonction de l'administrateur système |
       | Dupont |        | dupont.jean@gouv.fr | 0836656565  | Administrateur métier |

--- a/features/liste_des_habilitations.feature
+++ b/features/liste_des_habilitations.feature
@@ -17,5 +17,6 @@ Fonctionnalité: Liste des habilitations
   Scénario: Je démarre une nouvelle habilitation
     Quand je vais sur la page des habilitations
     Et que je clique sur "Remplir une demande" pour l'habilitation "Portail HubEE - Démarche CertDC"
+    Et que je clique sur "Démarrer"
     Alors il y a un titre contenant "Portail HubEE - Démarche CertDC"
     Et il y a un bouton "Enregistrer les modifications"

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -10,6 +10,14 @@ Quand("je démarre une nouvelle demande d'habilitation {string}") do |string|
   visit new_authorization_request_path(id: find_authorization_definition_from_name(string).id)
 end
 
+Quand('je clique sur {string} pour le formulaire {string}') do |cta_name, form_name|
+  form_start_block = find('li', text: form_name)
+
+  within(form_start_block) do
+    click_button(cta_name)
+  end
+end
+
 Quand('je remplis les informations du contact {string} avec :') do |string, table|
   contact_title_node = find('h3', text: string)
   contact_node = contact_title_node.find(:xpath, '..')


### PR DESCRIPTION
There is a single point of entry: /habilitations/:id/new

3 cases, with 3 different views:

1. Single and simple form ;
2. Single and multiple steps form: disclaimer about steps (recommended
   by DSFR team) ;
3. Multiple forms: kind of mix of 1. and 2.

Each comes with a common header which displays:

* A disclaimer about current organization
* If relevant: a warning with others authorizations in progress

-------

* [x] I18n
* ML Faire que 3. soit mieux : blocks and stuff + CtA démarrer direct
* ML Rendre ça customisable (par vue ?)
* QUID des start de form ? imo on garde pour des liens directs à donner (qui ne font pas de création)
* [x] Features tests
* [ ] Review