### PR TITLE
Feat/dat 260/etq i je peux revoquer une habilitation validee

### DIFF
--- a/app/controllers/instruction/revoke_authorization_requests_controller.rb
+++ b/app/controllers/instruction/revoke_authorization_requests_controller.rb
@@ -2,13 +2,13 @@ class Instruction::RevokeAuthorizationRequestsController < Instruction::Authoriz
   before_action :authorize_authorization_request_revocation
 
   def new
-    @denial_of_authorization = @authorization_request.denials.build
+    @revocation_of_authorization = @authorization_request.revocations.build
   end
 
   def create
-    organizer = RevokeAuthorizationRequest.call(denial_of_authorization_params:, authorization_request: @authorization_request, user: current_user)
+    organizer = RevokeAuthorizationRequest.call(revocation_of_authorization_params:, authorization_request: @authorization_request, user: current_user)
 
-    @denial_of_authorization = organizer.denial_of_authorization
+    @revocation_of_authorization = organizer.revocation_of_authorization
 
     if organizer.success?
       success_message_for_authorization_request(@authorization_request, key: 'instruction.revoke_authorization_requests.create')
@@ -22,8 +22,8 @@ class Instruction::RevokeAuthorizationRequestsController < Instruction::Authoriz
 
   private
 
-  def denial_of_authorization_params
-    params.require(:denial_of_authorization).permit(
+  def revocation_of_authorization_params
+    params.require(:revocation_of_authorization).permit(
       :reason,
     )
   end

--- a/app/controllers/instruction/revoke_authorization_requests_controller.rb
+++ b/app/controllers/instruction/revoke_authorization_requests_controller.rb
@@ -1,0 +1,38 @@
+class Instruction::RevokeAuthorizationRequestsController < Instruction::AuthorizationRequestsController
+  before_action :authorize_authorization_request_revocation
+
+  def new
+    @denial_of_authorization = @authorization_request.denials.build
+  end
+
+  def create
+    organizer = RevokeAuthorizationRequest.call(denial_of_authorization_params:, authorization_request: @authorization_request, user: current_user)
+
+    @denial_of_authorization = organizer.denial_of_authorization
+
+    if organizer.success?
+      success_message_for_authorization_request(@authorization_request, key: 'instruction.revoke_authorization_requests.create')
+
+      redirect_to instruction_authorization_requests_path,
+        status: :see_other
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def denial_of_authorization_params
+    params.require(:denial_of_authorization).permit(
+      :reason,
+    )
+  end
+
+  def extract_authorization_request
+    @authorization_request = AuthorizationRequest.find(params[:authorization_request_id])
+  end
+
+  def authorize_authorization_request_revocation
+    authorize [:instruction, @authorization_request], :revoke?
+  end
+end

--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -24,7 +24,7 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
 
   def text
     case name
-    when 'refuse', 'request_changes'
+    when 'refuse', 'request_changes', 'revoke'
       entity.reason
     when 'submit'
       humanized_changelog

--- a/app/interactors/create_revocation_of_authorization_model.rb
+++ b/app/interactors/create_revocation_of_authorization_model.rb
@@ -1,0 +1,21 @@
+class CreateRevocationOfAuthorizationModel < ApplicationInteractor
+  def call
+    context.revocation_of_authorization = authorization_request.revocations.build(
+      revocation_of_authorization_params
+    )
+
+    return if context.revocation_of_authorization.save
+
+    context.fail!
+  end
+
+  private
+
+  def authorization_request
+    context.authorization_request
+  end
+
+  def revocation_of_authorization_params
+    context.revocation_of_authorization_params
+  end
+end

--- a/app/mailers/authorization_request_mailer.rb
+++ b/app/mailers/authorization_request_mailer.rb
@@ -1,5 +1,5 @@
 class AuthorizationRequestMailer < ApplicationMailer
-  %i[validated refused changes_requested].each do |state|
+  %i[validated refused changes_requested revoked].each do |state|
     [state, "reopening_#{state}"].each do |mth|
       define_method(mth) do
         @authorization_request = params[:authorization_request]

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -71,6 +71,7 @@ class AuthorizationRequest < ApplicationRecord
   scope :validated_or_refused, -> { where('state in (?) or last_validated_at is not null', %w[validated refused]) }
   scope :not_archived, -> { where.not(state: 'archived') }
   scope :without_reopening, -> { where(last_validated_at: nil) }
+  scope :revoked, -> { where(state: 'revoked') }
 
   validates :form_uid, presence: true
 
@@ -142,6 +143,10 @@ class AuthorizationRequest < ApplicationRecord
 
     event :reopen do
       transition from: :validated, to: :draft, if: ->(authorization_request) { authorization_request.reopenable? }
+    end
+
+    event :revoke do
+      transition from: :validated, to: :revoked
     end
   end
   # rubocop:enable Metrics/BlockLength

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -254,7 +254,7 @@ class AuthorizationRequest < ApplicationRecord
   delegate :reopenable?, to: :definition
 
   def reopening?
-    state != 'validated' &&
+    %w[validated revoked].exclude?(state) &&
       last_validated_at.present?
   end
 

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -26,6 +26,17 @@ class AuthorizationRequest < ApplicationRecord
     inverse_of: :authorization_request,
     dependent: :destroy
 
+  has_many :revocations,
+    class_name: 'RevocationOfAuthorization',
+    inverse_of: :authorization_request,
+    dependent: :destroy
+
+  has_one :revocation,
+    -> { order(created_at: :desc) },
+    class_name: 'RevocationOfAuthorization',
+    inverse_of: :authorization_request,
+    dependent: :destroy
+
   has_many :changelogs,
     class_name: 'AuthorizationRequestChangelog',
     inverse_of: :authorization_request,

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -8,6 +8,7 @@ class AuthorizationRequestEvent < ApplicationRecord
     refuse
     archive
     reopen
+    revoke
 
     applicant_message
     instructor_message

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -1,14 +1,14 @@
 class AuthorizationRequestEvent < ApplicationRecord
   NAMES = %w[
-    create
-    update
-    submit
     approve
-    request_changes
-    refuse
     archive
+    create
+    refuse
+    request_changes
     reopen
     revoke
+    submit
+    update
 
     applicant_message
     instructor_message

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -28,12 +28,12 @@ class AuthorizationRequestEvent < ApplicationRecord
   def entity_type_is_authorized
     return if name.blank? || entity_type.blank?
 
-    return if name == 'refuse' && entity_type == 'DenialOfAuthorization'
+    return if %w[refuse revoke].include?(name) && entity_type == 'DenialOfAuthorization'
     return if name == 'request_changes' && entity_type == 'InstructorModificationRequest'
     return if name == 'submit' && entity_type == 'AuthorizationRequestChangelog'
     return if %w[approve reopen].include?(name) && entity_type == 'Authorization'
     return if %w[applicant_message instructor_message].include?(name) && entity_type == 'Message'
-    return if %w[approve refuse request_changes].exclude?(name) && entity_type == 'AuthorizationRequest'
+    return if %w[approve refuse request_changes revoke].exclude?(name) && entity_type == 'AuthorizationRequest'
 
     errors.add(:entity_type, :invalid)
   end

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -28,7 +28,8 @@ class AuthorizationRequestEvent < ApplicationRecord
   def entity_type_is_authorized
     return if name.blank? || entity_type.blank?
 
-    return if %w[refuse revoke].include?(name) && entity_type == 'DenialOfAuthorization'
+    return if name == 'refuse' && entity_type == 'DenialOfAuthorization'
+    return if name == 'revoke' && entity_type == 'RevocationOfAuthorization'
     return if name == 'request_changes' && entity_type == 'InstructorModificationRequest'
     return if name == 'submit' && entity_type == 'AuthorizationRequestChangelog'
     return if %w[approve reopen].include?(name) && entity_type == 'Authorization'

--- a/app/models/revocation_of_authorization.rb
+++ b/app/models/revocation_of_authorization.rb
@@ -1,0 +1,3 @@
+class RevocationOfAuthorization < ApplicationRecord
+  belongs_to :authorization_request
+end

--- a/app/notifiers/base_notifier.rb
+++ b/app/notifiers/base_notifier.rb
@@ -26,7 +26,7 @@ class BaseNotifier < ApplicationNotifier
     ).submitted.deliver_later
   end
 
-  def revoked(_params) = email_notification('revoked', params)
+  def revoked(params) = email_notification('revoked', params)
 
   %w[
     draft

--- a/app/notifiers/base_notifier.rb
+++ b/app/notifiers/base_notifier.rb
@@ -26,6 +26,8 @@ class BaseNotifier < ApplicationNotifier
     ).submitted.deliver_later
   end
 
+  def revoked(_params) = email_notification('revoked', params)
+
   %w[
     draft
     archived

--- a/app/organizers/refuse_authorization_request.rb
+++ b/app/organizers/refuse_authorization_request.rb
@@ -5,7 +5,7 @@ class RefuseAuthorizationRequest < ApplicationOrganizer
   end
 
   organize CreateDenialOfAuthorizationModel,
+    CreateAuthorizationRequestEventModel,
     ExecuteAuthorizationRequestTransitionWithCallbacks,
-    RestoreAuthorizationRequestToLatestAuthorization,
-    CreateAuthorizationRequestEventModel
+    RestoreAuthorizationRequestToLatestAuthorization
 end

--- a/app/organizers/revoke_authorization_request.rb
+++ b/app/organizers/revoke_authorization_request.rb
@@ -1,0 +1,8 @@
+class RevokeAuthorizationRequest < ApplicationOrganizer
+  before do
+    context.state_machine_event = :revoke
+    context.event_entity = :denial_of_authorization
+  end
+
+  organize ExecuteAuthorizationRequestTransitionWithCallbacks
+end

--- a/app/organizers/revoke_authorization_request.rb
+++ b/app/organizers/revoke_authorization_request.rb
@@ -1,10 +1,10 @@
 class RevokeAuthorizationRequest < ApplicationOrganizer
   before do
     context.state_machine_event = :revoke
-    context.event_entity = :denial_of_authorization
+    context.event_entity = :revocation_of_authorization
   end
 
-  organize CreateDenialOfAuthorizationModel,
+  organize CreateRevocationOfAuthorizationModel,
     CreateAuthorizationRequestEventModel,
     ExecuteAuthorizationRequestTransitionWithCallbacks
 end

--- a/app/organizers/revoke_authorization_request.rb
+++ b/app/organizers/revoke_authorization_request.rb
@@ -4,5 +4,7 @@ class RevokeAuthorizationRequest < ApplicationOrganizer
     context.event_entity = :denial_of_authorization
   end
 
-  organize ExecuteAuthorizationRequestTransitionWithCallbacks
+  organize CreateDenialOfAuthorizationModel,
+    CreateAuthorizationRequestEventModel,
+    ExecuteAuthorizationRequestTransitionWithCallbacks
 end

--- a/app/policies/instruction/authorization_request_policy.rb
+++ b/app/policies/instruction/authorization_request_policy.rb
@@ -8,6 +8,11 @@ class Instruction::AuthorizationRequestPolicy < ApplicationPolicy
       record.can_refuse?
   end
 
+  def revoke?
+    show? &&
+      record.can_revoke?
+  end
+
   def request_changes?
     show? &&
       record.can_request_changes?

--- a/app/queries/authorization_request_events_query.rb
+++ b/app/queries/authorization_request_events_query.rb
@@ -5,21 +5,20 @@ class AuthorizationRequestEventsQuery
     @authorization_request = authorization_request
   end
 
-  # rubocop:disable Metrics/AbcSize
   def perform
     AuthorizationRequestEvent
       .includes(%i[user entity])
       .where(
         sql_query,
         authorization_request.id,
-        authorization_request.denials.pluck(:id),
-        authorization_request.modification_requests.pluck(:id),
-        authorization_request.changelogs.pluck(:id),
-        authorization_request.messages.pluck(:id),
-        authorization_request.authorizations.pluck(:id),
+        authorization_request.denial_ids,
+        authorization_request.modification_request_ids,
+        authorization_request.changelog_ids,
+        authorization_request.message_ids,
+        authorization_request.authorization_ids,
+        authorization_request.revocation_ids
       )
   end
-  # rubocop:enable Metrics/AbcSize
 
   private
 
@@ -29,6 +28,7 @@ class AuthorizationRequestEventsQuery
       "(entity_id in (?) and entity_type = 'InstructorModificationRequest') or " \
       "(entity_id in (?) and entity_type = 'AuthorizationRequestChangelog') or " \
       "(entity_id in (?) and entity_type = 'Message') or " \
-      "(entity_id in (?) and entity_type = 'Authorization')"
+      "(entity_id in (?) and entity_type = 'Authorization') or" \
+      "(entity_id in (?) and entity_type = 'RevocationOfAuthorization')"
   end
 end

--- a/app/views/authorization_request_mailer/revoked.text.erb
+++ b/app/views/authorization_request_mailer/revoked.text.erb
@@ -1,0 +1,13 @@
+<%= render partial: 'mailer/shared/applicant/header', locals: { entity_name: @authorization_request.applicant.full_name } %>
+
+<%=
+  t(
+    '.description',
+    authorization_request_id: @authorization_request.id,
+    authorization_request_name: @authorization_request.name,
+    authorization_request_url: authorization_request_url(@authorization_request),
+    authorization_request_denial_reason: @authorization_request.denial.reason
+  )
+%>
+
+<%= render partial: 'mailer/shared/applicant/footer', locals: { authorization_definition_name: @authorization_request.definition.name } %>

--- a/app/views/authorization_request_mailer/revoked.text.erb
+++ b/app/views/authorization_request_mailer/revoked.text.erb
@@ -6,7 +6,7 @@
     authorization_request_id: @authorization_request.id,
     authorization_request_name: @authorization_request.name,
     authorization_request_url: authorization_request_url(@authorization_request),
-    authorization_request_denial_reason: @authorization_request.denial.reason
+    authorization_request_revocation_reason: @authorization_request.revocation.reason
   )
 %>
 

--- a/app/views/instruction/authorization_requests/_moderation_buttons.html.erb
+++ b/app/views/instruction/authorization_requests/_moderation_buttons.html.erb
@@ -23,6 +23,12 @@
           </li>
         <% end %>
 
+        <% if policy([:instruction, @authorization_request]).revoke? %>
+          <li>
+            <%= dsfr_main_modal_button(t('.revoke'), new_instruction_authorization_request_revocation_path(@authorization_request), class: %w(fr-translate__language fr-nav__link fr-icon-error-line)) %>
+          </li>
+        <% end %>
+
         <% if policy([:instruction, @authorization_request]).archive? %>
           <li>
             <%= dsfr_main_modal_button(t('.archive'), new_instruction_authorization_request_archive_path(@authorization_request), class: %w(fr-translate__language fr-nav__link fr-icon-delete-line)) %>

--- a/app/views/instruction/revoke_authorization_requests/new.html.erb
+++ b/app/views/instruction/revoke_authorization_requests/new.html.erb
@@ -2,7 +2,7 @@
   <div class="fr-grid-row fr-grid-row--center">
     <div class="fr-col-md-offset-1 fr-col-md-10">
       <turbo-frame id="main-modal-content">
-        <%= form_with(model: @denial_of_authorization, url: instruction_authorization_request_revocation_index_path(@authorization_request), data: { turbo_frame: 'main-modal-content' }) do |f| %>
+        <%= form_with(model: @revocation_of_authorization, url: instruction_authorization_request_revocation_index_path(@authorization_request), data: { turbo_frame: 'main-modal-content' }) do |f| %>
           <div class="fr-modal__content">
             <h1 class="fr-modal__title">
               <%= t(".initial.title", authorization_request_name: @authorization_request.name) %>

--- a/app/views/instruction/revoke_authorization_requests/new.html.erb
+++ b/app/views/instruction/revoke_authorization_requests/new.html.erb
@@ -1,0 +1,39 @@
+<div class="simple-page-action-wrapper fr-pt-5w">
+  <div class="fr-grid-row fr-grid-row--center">
+    <div class="fr-col-md-offset-1 fr-col-md-10">
+      <turbo-frame id="main-modal-content">
+        <%= form_with(model: @denial_of_authorization, url: instruction_authorization_request_revocation_index_path(@authorization_request), data: { turbo_frame: 'main-modal-content' }) do |f| %>
+          <div class="fr-modal__content">
+            <h1 class="fr-modal__title">
+              <%= t(".initial.title", authorization_request_name: @authorization_request.name) %>
+            </h1>
+
+            <p>
+              <%=
+                t(
+                  ".initial.description.organization",
+                  authorization_request_name: sanitize(@authorization_request.name),
+                  organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                  organization_siret: @authorization_request.organization.siret,
+                )
+              %>
+            </p>
+
+            <p>
+              <%= t(".initial.description.disclaimer").html_safe %>
+            </p>
+
+            <%= f.dsfr_text_area :reason %>
+          </div>
+
+          <div class="fr-modal__footer">
+            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+              <%= link_to t(".initial.cancel"), '#', class: %w(fr-btn fr-btn--secondary), aria: { controls: 'main-modal' } %>
+              <%= f.button t(".initial.revoke"), type: :submit, class: %w(fr-btn fr-btn--primary fr-icon-error-line fr-btn--icon-left) %>
+            </div>
+          </div>
+        <% end %>
+      </turbo-frame>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -1,6 +1,6 @@
 <% %i[error info success warning].each do |kind| %>
   <% if flash[kind].present? %>
-    <div class="fr-alert fr-alert--<%= kind %> fr-mb-8v" id="<%= flash[kind]['id'] %>">
+    <div class="fr-alert fr-alert--<%= kind %> fr-my-8v" id="<%= flash[kind]['id'] %>">
       <h3 class="fr-alert__title">
         <%= flash[kind]['title'] %>
       </h3>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -130,7 +130,7 @@ ignore_unused:
 - 'authorization_request_mailer.*.subject'
 - 'support.*'
 - 'authorization_request_forms.build.update.{reopening_,}error.*'
-- 'instruction.{approve,refuse,request_changes_on}_authorization_requests.create.{reopening_,}success.title'
+- 'instruction.{approve,refuse,request_changes_on,revoke}_authorization_requests.create.{reopening_,}success.title'
 - 'gdpr_contact_mailer.delegue_protection_donnees.subject'
 - 'gdpr_contact_mailer.responsable_traitement.subject'
 # - '{devise,kaminari,will_paginate}.*'

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -68,7 +68,9 @@ fr:
 
         volumetrie_appels_par_minute: Volumétrie d'appels par minute
       denial_of_authorization:
-        reason: Raison de l'action
+        reason: Raison du refus
+      revocation_of_authorization:
+        reason: Raison de la révocation
       instructor_modification_request:
         reason: Raison de la demande de modification
     errors:

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -70,7 +70,7 @@ fr:
       denial_of_authorization:
         reason: Raison du refus
       revocation_of_authorization:
-        reason: Raison de la révocation
+        reason: Indiquez les motifs de révocation
       instructor_modification_request:
         reason: Raison de la demande de modification
     errors:

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -68,7 +68,7 @@ fr:
 
         volumetrie_appels_par_minute: Volumétrie d'appels par minute
       denial_of_authorization:
-        reason: Raison du refus
+        reason: Raison de l'action
       instructor_modification_request:
         reason: Raison de la demande de modification
     errors:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -336,6 +336,11 @@ fr:
               Merci de renseigner une raison ci-dessous qui sera communiquée au demandeur. A noter que lors du refus, les modifications apportées par le demandeur depuis le début de la réouverture seront annulées. L'habilitation sera toujours valide.
           cancel: Annuler
           refuse: Refuser la demande de mise à jour
+      create:
+        success:
+          title: La demande d'habilitation %{name} a été refusée
+        reopening_success:
+          title: La demande de mise à jour de l'habilitation %{name} a été refusée
 
     revoke_authorization_requests:
       new:
@@ -347,11 +352,11 @@ fr:
             disclaimer: |
               Merci de renseigner une raison ci-dessous qui sera communiquée au demandeur.
           cancel: Annuler
-          revoke: Révoquer la demande d'habilitation
+          revoke: Révoquer l'habilitation
 
       create:
         success:
-          title: La demande d'habilitation %{name} a été révoquée
+          title: L'habilitation %{name} a été révoquée
 
     request_changes_on_authorization_requests:
       new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -345,12 +345,12 @@ fr:
     revoke_authorization_requests:
       new:
         initial:
-          title: Révocation de la demande d'habilitation
+          title: Révocation de l'habilitation
           description:
             organization: |
-              Vous êtes sur le point de révoquer la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de révoquer cette habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
             disclaimer: |
-              Merci de renseigner une raison ci-dessous qui sera communiquée au demandeur.
+              Merci de renseigner les motifs qui seront communiqués au demandeur.
           cancel: Annuler
           revoke: Révoquer l'habilitation
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -351,9 +351,7 @@ fr:
 
       create:
         success:
-          title: La demande d'habilitation %{name} a été refusée
-        reopening_success:
-          title: La demande de mise à jour de l'habilitation %{name} a été refusée
+          title: La demande d'habilitation %{name} a été révoquée
 
     request_changes_on_authorization_requests:
       new:
@@ -434,6 +432,15 @@ fr:
         refuse:
           text: |
             <strong>%{user_full_name}</strong> a refusé la demande:
+
+            <blockquote>
+              %{text}
+            </blockquote>
+          icon: close-circle-line
+          color: error
+        revoke:
+          text: |
+            <strong>%{user_full_name}</strong> a révoqué la demande:
 
             <blockquote>
               %{text}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -324,6 +324,7 @@ fr:
             organization: |
               Vous êtes sur le point de refuser la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
             disclaimer: |
+              <strong>Cette action est irréversible</strong>.
               Merci de renseigner une raison ci-dessous qui sera communiquée au demandeur.
           cancel: Annuler
           refuse: Refuser la demande d'habilitation
@@ -350,6 +351,7 @@ fr:
             organization: |
               Vous êtes sur le point de révoquer cette habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
             disclaimer: |
+              <strong>Cette action est irréversible</strong>.
               Merci de renseigner les motifs qui seront communiqués au demandeur.
           cancel: Annuler
           revoke: Révoquer l'habilitation

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -285,10 +285,11 @@ fr:
             show: Consulter
       moderation_buttons:
         title: Instruire la demande
-        refuse: Refuser
-        request_changes: Demander des modifications
         approve: Valider
         archive: Supprimer
+        refuse: Refuser
+        request_changes: Demander des modifications
+        revoke: Révoquer
     approve_authorization_requests:
       new:
         initial:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -337,6 +337,18 @@ fr:
           cancel: Annuler
           refuse: Refuser la demande de mise à jour
 
+    revoke_authorization_requests:
+      new:
+        initial:
+          title: Révocation de la demande d'habilitation
+          description:
+            organization: |
+              Vous êtes sur le point de révoquer la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+            disclaimer: |
+              Merci de renseigner une raison ci-dessous qui sera communiquée au demandeur.
+          cancel: Annuler
+          revoke: Révoquer la demande d'habilitation
+
       create:
         success:
           title: La demande d'habilitation %{name} a été refusée

--- a/config/locales/mailer.fr.yml
+++ b/config/locales/mailer.fr.yml
@@ -34,7 +34,7 @@ fr:
       description: |
         Votre habilitation "%{authorization_request_name}" (numéro %{authorization_request_id}) a été révoquée par nos équipes pour la raison suivante:
 
-        %{authorization_request_denial_reason}
+        %{authorization_request_revocation_reason}
 
         Vous pouvez consulter votre habilitation en suivant le lien suivant: %{authorization_request_url}
     changes_requested:

--- a/config/locales/mailer.fr.yml
+++ b/config/locales/mailer.fr.yml
@@ -29,6 +29,14 @@ fr:
         %{authorization_request_denial_reason}
 
         Vous pouvez consulter votre habilitation en suivant le lien suivant: %{authorization_request_url}
+    revoked:
+      subject: Votre demande d'habilitation numéro %{authorization_request_id} a été révoquée.
+      description: |
+        Votre habilitation "%{authorization_request_name}" (numéro %{authorization_request_id}) a été révoquée par nos équipes pour la raison suivante:
+
+        %{authorization_request_denial_reason}
+
+        Vous pouvez consulter votre habilitation en suivant le lien suivant: %{authorization_request_url}
     changes_requested:
       subject: Votre demande d'habilitation numéro %{authorization_request_id} requiert des modification
       description: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,9 +52,10 @@ Rails.application.routes.draw do
   namespace :instruction do
     resources :authorization_requests, only: %w[index show], path: 'demandes' do
       resources :approve_authorization_requests, only: %w[new create], path: 'approuver', as: :approval
+      resources :archive_authorization_requests, only: %w[new create], path: 'archiver', as: :archive
       resources :refuse_authorization_requests, only: %w[new create], path: 'refuser', as: :refusal
       resources :request_changes_on_authorization_requests, only: %w[new create], path: 'demande-de-modifications', as: :request_changes
-      resources :archive_authorization_requests, only: %w[new create], path: 'archiver', as: :archive
+      resources :revoque_authorization_requests, only: %w[new create], path: 'révoquer', as: :revocation
 
       resources :authorization_request_events, only: :index, path: 'historique', as: :events
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
       resources :archive_authorization_requests, only: %w[new create], path: 'archiver', as: :archive
       resources :refuse_authorization_requests, only: %w[new create], path: 'refuser', as: :refusal
       resources :request_changes_on_authorization_requests, only: %w[new create], path: 'demande-de-modifications', as: :request_changes
-      resources :revoque_authorization_requests, only: %w[new create], path: 'révoquer', as: :revocation
+      resources :revoke_authorization_requests, only: %w[new create], path: 'révoquer', as: :revocation
 
       resources :authorization_request_events, only: :index, path: 'historique', as: :events
 

--- a/db/migrate/20240326144413_add_revoke_constraints_to_events.rb
+++ b/db/migrate/20240326144413_add_revoke_constraints_to_events.rb
@@ -16,7 +16,7 @@ class AddRevokeConstraintsToEvents < ActiveRecord::Migration[7.1]
         (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
         (name = 'applicant_message' AND entity_type = 'Message') OR
         (name = 'instructor_message' AND entity_type = 'Message') OR
-        (name = 'revoke' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'revoke' AND entity_type = 'RevocationOfAuthorization') OR
         (entity_type = 'AuthorizationRequest')
       )
     SQL

--- a/db/migrate/20240326144413_add_revoke_constraints_to_events.rb
+++ b/db/migrate/20240326144413_add_revoke_constraints_to_events.rb
@@ -1,0 +1,45 @@
+class AddRevokeConstraintsToEvents < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'applicant_message' AND entity_type = 'Message') OR
+        (name = 'instructor_message' AND entity_type = 'Message') OR
+        (name = 'revoke' AND entity_type = 'DenialOfAuthorization') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'revoke' AND entity_type = 'DenialOfAuthorization') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+end

