### PR TITLE
Implement diffing within historic

### DIFF
--- a/app/controllers/instruction/authorization_request_events_controller.rb
+++ b/app/controllers/instruction/authorization_request_events_controller.rb
@@ -4,7 +4,7 @@ class Instruction::AuthorizationRequestEventsController < Instruction::Authoriza
   def index
     authorize [:instruction, @authorization_request], :show?
 
-    @events = @authorization_request.events.includes(%i[user entity]).order(created_at: :desc)
+    @events = @authorization_request.events.includes(%i[user entity]).order(created_at: :desc).decorate
   end
 
   private

--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -7,7 +7,48 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
     user.full_name
   end
 
+  def name
+    case object.name
+    when 'submit'
+      if initial_submit?
+        'initial_submit'
+      else
+        'submit'
+      end
+    else
+      object.name
+    end
+  end
+
   def text
-    entity.try(:reason)
+    case name
+    when 'refuse', 'request_changes'
+      entity.reason
+    when 'submit'
+      humanized_changelog
+    end
+  end
+
+  private
+
+  def humanized_changelog
+    h.content_tag(:ul) do
+      object.entity.diff.map { |attribute, values|
+        h.content_tag(:li, build_attribute_change(attribute, values))
+      }.join.html_safe
+    end
+  end
+
+  def build_attribute_change(attribute, values)
+    t(
+      'authorization_request_event.changelog_entry',
+      attribute: object.authorization_request.class.human_attribute_name(attribute),
+      old_value: values.first,
+      new_value: values.last,
+    )
+  end
+
+  def initial_submit?
+    object.entity.diff.all? { |_attribute, values| values.first.nil? }
   end
 end

--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -1,0 +1,13 @@
+class AuthorizationRequestEventDecorator < ApplicationDecorator
+  delegate_all
+
+  def user_full_name
+    return unless user
+
+    user.full_name
+  end
+
+  def text
+    entity.try(:reason)
+  end
+end

--- a/app/interactors/create_authorization_request_changelog.rb
+++ b/app/interactors/create_authorization_request_changelog.rb
@@ -1,0 +1,47 @@
+class CreateAuthorizationRequestChangelog < ApplicationInteractor
+  def call
+    if authorization_request.changelogs.empty?
+      create_initial_changelog
+    else
+      create_changelog_with_diff
+    end
+  end
+
+  private
+
+  def create_initial_changelog
+    create_changelog(
+      authorization_request.data.transform_values { |v| [nil, v] }
+    )
+  end
+
+  def create_changelog_with_diff
+    create_changelog(
+      reified_data.each_with_object({}) do |(key, old_value), diff|
+        next if authorization_request.data[key] == old_value
+
+        diff[key] = [old_value, authorization_request.data[key]]
+      end
+    )
+  end
+
+  def reified_data
+    @reified_data ||= latest_changelog.diff.each_with_object(authorization_request.data.dup) do |(key, value), latest_data|
+      latest_data[key] = value[1]
+    end
+  end
+
+  def latest_changelog
+    @latest_changelog ||= authorization_request.changelogs.last
+  end
+
+  def create_changelog(diff)
+    context.changelog = authorization_request.changelogs.create!(
+      diff:
+    )
+  end
+
+  def authorization_request
+    context.authorization_request
+  end
+end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -21,6 +21,11 @@ class AuthorizationRequest < ApplicationRecord
     inverse_of: :authorization_request,
     dependent: :destroy
 
+  has_many :changelogs,
+    class_name: 'AuthorizationRequestChangelog',
+    inverse_of: :authorization_request,
+    dependent: :destroy
+
   has_many :modification_requests,
     class_name: 'InstructorModificationRequest',
     inverse_of: :authorization_request,

--- a/app/models/authorization_request_changelog.rb
+++ b/app/models/authorization_request_changelog.rb
@@ -1,0 +1,3 @@
+class AuthorizationRequestChangelog < ApplicationRecord
+  belongs_to :authorization_request
+end

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -26,6 +26,7 @@ class AuthorizationRequestEvent < ApplicationRecord
 
     return if name == 'refuse' && entity_type == 'DenialOfAuthorization'
     return if name == 'request_changes' && entity_type == 'InstructorModificationRequest'
