### PR TITLE
Displays requested changes reason to applicant

### DIFF
--- a/app/policies/authorization_request_policy.rb
+++ b/app/policies/authorization_request_policy.rb
@@ -6,12 +6,12 @@ class AuthorizationRequestPolicy < ApplicationPolicy
 
   def show?
     same_user_and_organization? &&
-      record.in_draft?
+      record.draft?
   end
 
   def summary?
     if same_user_and_organization?
-      !record.in_draft? ||
+      !record.draft? ||
         review_authorization_request.success?
     elsif same_current_organization?
       true

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -2,6 +2,28 @@
   <%= render partial: 'authorization_request_forms/current_user_mentions_alert' %>
 
   <div id="<%= dom_id(@authorization_request, :summary) %>">
+    <% if @authorization_request.changes_requested? %>
+      <div class="fr-alert fr-alert--warning fr-mb-2v">
+        <h3 class="fr-alert__title">
+          <% if @authorization_request.reopening? %>
+            <%= t("authorization_requests.show.reopening_changes_requested.title") %>
+          <% else %>
+            <%= t("authorization_requests.show.changes_requested.title") %>
+          <% end %>
+        </h3>
+
+        <% if @authorization_request.reopening? %>
+          <%= t('authorization_requests.show.reopening_changes_requested.description') %>
+        <% else %>
+          <%= t("authorization_requests.show.changes_requested.description") %>
+        <% end %>
+
+        <blockquote>
+          <%= simple_format(@authorization_request.modification_request.reason) %>
+        </blockquote>
+      </div>
+    <% end %>
+
     <% if @authorization %>
       <% if @authorization.latest? && @authorization.request.reopening? %>
         <div class="fr-alert fr-alert--info fr-mb-4v">

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -140,6 +140,13 @@ fr:
       reopening_refused:
         title: Votre demande de mise à jour a été refusée
         description: *authorization_request_refused_description
+      changes_requested:
+        title: Votre demande d'habilitation nécessite des modifications avant d'être validée
+        description: *authorization_request_refused_description
+      reopening_changes_requested:
+        title: Votre demande de mise à jour nécessite des modifications avant d'être validée
+        description: *authorization_request_refused_description
+
   start_authorization_request_form:
     cta: Débuter mon habilitation pour %{authorization_name}
   authorization_request_forms:

--- a/features/consultation_habilitation.feature
+++ b/features/consultation_habilitation.feature
@@ -17,6 +17,13 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Et il n'y a pas de bouton "Sauvegarder"
     Et il y a un formulaire en mode résumé
 
+  Scénario: Je consulte une demande d'habilitation demandant des modifications m'appartenant
+    Quand je me rends sur une demande d'habilitation "API Entreprise" à modifier
+    Alors il y a un bouton "Modifier"
+    Et il y a un bouton "Soumettre la demande"
+    Et il y a un message d'attention contenant "Veuillez inclure une preuve"
+    Et il y a un formulaire en une seule page
+
   Scénario: Je consulte une demande d'habilitation validée m'appartenant
     Quand je me rends sur une demande d'habilitation "API Entreprise" validée
     Alors il n'y a pas de bouton "Sauvegarder"

--- a/features/consultation_habilitation.feature
+++ b/features/consultation_habilitation.feature
@@ -15,13 +15,11 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Quand je me rends sur une demande d'habilitation "API Entreprise" refusée
     Alors il y a un message d'erreur contenant "a été refusée"
     Et il n'y a pas de bouton "Sauvegarder"
-    Et il n'y a pas de bouton "Soumettre"
     Et il y a un formulaire en mode résumé
 
   Scénario: Je consulte une demande d'habilitation validée m'appartenant
     Quand je me rends sur une demande d'habilitation "API Entreprise" validée
-    Et il n'y a pas de bouton "Sauvegarder"
-    Et il n'y a pas de bouton "Soumettre"
+    Alors il n'y a pas de bouton "Sauvegarder"
     Et il y a un formulaire en mode résumé
 
   Scénario: Je consulte une demande d'habilitation simple en brouillon m'appartenant

--- a/features/support/authorization_request_helpers.rb
+++ b/features/support/authorization_request_helpers.rb
@@ -21,7 +21,7 @@ end
 # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
 def extract_state_from_french_status(status)
   case status
-  when 'attente de modification', 'sujet à modification'
+  when 'attente de modification', 'sujet à modification', 'modifier'
     'changes_requested'
   when 'attente', 'attentes', 'soumise', 'soumises', 'modérer'
     'submitted'

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -78,6 +78,7 @@ FactoryBot.define do
 
     trait :changes_requested do
       state { 'changes_requested' }
+      fill_all_attributes { true }
 
       after(:build) do |authorization_request|
         authorization_request.modification_requests << build(:instructor_modification_request, authorization_request:)


### PR DESCRIPTION
1. Displays summary mode for request changes: no single page nor
   multiple steps ;
2. Forgot to displays the request changes reason in previous iterations

Closes https://linear.app/pole-api/issue/API-2276/un-formulaire-a-etapes-ne-devrait-etre-faisable-quune-fois-tout-du