### PR TITLE
Track initial changes within changelog for pre-filled forms

### DIFF
--- a/app/models/authorization_request_form.rb
+++ b/app/models/authorization_request_form.rb
@@ -83,6 +83,10 @@ class AuthorizationRequestForm < StaticApplicationRecord
     value_or_default(@public, true)
   end
 
+  def prefilled?
+    data.present?
+  end
+
   def data
     @data || {}
   end

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -155,8 +155,8 @@ FactoryBot.define do
     trait :with_personal_data do
       after(:build) do |authorization_request, evaluator|
         if authorization_request.need_complete_validation? || evaluator.fill_all_attributes
-          authorization_request.destinataire_donnees_caractere_personnel = 'Agents'
-          authorization_request.duree_conservation_donnees_caractere_personnel = 1
+          authorization_request.destinataire_donnees_caractere_personnel ||= 'Agents'
+          authorization_request.duree_conservation_donnees_caractere_personnel ||= '1'
         end
       end
     end
@@ -173,6 +173,8 @@ FactoryBot.define do
     trait :with_scopes do
       after(:build) do |authorization_request, evaluator|
         if authorization_request.need_complete_validation? || evaluator.fill_all_attributes
+          next if authorization_request.scopes.any?
+
           authorization_request.scopes ||= []
           authorization_request.scopes << authorization_request.available_scopes.first.value
         end


### PR DESCRIPTION
https://linear.app/pole-api/issue/API-2411/tracker-les-changemenst-entre-la-creation-et-la-premiere-soumission-si