--- a/db/migrate/20240326144413_add_revoke_constraints_to_events.rb
+++ b/db/migrate/20240326144413_add_revoke_constraints_to_events.rb
@@ -37,7 +37,8 @@ class AddRevokeConstraintsToEvents < ActiveRecord::Migration[7.1]
         (name = 'approve' AND entity_type = 'Authorization') OR
         (name = 'reopen' AND entity_type = 'Authorization') OR
         (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
-        (name = 'revoke' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'applicant_message' AND entity_type = 'Message') OR
+        (name = 'instructor_message' AND entity_type = 'Message') OR
         (entity_type = 'AuthorizationRequest')
       )
     SQL

--- a/db/migrate/20240329103410_create_revocation_of_authorizations.rb
+++ b/db/migrate/20240329103410_create_revocation_of_authorizations.rb
@@ -1,0 +1,10 @@
+class CreateRevocationOfAuthorizations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :revocation_of_authorizations do |t|
+      t.string :reason, null: false
+      t.references :authorization_request, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_26_144413) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_29_103410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_26_144413) do
     t.index ["entity_type", "entity_id"], name: "index_authorization_request_events_on_entity"
     t.index ["user_id"], name: "index_authorization_request_events_on_user_id"
     t.check_constraint "name::text !~~ 'system_%'::text AND user_id IS NOT NULL OR name::text ~~ 'system_%'::text", name: "user_id_not_null_unless_system_event"