+    return if name == 'submit' && entity_type == 'AuthorizationRequestChangelog'
     return if %w[approve reopen].include?(name) && entity_type == 'Authorization'
     return if %w[approve refuse request_changes].exclude?(name) && entity_type == 'AuthorizationRequest'
 

--- a/app/organizers/submit_authorization_request.rb
+++ b/app/organizers/submit_authorization_request.rb
@@ -7,6 +7,7 @@ class SubmitAuthorizationRequest < ApplicationOrganizer
 
   organize AssignParamsToAuthorizationRequest,
     TriggerAuthorizationRequestEvent,
+    CreateAuthorizationRequestChangelog,
     CreateAuthorizationRequestEventModel
 
   after do

--- a/app/organizers/submit_authorization_request.rb
+++ b/app/organizers/submit_authorization_request.rb
@@ -2,6 +2,7 @@ class SubmitAuthorizationRequest < ApplicationOrganizer
   before do
     context.authorization_request_params ||= ActionController::Parameters.new
     context.state_machine_event = :submit
+    context.event_entity = :changelog
     context.save_context ||= :submit
   end
 

--- a/app/queries/authorization_request_events_query.rb
+++ b/app/queries/authorization_request_events_query.rb
@@ -12,6 +12,7 @@ class AuthorizationRequestEventsQuery
         authorization_request.id,
         authorization_request.denials.pluck(:id),
         authorization_request.modification_requests.pluck(:id),
+        authorization_request.changelogs.pluck(:id),
         authorization_request.authorizations.pluck(:id),
       )
   end
@@ -22,6 +23,7 @@ class AuthorizationRequestEventsQuery
     "(entity_id = ? and entity_type = 'AuthorizationRequest') or " \
       "(entity_id in (?) and entity_type = 'DenialOfAuthorization') or " \
       "(entity_id in (?) and entity_type = 'InstructorModificationRequest') or " \
+      "(entity_id in (?) and entity_type = 'AuthorizationRequestChangelog') or " \
       "(entity_id in (?) and entity_type = 'Authorization')"
   end
 end

--- a/app/views/instruction/authorization_request_events/_authorization_request_event.html.erb
+++ b/app/views/instruction/authorization_request_events/_authorization_request_event.html.erb
@@ -14,8 +14,8 @@
     t(
       ".#{authorization_request_event.name}.text",
       **{
-        user_full_name: authorization_request_event.user.try(:full_name),
-        reason: authorization_request_event.entity.try(:reason),
+        user_full_name: authorization_request_event.user_full_name,
+        text: authorization_request_event.text,
       }.compact
     ).html_safe
   %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -22,6 +22,8 @@ fr:
       archived: Archivée
       revoked: Révoquée
     reopening: Mise à jour
+  authorization_request_event:
+    changelog_entry: "Le champ \"%{attribute}\" a changé de \"%{old_value}\" en \"%{new_value}\""
 
   layouts:
     header:
@@ -352,8 +354,15 @@ fr:
           text: "<strong>%{user_full_name}</strong> a mis à jour la demande"
         archive:
           text: "<strong>%{user_full_name}</strong> a archivé la demande"
-        submit:
+        initial_submit:
           text: "<strong>%{user_full_name}</strong> a soumis la demande"
+        submit:
+          text: |
+            <strong>%{user_full_name}</strong> a soumis la demande
+
+            La liste des changements depuis la dernière modération sont:
+            %{text}
+
         approve:
           text: "<strong>%{user_full_name}</strong> a approuvé la demande"
           icon: success-fill

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -363,7 +363,7 @@ fr:
             <strong>%{user_full_name}</strong> a demandé des modifications sur la demande:
 
             <blockquote>
-              %{reason}
+              %{text}
             </blockquote>
           icon: warning-fill
           color: warning
@@ -372,7 +372,7 @@ fr:
             <strong>%{user_full_name}</strong> a refusé la demande:
 
             <blockquote>
-              %{reason}
+              %{text}
             </blockquote>
           icon: error-fill
           color: error

