### PR TITLE
BUGFIX Summary submit which cleans checked scopes not included by default

### DIFF
--- a/app/form_builders/authorization_request_form_builder.rb
+++ b/app/form_builders/authorization_request_form_builder.rb
@@ -97,9 +97,18 @@ class AuthorizationRequestFormBuilder < DSFRFormBuilder
             nil
           ),
           dsfr_scope_label(scope),
-          scope.included? ? scope_hidden_field(scope) : nil
+          include_scope_hidden_field?(scope, disabled) ? scope_hidden_field(scope) : nil
         ].compact
       )
+    end
+  end
+
+  def include_scope_hidden_field?(scope, disabled)
+    if disabled
+      scope.included? ||
+        @object.scopes.include?(scope.value)
+    else
+      scope.included?
     end
   end
 

--- a/spec/features/authorization_requests/scopes_spec.rb
+++ b/spec/features/authorization_requests/scopes_spec.rb
@@ -1,54 +1,83 @@
-RSpec.describe 'Authorization request with a scope step' do
-  let(:user) { create(:user) }
-  let(:authorization_request) do
-    authorization_request = create(:authorization_request, :api_particulier, fill_all_attributes: true, applicant: user)
-    authorization_request.current_build_step = 'basic_infos'
-    authorization_request.scopes = nil
-    authorization_request.save!
-    authorization_request
-  end
-  let(:authorization_request_form) { authorization_request.form }
+RSpec.describe 'Authorization request with scopes' do
+  describe 'at the scope step' do
+    let(:user) { create(:user) }
+    let(:authorization_request) do
+      authorization_request = create(:authorization_request, :api_particulier, fill_all_attributes: true, applicant: user)
+      authorization_request.current_build_step = 'basic_infos'
+      authorization_request.scopes = nil
+      authorization_request.save!
+      authorization_request
+    end
+    let(:authorization_request_form) { authorization_request.form }
 
-  let(:scope_step_name) { I18n.t('wicked.scopes') }
+    let(:scope_step_name) { I18n.t('wicked.scopes') }
 
-  before do
-    sign_in(user)
+    before do
+      sign_in(user)
 
-    visit authorization_request_form_build_path(form_uid: authorization_request_form.uid, authorization_request_id: authorization_request.id, id: scope_step_name)
-  end
+      visit authorization_request_form_build_path(form_uid: authorization_request_form.uid, authorization_request_id: authorization_request.id, id: scope_step_name)
+    end
 
-  describe 'submitting no scope' do
-    subject(:submitting_without_scope) do
-      within(css_id(authorization_request)) do
-        click_link_or_button 'next_authorization_request'
+    describe 'submitting no scope' do
+      subject(:submitting_without_scope) do
+        within(css_id(authorization_request)) do
+          click_link_or_button 'next_authorization_request'
+        end
+      end
+
+      it 'does not change scopes and displays an error' do
+        expect {
+          submitting_without_scope
+        }.not_to change { authorization_request.reload.scopes }
+
+        expect(page).to have_css('.fr-alert')
       end
     end
 
-    it 'does not change scopes and displays an error' do
-      expect {
-        submitting_without_scope
-      }.not_to change { authorization_request.reload.scopes }
+    describe 'submitting with one scope' do
+      subject(:submitting_without_scope) do
+        within(css_id(authorization_request)) do
+          check 'authorization_request_api_particulier_scopes_cnaf_quotient_familial'
 
-      expect(page).to have_css('.fr-alert')
+          click_link_or_button 'next_authorization_request'
+        end
+      end
+
+      it 'changes scopes and change step' do
+        expect {
+          submitting_without_scope
+        }.to change { authorization_request.reload.scopes }.to(['cnaf_quotient_familial'])
+
+        expect(page).to have_no_css('.fr-alert')
+        expect(page).to have_no_current_path(authorization_request_form_build_path(form_uid: authorization_request_form.uid, authorization_request_id: authorization_request.id, id: scope_step_name))
+      end
     end
   end
 
-  describe 'submitting with one scope' do
-    subject(:submitting_without_scope) do
-      within(css_id(authorization_request)) do
-        check 'authorization_request_api_particulier_scopes_cnaf_quotient_familial'
+  describe 'at the review step, with some scopes defined' do
+    let(:user) { create(:user) }
+    let(:authorization_request) do
+      authorization_request = create(:authorization_request, :api_entreprise, fill_all_attributes: true, applicant: user)
+      authorization_request.scopes = default_scopes + additional_scopes
+      authorization_request.save!
+      authorization_request
+    end
+    let(:default_scopes) { AuthorizationDefinition.find('api_entreprise').scopes.select(&:included?).map(&:value) }
+    let(:additional_scopes) { %w[unites_legales_etablissements_insee] }
 
-        click_link_or_button 'next_authorization_request'
-      end
+    before do
+      sign_in(user)
+
+      visit summary_authorization_request_form_path(form_uid: authorization_request.form.uid, id: authorization_request.id)
     end
 
-    it 'changes scopes and change step' do
-      expect {
-        submitting_without_scope
-      }.to change { authorization_request.reload.scopes }.to(['cnaf_quotient_familial'])
+    it 'keeps the scopes on submit' do
+      check 'authorization_request_api_entreprise_terms_of_service_accepted'
+      check 'authorization_request_api_entreprise_data_protection_officer_informed'
 
-      expect(page).to have_no_css('.fr-alert')
-      expect(page).to have_no_current_path(authorization_request_form_build_path(form_uid: authorization_request_form.uid, authorization_request_id: authorization_request.id, id: scope_step_name))
+      click_on 'submit_authorization_request'
+
+      expect(authorization_request.reload.scopes).to match_array((default_scopes + additional_scopes))
     end
   end
 end


### PR DESCRIPTION
This is a known limitation of the HTTP protocol: the specification ignores checkbox checked and disabled (context/source https://www.ruby-forum.com/t/check-box-tag-and-disabled-disabled-problem/59023/2)

The previous version tackles this by including an hidden input for included scopes (which are disabled by default) when we are currently filling the authorization request (ref f6a9ace3dd07a9030ff2b7ba3dcac67419779dbb)

However, when we are on the summary page, all checkboxes are disabled, so we have to include this hidden input too on previous checked scopes, for the same reason as described above.