-    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'DenialOfAuthorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
+    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'RevocationOfAuthorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
   end
 
   create_table "authorization_requests", force: :cascade do |t|
@@ -226,6 +226,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_26_144413) do
     t.index ["user_id"], name: "index_organizations_users_on_user_id"
   end
 
+  create_table "revocation_of_authorizations", force: :cascade do |t|
+    t.string "reason", null: false
+    t.bigint "authorization_request_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["authorization_request_id"], name: "index_revocation_of_authorizations_on_authorization_request_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "family_name"
@@ -265,4 +273,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_26_144413) do
   add_foreign_key "instructor_modification_requests", "authorization_requests"
   add_foreign_key "messages", "authorization_requests"
   add_foreign_key "messages", "users", column: "from_id"
+  add_foreign_key "revocation_of_authorizations", "authorization_requests"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_11_140518) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_26_144413) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_140518) do
     t.index ["entity_type", "entity_id"], name: "index_authorization_request_events_on_entity"
     t.index ["user_id"], name: "index_authorization_request_events_on_user_id"
     t.check_constraint "name::text !~~ 'system_%'::text AND user_id IS NOT NULL OR name::text ~~ 'system_%'::text", name: "user_id_not_null_unless_system_event"
-    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
+    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'DenialOfAuthorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
   end
 
   create_table "authorization_requests", force: :cascade do |t|

