### PR TITLE
Handle changes on pre-filled forms

### DIFF
--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -10,7 +10,9 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
   def name
     case object.name
     when 'submit'
-      if initial_submit?
+      if initial_submit_with_changed_prefilled?
+        'initial_submit_with_changed_prefilled'
+      elsif initial_submit?
         'initial_submit'
       else
         'submit'
@@ -26,6 +28,8 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
       entity.reason
     when 'submit'
       humanized_changelog
+    when 'initial_submit_with_changed_prefilled'
+      humanized_changelog_without_blank_values
     when 'applicant_message', 'instructor_message'
       entity.body
     end
@@ -34,11 +38,27 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
   private
 
   def humanized_changelog
+    changelog_builder(changelog_diffs)
+  end
+
+  def humanized_changelog_without_blank_values
+    changelog_builder(changelog_diffs_without_blank_values)
+  end
+
+  def changelog_builder(diffs)
     h.content_tag(:ul) do
-      object.entity.diff.map { |attribute, values|
+      diffs.map { |attribute, values|
         h.content_tag(:li, build_attribute_change(attribute, values))
       }.join.html_safe
     end
+  end
+
+  def changelog_diffs
+    object.entity.diff
+  end
+
+  def changelog_diffs_without_blank_values
+    changelog_diffs.reject { |_h, v| v[0].blank? }
   end
 
   def build_attribute_change(attribute, values)
@@ -51,6 +71,18 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
   end
 
   def initial_submit?
-    object.entity.diff.all? { |_attribute, values| values.first.nil? }
+    object.authorization_request.changelogs.one?
+  end
+
+  def initial_submit_with_changed_prefilled?
+    initial_submit? &&
+      object.authorization_request.form.prefilled? &&
+      prefilled_changed?
+  end
+
+  def prefilled_changed?
+    object.authorization_request.form.data.any? do |key, value|
+      object.authorization_request.data[key] != value
+    end
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -392,6 +392,12 @@ fr:
           text: "<strong>%{user_full_name}</strong> a supprimé la demande"
         initial_submit:
           text: "<strong>%{user_full_name}</strong> a soumis la demande"
+        initial_submit_with_changed_prefilled:
+          text: |
+            <strong>%{user_full_name}</strong> a soumis la demande
+
+            Les données suivantes ont été modifiées par rapport aux informations pré-remplies:
+            %{text}
         submit:
           text: |
             <strong>%{user_full_name}</strong> a soumis la demande


### PR DESCRIPTION
Related f49eb99be487a7826f637a938139ff64075840b9

This previous commit did not handled view and displayed strange diffs. This new commit exclude fields with empty initial value.

Ref https://linear.app/pole-api/issue/API-2411/tracker-les-changemenst-entre-la-creation-et-la-premiere-soumission-si