### PR TITLE
Feat/dat 271/ réarranger les champs du tableau

### DIFF
--- a/app/assets/stylesheets/dsfr-extensions.css
+++ b/app/assets/stylesheets/dsfr-extensions.css
@@ -60,3 +60,53 @@
 .fr-bg-alt-blue-france {
   background-color: var(--background-action-low-blue-france);
 }
+
+
+/* Badge Icon */
+
+.fr-badge--purple-glycine::before,
+.fr-badge--secondary::before {
+  content: ""
+}
+
+.fr-badge.fr-badge--info::before,
+.fr-badge--sm.fr-badge--info::before {
+  -webkit-mask-image: url("icons/system/time-fill.svg");
+  mask-image: url("icons/system/time-fill.svg");
+}
+
+.fr-badge.fr-badge--success::before,
+.fr-badge--sm.fr-badge--success::before {
+  -webkit-mask-image: url("icons/system/check-line.svg");
+  mask-image: url("icons/system/check-line.svg");
+}
+
+.fr-badge.fr-badge--error::before,
+.fr-badge--sm.fr-badge--error::before {
+  -webkit-mask-image: url("icons/system/fr--error-fill.svg");
+  mask-image: url("icons/system/fr--error-fill.svg");
+}
+
+.fr-badge.fr-badge--warning::before,
+.fr-badge--sm.fr-badge--warning::before {
+  -webkit-mask-image: url("icons/system/fr--warning-fill.svg");
+  mask-image: url("icons/system/fr--warning-fill.svg");
+}
+
+.fr-badge.fr-badge--new::before,
+.fr-badge--sm.fr-badge--new::before {
+  -webkit-mask-image: url("icons/weather/flashlight-fill.svg");
+  mask-image: url("icons/weather/flashlight-fill.svg");
+}
+
+.fr-badge.fr-badge--purple-glycine::before,
+.fr-badge--sm.fr-badge--purple-glycine::before {
+  -webkit-mask-image: url("icons/others/recycle-fill.svg");
+  mask-image: url("icons/others/recycle-fill.svg");
+}
+
+.fr-badge.fr-badge--secondary::before,
+.fr-badge--sm.fr-badge--secondary::before {
+  -webkit-mask-image: url("icons/business/archive-fill.svg");
+  mask-image: url("icons/business/archive-fill.svg");
+}

--- a/app/assets/stylesheets/dsfr-extensions.css
+++ b/app/assets/stylesheets/dsfr-extensions.css
@@ -61,7 +61,6 @@
   background-color: var(--background-action-low-blue-france);
 }
 
-
 /* Badge Icon */
 
 .fr-badge--purple-glycine::before,
@@ -109,4 +108,16 @@
 .fr-badge--sm.fr-badge--secondary::before {
   -webkit-mask-image: url("icons/business/archive-fill.svg");
   mask-image: url("icons/business/archive-fill.svg");
+}
+
+/* Badge color */
+
+fr-badge--grey {
+  background-color: var(--grey-975-75-hover);
+  color: var(--grey-50-1000);
+}
+
+.fr-badge.fr-badge--secondary {
+  background-color: var(--grey-50-1000);
+  color: var(--grey-1000-50);
 }

--- a/app/controllers/instruction/authorization_requests_controller.rb
+++ b/app/controllers/instruction/authorization_requests_controller.rb
@@ -5,7 +5,7 @@ class Instruction::AuthorizationRequestsController < InstructionController
   before_action :extract_authorization_request, except: [:index]
 
   def index
-    @q = policy_scope([:instruction, AuthorizationRequest]).not_archived.ransack(params[:q])
+    @q = policy_scope([:instruction, AuthorizationRequest]).includes([:organization]).not_archived.ransack(params[:q])
     @q.sorts = 'created_at desc' if @q.sorts.empty?
     @authorization_requests = @q.result(distinct: true).page(params[:page])
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,10 +13,10 @@ module ApplicationHelper
     @authorization_definition.present? && @display_provider_logo_in_header # rubocop:disable Naming/HelperInstanceVariable
   end
 