--- a/features/instruction/modérer_une_habilitation.feature
+++ b/features/instruction/modérer_une_habilitation.feature
@@ -29,7 +29,7 @@ Fonctionnalité: Instruction: modération
   Scénario: Je refuse une demande d'habilitation avec un message valide
     Quand je me rends sur une demande d'habilitation "API Particulier" à modérer
     Et je clique sur "Refuser"
-    Et que je remplis "Raison de l'action" avec "Vous êtes une entreprise privée"
+    Et que je remplis "Raison du refus" avec "Vous êtes une entreprise privée"
     Et que je clique sur "Refuser la demande d'habilitation"
     Alors je suis sur la page "Liste des demandes en cours"
     Et je vois 1 demande d'habilitation "API Particulier" refusée

--- a/features/instruction/modérer_une_habilitation.feature
+++ b/features/instruction/modérer_une_habilitation.feature
@@ -29,8 +29,8 @@ Fonctionnalité: Instruction: modération
   Scénario: Je refuse une demande d'habilitation avec un message valide
     Quand je me rends sur une demande d'habilitation "API Particulier" à modérer
     Et je clique sur "Refuser"
-    Et que je remplis "Raison du refus" avec "Vous êtes une entreprise privée"
-    Et que je clique sur "Refuser la demande"
+    Et que je remplis "Raison de l'action" avec "Vous êtes une entreprise privée"
+    Et que je clique sur "Refuser la demande d'habilitation"
     Alors je suis sur la page "Liste des demandes en cours"
     Et je vois 1 demande d'habilitation "API Particulier" refusée
     Et un email est envoyé contenant "Vous êtes une entreprise privée"