--- a/db/migrate/20240223231856_create_authorization_request_changelogs.rb
+++ b/db/migrate/20240223231856_create_authorization_request_changelogs.rb
@@ -1,0 +1,10 @@
+class CreateAuthorizationRequestChangelogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :authorization_request_changelogs do |t|
+      t.json :diff, default: {}
+      t.references :authorization_request, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240223235741_change_constraints_to_authorization_request_events.rb
+++ b/db/migrate/20240223235741_change_constraints_to_authorization_request_events.rb
@@ -1,0 +1,40 @@
+class ChangeConstraintsToAuthorizationRequestEvents < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_23_231856) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_23_235741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_23_231856) do
     t.index ["entity_type", "entity_id"], name: "index_authorization_request_events_on_entity"
     t.index ["user_id"], name: "index_authorization_request_events_on_user_id"
     t.check_constraint "name::text !~~ 'system_%'::text AND user_id IS NOT NULL OR name::text ~~ 'system_%'::text", name: "user_id_not_null_unless_system_event"
-    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
+    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
   end
 
   create_table "authorization_requests", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_22_161240) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_23_231856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -41,6 +41,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_22_161240) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "authorization_request_changelogs", force: :cascade do |t|
+    t.json "diff", default: {}
+    t.bigint "authorization_request_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["authorization_request_id"], name: "idx_on_authorization_request_id_b550d70011"
   end
 
   create_table "authorization_request_events", force: :cascade do |t|
@@ -132,8 +140,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_22_161240) do
     t.index ["external_id"], name: "index_users_on_external_id", unique: true, where: "(external_id IS NOT NULL)"
   end
 
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.jsonb "object_changes"
+    t.datetime "created_at"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "authorization_request_changelogs", "authorization_requests"
   add_foreign_key "authorizations", "authorization_requests", column: "request_id"
   add_foreign_key "authorizations", "users", column: "applicant_id"
   add_foreign_key "denial_of_authorizations", "authorization_requests"

--- a/features/instruction/historique_habilitation.feature
+++ b/features/instruction/historique_habilitation.feature
@@ -13,5 +13,6 @@ Fonctionnalité: Instruction: historique habilitation
     Et je clique sur "Valider la demande d'habilitation"
     Et que je clique sur "Consulter"
     Et que je clique sur "Historique"
-    Alors la page contient "Dupont Jean a approuvé la demande"
+    Alors la page contient "a approuvé la demande"
+    Et la page contient "a soumis la demande"
 

--- a/features/instruction/historique_habilitation.feature
+++ b/features/instruction/historique_habilitation.feature
@@ -16,3 +16,17 @@ Fonctionnalité: Instruction: historique habilitation
     Alors la page contient "a approuvé la demande"
     Et la page contient "a soumis la demande"
 
+  @DisableBullet
+  Scénario: Je vois les modifications apportées entre 2 soumissions
+    Quand il y a 1 demande d'habilitation "API Entreprise" en attente
+    Et que cette demande a été "sujet à modification"
+    Et que cette demande a été modifiée avec les informations suivantes :
+      | champ       | nouvelle valeur                |
+      | intitule    | Nouvelle valeur de titre       |
+      | description | Nouvelle valeur de description |
+    Et que cette demande a été "soumise"
+    Et que je vais sur la page instruction
+    Et que je clique sur "Consulter"
+    Et que je clique sur "Historique"
+    Alors la page contient "Le champ \"Nom du projet\" a changé de \"Demande d'accès à la plateforme fournisseur\" en \"Nouvelle valeur de titre\""
+    Et la page contient "Le champ \"Description du projet\" a changé de \"Description de la demande\" en \"Nouvelle valeur de description\""

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -35,6 +35,16 @@ Quand('je remplis les informations du contact {string} avec :') do |string, tabl
   end
 end
 
+Quand('cette demande a été modifiée avec les informations suivantes :') do |table|
+  authorization_request = AuthorizationRequest.last
+
+  params = table.hashes.each_with_object({}) do |hash, data|
+    data[hash['champ']] = hash['nouvelle valeur']
+  end
+
+  authorization_request.update!(params)
+end
+
 Quand("je clique sur {string} pour l'habilitation {string}") do |cta_name, habilitation_name|
   click_link cta_name, href: new_authorization_request_path(id: find_authorization_definition_from_name(habilitation_name).id.dasherize) # rubocop:disable Capybara/ClickLinkOrButtonStyle
 end