-  def authorization_request_status_badge(authorization_request, no_icon: false)
+  def authorization_request_status_badge(authorization_request, no_icon: false, scope: nil)
     content_tag(
       :span,
-      t("authorization_request.status.#{authorization_request.state}"),
+      t(authorization_request_status_badge_translation(authorization_request, scope)),
       class: [
         'fr-badge',
         no_icon ? 'fr-badge--no-icon' : nil,
@@ -49,5 +49,14 @@ module ApplicationHelper
       t('authorization_request.reopening'),
       class: 'fr-badge fr-badge--no-icon fr-badge--purple-glycine',
     )
+  end
+
+  def authorization_request_status_badge_translation(authorization_request, scope)
+    case scope
+    when :instruction, 'instruction'
+      "instruction.authorization_requests.index.status.#{authorization_request.state}"
+    else
+      "authorization_request.status.#{authorization_request.state}"
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
   def authorization_request_status_badge_class(authorization_request)
     case authorization_request.state
     when 'draft'
-      %w[fr-badge--purple-glycine fr-badge--no-icon]
+      %w[fr-badge--grey fr-badge--no-icon]
     when 'changes_requested'
       %w[fr-badge--warning]
     when 'submitted'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,7 @@ module ApplicationHelper
     when 'validated'
       %w[fr-badge--success]
     when 'refused', 'revoked'
-      %w[fr-badge--error fr-badge--no-icon]
+      %w[fr-badge--error]
     when 'archived'
       %w[fr-badge--secondary]
     end
@@ -47,7 +47,7 @@ module ApplicationHelper
     content_tag(
       :span,
       t('authorization_request.reopening'),
-      class: 'fr-badge fr-badge--no-icon fr-badge--purple-glycine',
+      class: 'fr-badge fr-badge--purple-glycine',
     )
   end
 

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -60,9 +60,6 @@
     <tbody>
       <% @authorization_requests.each do |authorization_request| %>
         <tr id="<%= dom_id(authorization_request) %>" class="authorization-request">
-          <td class="authorization-request-id">
-            <%= authorization_request.id %>
-          </td>
           <td class="authorization-request-state">
             <%= authorization_request_status_badge(authorization_request) %>
 
@@ -70,17 +67,20 @@
               <%= authorization_request_reopening_badge %>
             <% end %>
           </td>
-          <td class="authorization-request-name">
+          <td class="authorization-request-created_at">
+            <%= authorization_request.created_at.strftime("%d/%m/%y") %>
+          </td>
+          <td class="authorization-request-organization">
+            <%= authorization_request.applicant.current_organization.raison_sociale %>
+          </td>
+          <td class="authorization-request-project-name">
             <%= authorization_request.name %>
           </td>
-          <td class="authorization-request-created_at">
-            <%= authorization_request.created_at %>
-          </td>
-          <td class="authorization-request-definition-name">
+          <td class="authorization-request-target-api">
             <%= authorization_request.definition.name %>
           </td>
-          <td class="authorization-request-form-name">
-            <%= authorization_request.form.name %>
+          <td class="authorization-request-applicant-email">
+            <%= authorization_request.applicant.email %>
           </td>
           <td class="authorization-request-actions">
             <%= link_to t('.table.actions.show'), instruction_authorization_request_path(authorization_request), class: %w(fr-btn fr-btn--sm) %>

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -35,12 +35,12 @@
       <tr>
         <%
           %w[
-            id
             status
-            name
             created_at
-            type
-            form_name
+            organization
+            project_name
+            target_api
+            applicant_email
             actions
           ].each do |attr|
         %>

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -71,12 +71,12 @@
             <%= authorization_request.created_at.strftime("%d/%m/%y") %>
           </td>
           <td class="authorization-request-organization">
-            <%= authorization_request.applicant.current_organization.raison_sociale %>
+            <%= authorization_request.organization.raison_sociale %>
           </td>
           <td class="authorization-request-project-name">
             <%= authorization_request.name %>
           </td>
-          <td class="authorization-request-target-api">
+          <td class="authorization-request-definition-name">
             <%= authorization_request.definition.name %>
           </td>
           <td class="authorization-request-applicant-email">

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -1,3 +1,5 @@
+<p class="fr-h2 fr-mt-5w"><%= t('.table.caption') %></p>
+
 <%= search_form_for(@q, url: instruction_authorization_requests_path, html: { method: :get, data: { turbo: false }, class: %w[search-box] }) do |f| %>
   <div class="search-inputs">
     <div class="fr-input-group input">
@@ -28,9 +30,6 @@
 
 <div class="fr-table fr-table--bordered fr-table--layout-fixed">
   <table>
-    <caption>
-      <%= t('.table.caption') %>
-    </caption>
     <thead>
       <tr>
         <%

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -61,7 +61,7 @@
       <% @authorization_requests.each do |authorization_request| %>
         <tr id="<%= dom_id(authorization_request) %>" class="authorization-request">
           <td class="authorization-request-state">
-            <%= authorization_request_status_badge(authorization_request) %>
+            <%= authorization_request_status_badge(authorization_request, scope: :instruction) %>
 
             <% if authorization_request.reopening? %>
               <%= authorization_request_reopening_badge %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -133,6 +133,7 @@ ignore_unused:
 - 'instruction.{approve,refuse,request_changes_on}_authorization_requests.create.{reopening_,}success.title'
 - 'gdpr_contact_mailer.delegue_protection_donnees.subject'
 - 'gdpr_contact_mailer.responsable_traitement.subject'
+- 'instruction.authorization_requests.index.status.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -275,7 +275,7 @@ fr:
           caption: Liste des demandes en cours
           header:
             status: Statut
-            created_at: Date
+            created_at: Date de création
             organization: Organisation
             project_name: Projet
             target_api: Nom de l'API
@@ -283,6 +283,14 @@ fr:
             actions: Actions
           actions:
             show: Consulter
+        status:
+          draft: Brouillon
+          changes_requested: A modifier
+          submitted: En cours
+          validated: Validée
+          refused: Refusée
+          archived: Archivée/supprimée
+          revoked: Révoquée
       moderation_buttons:
         title: Instruire la demande
         refuse: Refuser

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -274,12 +274,12 @@ fr:
         table:
           caption: Liste des demandes en cours
           header:
-            id: Identifiant
-            name: Intitulé de la demande
-            created_at: Date
-            type: Type de données
-            form_name: Nom du formulaire
             status: Statut
+            created_at: Date
+            organization: Organisation
+            project_name: Projet
+            target_api: Nom de l'API
+            applicant_email: Email du demandeur
             actions: Actions
           actions:
             show: Consulter

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,7 +19,7 @@ fr:
       submitted: En cours d'instruction
       validated: Validée
       refused: Refusée
-      archived: Archivée/supprimée
+      archived: Archivée
       revoked: Révoquée
     reopening: Mise à jour
     contacts:
@@ -289,7 +289,7 @@ fr:
           submitted: En cours
           validated: Validée
           refused: Refusée
-          archived: Archivée/supprimée
+          archived: Archivée
           revoked: Révoquée
       moderation_buttons:
         title: Instruire la demande

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -150,9 +150,9 @@ Quand(/je suis mentionné dans (\d+) demandes? d'habilitation "([^"]+)" en tant 
 end
 
 # https://rubular.com/r/dRUFmK5dzDpjJv
-Alors(/je vois (\d+) demandes? d'habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, type, status|
-  if type.present?
-    expect(page).to have_css('.authorization-request-definition-name', text: type, count:)
+Alors(/je vois (\d+) demandes? d'habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, target_api, status|
+  if target_api.present?
+    expect(page).to have_css('.authorization-request-target-api', text: target_api, count:)
   else
     expect(page).to have_css('.authorization-request', count:)
   end

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -150,9 +150,9 @@ Quand(/je suis mentionné dans (\d+) demandes? d'habilitation "([^"]+)" en tant 
 end
 
 # https://rubular.com/r/dRUFmK5dzDpjJv
-Alors(/je vois (\d+) demandes? d'habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, target_api, status|
-  if target_api.present?
-    expect(page).to have_css('.authorization-request-target-api', text: target_api, count:)
+Alors(/je vois (\d+) demandes? d'habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, definition_name, status|
+  if definition_name.present?
+    expect(page).to have_css('.authorization-request-definition-name', text: definition_name, count:)
   else
     expect(page).to have_css('.authorization-request', count:)
   end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -9,6 +9,7 @@ end
 Alors('il y a un titre contenant {string}') do |text|
   elements = [
     page.all('h1').first,
+    page.all('p.fr-h2').first,
     page.all('h2').first,
     page.all('table caption').first,
   ]


### PR DESCRIPTION
Cette PR ne couvre que les points suivants du ticket 

- [x] Les colonnes ne correspondent pas à la maquette
- [x] Le titre de la page devrait être au dessus des filtres

![Capture d’écran 2024-04-03 à 16 42 20](https://github.com/etalab/data_pass/assets/43042737/b03c0c02-4adc-4174-bc36-3fcd93d77992)


Petite interrogation 
- Est ce qu'il y a un hover sur la ligne d'habilitation pour ouvrir l'habilitation en place du bouton consulter ? 
- Rappel des deux boutons (messagerie Demandeur / instructeur - demande d'opinion ou demande d'avis entre instructeurs ? ) 