--- a/features/instruction/révocation_habilitation.feature
+++ b/features/instruction/révocation_habilitation.feature
@@ -12,7 +12,7 @@ Fonctionnalité: Instruction: révocation d'habilitation
   Scénario: Je révoque une habilitation avec un message valide
     Quand je me rends sur une habilitation "API Entreprise" validée
     Et je clique sur "Révoquer"
-    Et que je remplis "Raison de la révocation" avec "Une nouvelle demande a été validée"
+    Et que je remplis "Indiquez les motifs de révocation" avec "Une nouvelle demande a été validée"
     Et que je clique sur "Révoquer l'habilitation"
     Alors je suis sur la page "Liste des demandes en cours"
     Et je vois 1 habilitation "API Entreprise" révoquée

--- a/features/instruction/révocation_habilitation.feature
+++ b/features/instruction/révocation_habilitation.feature
@@ -1,0 +1,20 @@
+# language: fr
+
+Fonctionnalité: Instruction: révocation d'habilitation
+  Un instructeur peut révoquer une habilitation.
+
+  Contexte:
+    Sachant que je suis un instructeur "API Entreprise"
+    Et que je me connecte
+
+  @AvecCourriels
+  @DisableBullet
+  Scénario: Je révoque une habilitation avec un message valide
+    Quand je me rends sur une habilitation "API Entreprise" validée
+    Et je clique sur "Révoquer"
+    Et que je remplis "Reason" avec "Une nouvelle demande a été validée"
+    Et que je clique sur "Révoquer la demande"
+    Alors je suis sur la page "Liste des demandes en cours"
+    Et je vois 1 habilitation "API Entreprise" révoquée
+    Et un email est envoyé contenant "Une nouvelle demande a été validée"
+    Et il y a un message de succès contenant "a été révoquée"

