### PR TITLE
Change all f.submit to f.button type: :submit

### DIFF
--- a/app/helpers/authorization_requests_helpers.rb
+++ b/app/helpers/authorization_requests_helpers.rb
@@ -1,7 +1,7 @@
 module AuthorizationRequestsHelpers
   def start_authorization_request_form(form)
     authorization_request_form_tag(form.authorization_request_class.new(form_uid: form.uid)) do |f|
-      f.submit t('start_authorization_request_form.cta', authorization_name: form.authorization_definition.name), name: :start, id: dom_id(form, :start_authorization_request), class: %w[fr-btn fr-icon-save-line fr-btn--icon-left]
+      f.button t('start_authorization_request_form.cta', authorization_name: form.authorization_definition.name), type: :submit, name: :start, id: dom_id(form, :start_authorization_request), class: %w[fr-btn fr-icon-save-line fr-btn--icon-left]
     end
   end
 

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -111,7 +111,7 @@
 
     <% if policy(@authorization_request).submit? %>
       <div class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left fr-btns-group--right">
-        <%= f.submit t('authorization_request_forms.form.submit'), name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-btn--sm fr-icon-checkbox-line fr-btn--icon-left) %>
+        <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-btn--sm fr-icon-checkbox-line fr-btn--icon-left) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/authorization_request_from_templates/index.html.erb
+++ b/app/views/authorization_request_from_templates/index.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="authorization_request_templates">
   <%= form_with(url: authorization_request_from_templates_path(form_uid: @authorization_request_form.id), method: :post, data: { turbo_frame: "_top" }) do |f| %>
     <%= f.select :template_uid, options_from_collection_for_select(@authorization_request_templates, :id, :name), {}, class: 'fr-select' %>
-    <%= f.submit "Sélectionner", class: %(fr-btn) %>
+    <%= f.button "Sélectionner", type: :submit, class: %(fr-btn) %>
   <% end %>
 </turbo-frame>

--- a/app/views/authorization_requests/blocks/edit.html.erb
+++ b/app/views/authorization_requests/blocks/edit.html.erb
@@ -1,5 +1,5 @@
 <%= authorization_request_form(@authorization_request, url: authorization_request_block_path([@authorization_request, block_id])) do |f| %>
   <%= render partial: "authorization_request_forms/shared/#{block_id}", locals: { f: } %>
 
-  <%= f.submit t('authorization_request_forms.form.save'), name: :save, id: :save_authorization_request, class: %w(fr-btn fr-btn--sm fr-btn--secondary fr-icon-save-line fr-btn--icon-left) %>
+  <%= f.button t('authorization_request_forms.form.save'), type: :submit, name: :save, id: :save_authorization_request, class: %w(fr-btn fr-btn--sm fr-btn--secondary fr-icon-save-line fr-btn--icon-left) %>
 <% end %>

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit t('.search.btn'), class: %w[fr-btn fr-btn--primary] %>
+    <%= f.button t('.search.btn'), type: :submit, class: %w[fr-btn fr-btn--primary] %>
   </div>
 <% end %>
 

--- a/app/views/instruction/refuse_authorization_requests/new.html.erb
+++ b/app/views/instruction/refuse_authorization_requests/new.html.erb
@@ -31,7 +31,7 @@
           <div class="fr-modal__footer">
             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
               <%= link_to t(".#{namespace}.cancel"), '#', class: %w(fr-btn fr-btn--secondary), aria: { controls: 'main-modal' } %>
-              <%= f.submit t(".#{namespace}.refuse"), class: %w(fr-btn fr-btn--primary fr-icon-error-line fr-btn--icon-left) %>
+              <%= f.button t(".#{namespace}.refuse"), type: :submit, class: %w(fr-btn fr-btn--primary fr-icon-error-line fr-btn--icon-left) %>
             </div>
           </div>
         <% end %>

--- a/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
+++ b/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
@@ -31,7 +31,7 @@
           <div class="fr-modal__footer">
             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
               <%= link_to t(".#{namespace}.cancel"), '#', class: %w(fr-btn fr-btn--secondary), aria: { controls: 'main-modal' } %>
-              <%= f.submit t(".#{namespace}.request_changes"), class: %w(fr-btn fr-btn--primary fr-icon-error-line fr-btn--icon-left) %>
+              <%= f.button t(".#{namespace}.request_changes"), type: :submit, class: %w(fr-btn fr-btn--primary fr-icon-error-line fr-btn--icon-left) %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
`submit_tag` generates an input type submit, which is not compatible with DSFR button icons (does not display any).

Closes https://linear.app/pole-api/issue/API-2369/changer-les-fsubmit-en-fbutton-type-submit-pour-afficher-les-icones