@@ -121,6 +131,8 @@ Quand('cette demande a été {string}') do |status|
     organizer = ApproveAuthorizationRequest.call(authorization_request:, user:)
   when 'refused'
     organizer = RefuseAuthorizationRequest.call(authorization_request:, user:, denial_of_authorization_params: attributes_for(:denial_of_authorization))
+  when 'changes_requested'
+    organizer = RequestChangesOnAuthorizationRequest.call(authorization_request:, user:, instructor_modification_request_params: attributes_for(:instructor_modification_request))
   else
     raise "Unknown status: #{status}"
   end

--- a/features/support/authorization_request_helpers.rb
+++ b/features/support/authorization_request_helpers.rb
@@ -21,7 +21,7 @@ end
 # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
 def extract_state_from_french_status(status)
   case status
-  when 'attente de modification'
+  when 'attente de modification', 'sujet à modification'
     'changes_requested'
   when 'attente', 'attentes', 'soumise', 'soumises', 'modérer'
     'submitted'

--- a/features/support/bullet.rb
+++ b/features/support/bullet.rb
@@ -1,0 +1,7 @@
+Before do |scenario|
+  Bullet.enable = scenario.source_tag_names.exclude?('@DisableBullet')
+end
+
+After do
+  Bullet.enable = true
+end

--- a/spec/factories/authorization_request_changelogs.rb
+++ b/spec/factories/authorization_request_changelogs.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :authorization_request_changelog do
+    authorization_request { build(:authorization_request, :submitted) }
+
+    after(:build) do |authorization_request_changelog|
+      next if authorization_request_changelog.diff.present?
+
+      authorization_request_changelog.diff = authorization_request_changelog.authorization_request.data.transform_values { |v| [nil, v] }
+    end
+  end
+end

--- a/spec/factories/authorization_request_events.rb
+++ b/spec/factories/authorization_request_events.rb
@@ -27,9 +27,15 @@ FactoryBot.define do
     end
 
     trait :submit do
-      entity_is_authorization_request
-
       name { 'submit' }
+
+      entity factory: %i[authorization_request_changelog]
+
+      after(:build) do |authorization_request_event, evaluator|
+        next if evaluator.authorization_request.blank?
+
+        authorization_request_event.entity = build(:authorization_request_changelog, authorization_request: evaluator.authorization_request)
+      end
     end
 
     trait :approve do

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -87,6 +87,18 @@ FactoryBot.define do
     trait :submitted do
       state { 'submitted' }
       fill_all_attributes { true }
+
+      after(:create) do |authorization_request|
+        changelog = CreateAuthorizationRequestChangelog.call(authorization_request:, user: authorization_request.applicant).changelog
+
+        CreateAuthorizationRequestEventModel.call(
+          authorization_request:,
+          user: authorization_request.applicant,
+          event_name: 'submit',
+          event_entity: :changelog,
+          changelog:,
+        )
+      end
     end
 
     trait :refused do

--- a/spec/models/authorization_request_changelog_spec.rb
+++ b/spec/models/authorization_request_changelog_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe AuthorizationRequestChangelog do
+  it 'has valid factory' do
+    expect(build(:authorization_request_changelog)).to be_valid
+  end
+end

--- a/spec/organizers/approve_authorization_request_spec.rb
+++ b/spec/organizers/approve_authorization_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ApproveAuthorizationRequest do
     let(:user) { create(:user, :instructor, authorization_request_types: %w[hubee_cert_dc]) }
 
     context 'with authorization request in submitted state' do
-      let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
+      let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
 
       it { is_expected.to be_success }
 
@@ -22,7 +22,7 @@ RSpec.describe ApproveAuthorizationRequest do
       end
 
       context 'when it is a reopening' do
-        let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened) }
+        let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened) }
 
         before do
           authorization_request.update!(state: 'submitted')
@@ -48,7 +48,7 @@ RSpec.describe ApproveAuthorizationRequest do
 
       context 'with authorization request which has a bridge' do
         let(:bridge) { instance_double(APIInfinoeSandboxBridge, perform: true) }