--- a/features/instruction/révocation_habilitation.feature
+++ b/features/instruction/révocation_habilitation.feature
@@ -12,7 +12,7 @@ Fonctionnalité: Instruction: révocation d'habilitation
   Scénario: Je révoque une habilitation avec un message valide
     Quand je me rends sur une habilitation "API Entreprise" validée
     Et je clique sur "Révoquer"
-    Et que je remplis "Raison de l'action" avec "Une nouvelle demande a été validée"
+    Et que je remplis "Raison de la révocation" avec "Une nouvelle demande a été validée"
     Et que je clique sur "Révoquer l'habilitation"
     Alors je suis sur la page "Liste des demandes en cours"
     Et je vois 1 habilitation "API Entreprise" révoquée

--- a/features/instruction/révocation_habilitation.feature
+++ b/features/instruction/révocation_habilitation.feature
@@ -12,8 +12,8 @@ Fonctionnalité: Instruction: révocation d'habilitation
   Scénario: Je révoque une habilitation avec un message valide
     Quand je me rends sur une habilitation "API Entreprise" validée
     Et je clique sur "Révoquer"
-    Et que je remplis "Reason" avec "Une nouvelle demande a été validée"
-    Et que je clique sur "Révoquer la demande"
+    Et que je remplis "Raison de l'action" avec "Une nouvelle demande a été validée"
+    Et que je clique sur "Révoquer l'habilitation"
     Alors je suis sur la page "Liste des demandes en cours"
     Et je vois 1 habilitation "API Entreprise" révoquée
     Et un email est envoyé contenant "Une nouvelle demande a été validée"

