### PR TITLE
Change default_from for mailing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module DataPass
 
     config.action_mailer.preview_paths = [Rails.root.join('spec/mailers/previews')]
 
-    config.default_from = 'support@datapass.api.gouv.fr'
+    config.default_from = 'notifications@api.gouv.fr'
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Make it iso to v1. This email has an auto-reply to indicates that there's no human behind (almost a `no-reply`).