### PR TITLE
Harden tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,14 +81,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-  config.before(:each, type: :request) do
-    OmniAuth.config.test_mode = true
-  end
-
-  config.after(:each, type: :request) do
-    OmniAuth.config.mock_auth[:mon_compte_pro] = nil
-    OmniAuth.config.test_mode = false
-  end
 
   config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
spec/features/profile_spec.rb failed with seed 9503. After inspect it seems that OmniAuth was not in test mode.

There was a specific config for request specs on OmniAuth, which seems to be useless: `OmniAuth.config.test_mode` is already true thanks to initializers, and remove the `mon_compte_pro` mock is not relevant on all tests.

This commit simplifies and make it green