--- a/features/instruction/révocation_habilitation.feature
+++ b/features/instruction/révocation_habilitation.feature
@@ -4,17 +4,17 @@ Fonctionnalité: Instruction: révocation d'habilitation
   Un instructeur peut révoquer une habilitation.
 
   Contexte:
-    Sachant que je suis un instructeur "API Entreprise"
+    Sachant que je suis un instructeur "API Particulier"
     Et que je me connecte
 
   @AvecCourriels
   @DisableBullet
   Scénario: Je révoque une habilitation avec un message valide
-    Quand je me rends sur une habilitation "API Entreprise" validée
+    Quand je me rends sur une habilitation "API Particulier" validée
     Et je clique sur "Révoquer"
     Et que je remplis "Indiquez les motifs de révocation" avec "Une nouvelle demande a été validée"
     Et que je clique sur "Révoquer l'habilitation"
     Alors je suis sur la page "Liste des demandes en cours"
-    Et je vois 1 habilitation "API Entreprise" révoquée
+    Et je vois 1 habilitation "API Particulier" révoquée
     Et un email est envoyé contenant "Une nouvelle demande a été validée"
     Et il y a un message de succès contenant "a été révoquée"

--- a/features/support/authorization_request_helpers.rb
+++ b/features/support/authorization_request_helpers.rb
@@ -41,6 +41,8 @@ def extract_state_from_french_status(status)
     'archived'
   when 'réouverte', 'réouvertes'
     'reopened'
