### PR TITLE
Can create new Authorization Requests in development console

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
-  sequence(:email) { |n| "user#{n}@gouv.fr" }
-  sequence(:external_id) { |n| (n + 100).to_s }
+  sequence(:email) { |n| "user#{User.count + n}@gouv.fr" }
+  sequence(:external_id) { |n| (n + User.maximum('CAST(external_id AS INTEGER)').to_i).to_s }
 
   factory :user do
     email


### PR DESCRIPTION
Previously, unicity condition on email and external_id was preventing from creating more ARs in development

this is a bit ugly (yucky database-lookup when creating objects) but more practical.

(this was requested by @Isalafont which often likes to create objects in the console)