-        let(:authorization_request) { create(:authorization_request, :api_infinoe_sandbox, :submitted) }
+        let!(:authorization_request) { create(:authorization_request, :api_infinoe_sandbox, :submitted) }
 
         before do
           allow(APIInfinoeSandboxBridge).to receive(:new).and_return(bridge)
@@ -63,7 +63,7 @@ RSpec.describe ApproveAuthorizationRequest do
     end
 
     context 'with authorization request in draft state' do
-      let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :draft) }
+      let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :draft) }
 
       it { is_expected.to be_failure }
 

--- a/spec/organizers/archive_authorization_request_spec.rb
+++ b/spec/organizers/archive_authorization_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ArchiveAuthorizationRequest do
     let(:user) { create(:user) }
 
     context 'with authorization request in submitted state' do
-      let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
+      let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
 
       it { is_expected.to be_success }
 
@@ -17,7 +17,7 @@ RSpec.describe ArchiveAuthorizationRequest do
     end
 
     context 'with authorization request in validated state' do
-      let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }
+      let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }
 
       it { is_expected.to be_failure }
 

--- a/spec/organizers/refuse_authorization_request_spec.rb
+++ b/spec/organizers/refuse_authorization_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RefuseAuthorizationRequest do
       let(:denial_of_authorization_params) { attributes_for(:denial_of_authorization) }
 
       context 'with authorization request in submitted state' do
-        let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
+        let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
 
         it { is_expected.to be_success }
 
@@ -29,7 +29,7 @@ RSpec.describe RefuseAuthorizationRequest do
         end
 
         context 'when it is a reopening' do
-          let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened) }
+          let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened) }
 
           before do
             authorization_request.update!(state: 'submitted')
@@ -40,7 +40,7 @@ RSpec.describe RefuseAuthorizationRequest do
           end
 
           context 'when there was updates on the authorization request' do
-            let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened, administrateur_metier_email: 'old@gouv.fr') }
+            let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened, administrateur_metier_email: 'old@gouv.fr') }
 
             before do
               authorization_request.administrateur_metier_email = 'new@gouv.fr'
@@ -57,7 +57,7 @@ RSpec.describe RefuseAuthorizationRequest do
       end
 
       context 'with authorization request in draft state' do
-        let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :draft) }
+        let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :draft) }
 
         it { is_expected.to be_failure }
 
@@ -69,7 +69,7 @@ RSpec.describe RefuseAuthorizationRequest do
 
     context 'with invalid params' do
       let(:denial_of_authorization_params) { attributes_for(:denial_of_authorization, reason: nil) }
-      let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
+      let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
 
       it { is_expected.to be_failure }
 

--- a/spec/organizers/request_changes_on_authorization_request_spec.rb
+++ b/spec/organizers/request_changes_on_authorization_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RequestChangesOnAuthorizationRequest do
       let(:instructor_modification_request_params) { attributes_for(:instructor_modification_request) }
 
       context 'with authorization request in submitted state' do
-        let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
+        let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :submitted) }
 
         it { is_expected.to be_success }
 
@@ -25,7 +25,7 @@ RSpec.describe RequestChangesOnAuthorizationRequest do
         end
 
         context 'when it is a reopening' do
-          let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened) }
+          let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened) }
 
           before do
             authorization_request.update!(state: 'submitted')
@@ -40,7 +40,7 @@ RSpec.describe RequestChangesOnAuthorizationRequest do
       end
 
       context 'with authorization request in draft state' do
-        let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :draft) }
+        let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :draft) }
 
         it { is_expected.to be_failure }
 


### PR DESCRIPTION
Je n'ai pas utilisé paper_trail pour 2 raisons:
1. Ça ne gérait pas bien le jsonb => il aurait fallu que je fasse un algo de diffing custom (ce qui représente 80% du code en fait)
2. Mon objet n'étant pas exactement dirty à ce moment là je ne pouvais pas avoir mon snapshot facilement
3. Le 2. fait que j'aurais du faire du tracking sur l'ensemble des update et faire des diff entre 2 versions différentes (en gros le `submit` fait un assign, puis la transition, puis un update, donc 2 `update` in fine)

En bref, j'ai recodé le diffing et introduit un objet plus simple. Ça sera aussi plus simple pour faire la migration.