+  when 'révoquée', 'révoquées'
+    'revoked'
   else
     raise "Unknown status #{status}"
   end

--- a/spec/factories/authorization_request_events.rb
+++ b/spec/factories/authorization_request_events.rb
@@ -62,6 +62,18 @@ FactoryBot.define do
       end
     end
 
+    trait :revoke do
+      name { 'revoke' }
+
+      entity factory: %i[denial_of_authorization]
+
+      after(:build) do |authorization_request_event, evaluator|
+        next if evaluator.authorization_request.blank?
+
+        authorization_request_event.entity = build(:denial_of_authorization, authorization_request: evaluator.authorization_request)
+      end
+    end
+
     trait :request_changes do
       name { 'request_changes' }
 

--- a/spec/factories/authorization_request_events.rb
+++ b/spec/factories/authorization_request_events.rb
@@ -65,12 +65,12 @@ FactoryBot.define do
     trait :revoke do
       name { 'revoke' }
 
-      entity factory: %i[denial_of_authorization]
+      entity factory: %i[revocation_of_authorization]
 
       after(:build) do |authorization_request_event, evaluator|
         next if evaluator.authorization_request.blank?
 
-        authorization_request_event.entity = build(:denial_of_authorization, authorization_request: evaluator.authorization_request)
+        authorization_request_event.entity = build(:revocation_of_authorization, authorization_request: evaluator.authorization_request)
       end
     end
 

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -84,10 +84,6 @@ FactoryBot.define do
       state { 'archived' }
     end
 
-    trait :revoked do
-      state { 'revoked' }
-    end
-
     trait :changes_requested do
       state { 'changes_requested' }
       fill_all_attributes { true }
@@ -116,6 +112,15 @@ FactoryBot.define do
 
     trait :refused do
       state { 'refused' }
+      fill_all_attributes { true }
+
+      after(:build) do |authorization_request|
+        authorization_request.denials << build(:denial_of_authorization, authorization_request:)
+      end
+    end
+
+    trait :revoked do
+      state { 'revoked' }
       fill_all_attributes { true }
 
       after(:build) do |authorization_request|

--- a/spec/factories/revocation_of_authorizations.rb
+++ b/spec/factories/revocation_of_authorizations.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :revocation_of_authorization do
+    reason { 'une habilitation du même type est validé' }
+    authorization_request factory: %i[authorization_request], state: 'revoked'
+  end
+end


### PR DESCRIPTION
- [x] Affichage de la Pop Up Clé à lier
- [x] Fix i18n Unused key : `instruction.revoke_authorization_requests.create.success.title | La demande d'habilitation %{name} a été révoquée`
- [x] Modification du status Révoquée (s'affiche actuellement un status `révoquée` et un status `en cours de mis à jour` en même temps
![Capture d’écran 2024-03-26 à 11 41 39](https://github.com/etalab/data_pass/assets/43042737/9faaf72d-67bd-4ad9-9dd5-b65a00c4a2c1)
- [x] Sur l'habilitation liée à la demande (snapshot), le status est encore à `validée`
![Capture d’écran 2024-03-26 à 11 41 07](https://github.com/etalab/data_pass/assets/43042737/0bad92be-bed1-4960-9919-90204657fc0a)
- [x] Confirmation que la couleur du status Révoquée est bien la bonne @eva.spaeter 
- [x] Rspec 
- [x] Cucumber