### PR TITLE
Introduce basic copy relationship

### DIFF
--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -36,6 +36,12 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
   end
   alias comment text # see WebhookEventSerializer
 
+  def copied_from_authorization_request_id
+    return unless name == 'copy'
+
+    entity.copied_from_request.id
+  end
+
   private
 
   def humanized_changelog

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -66,6 +66,16 @@ class AuthorizationRequest < ApplicationRecord
     inverse_of: :entity,
     dependent: :destroy
 
+  has_one :copied_from_request,
+    inverse_of: :next_request_copied,
+    class_name: 'AuthorizationRequest',
+    dependent: :nullify
+
+  belongs_to :next_request_copied,
+    class_name: 'AuthorizationRequest',
+    inverse_of: :copied_from_request,
+    optional: true
+
   def latest_authorization
     authorizations.order(created_at: :desc).limit(1).first
   end

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -10,6 +10,8 @@ class AuthorizationRequestEvent < ApplicationRecord
     submit
     update
 
+    copy
+
     applicant_message
     instructor_message
 

--- a/app/views/instruction/authorization_request_events/_authorization_request_event.html.erb
+++ b/app/views/instruction/authorization_request_events/_authorization_request_event.html.erb
@@ -16,6 +16,7 @@
       **{
         user_full_name: authorization_request_event.user_full_name,
         text: simple_format(authorization_request_event.text),
+        copied_from_authorization_request_id: authorization_request_event.copied_from_authorization_request_id,
       }.compact
     ).html_safe
   %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -467,6 +467,10 @@ fr:
           icon: close-circle-line
           color: error
 
+        copy:
+          text: |
+            <strong>%{user_full_name}</strong> a copié la demande %{copied_from_authorization_request_id}
+
         reopen:
           text: "<strong>%{user_full_name}</strong> a réouvert l'habilitation"
 

--- a/db/migrate/20240424133631_add_next_request_copied_on_authorization_requests.rb
+++ b/db/migrate/20240424133631_add_next_request_copied_on_authorization_requests.rb
@@ -1,0 +1,5 @@
+class AddNextRequestCopiedOnAuthorizationRequests < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :authorization_requests, :next_request_copied, foreign_key: { to_table: :authorization_requests }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_29_103410) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_24_133631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -87,7 +87,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_29_103410) do
     t.string "form_uid", null: false
     t.datetime "reopened_at"
     t.string "linked_token_manager_id"
+    t.bigint "next_request_copied_id"
     t.index ["applicant_id"], name: "index_authorization_requests_on_applicant_id"
+    t.index ["next_request_copied_id"], name: "index_authorization_requests_on_next_request_copied_id"
     t.index ["organization_id"], name: "index_authorization_requests_on_organization_id"
   end
 
@@ -267,6 +269,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_29_103410) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authorization_documents", "authorizations"
   add_foreign_key "authorization_request_changelogs", "authorization_requests"
+  add_foreign_key "authorization_requests", "authorization_requests", column: "next_request_copied_id"
   add_foreign_key "authorizations", "authorization_requests", column: "request_id"
   add_foreign_key "authorizations", "users", column: "applicant_id"
   add_foreign_key "denial_of_authorizations", "authorization_requests"

--- a/spec/factories/authorization_request_events.rb
+++ b/spec/factories/authorization_request_events.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :authorization_request_event do
     name { 'create' }
     user
-    entity factory: %i[authorization_request]
+    entity factory: %i[authorization_request api_entreprise]
 
     transient do
       authorization_request { nil }
@@ -101,6 +101,22 @@ FactoryBot.define do
         next if evaluator.authorization_request.blank?
 
         authorization_request_event.entity = build(:authorization, request: evaluator.authorization_request)
+      end
+    end
+
+    trait :copy do
+      entity factory: %i[authorization_request api_entreprise]
+      entity_is_authorization_request
+
+      name { 'copy' }
+
+      after(:build) do |authorization_request_event|
+        authorization_request = authorization_request_event.entity
+        authorization_request_trait = authorization_request.type.split('::').last.underscore.to_sym
+
+        copied_from_authorization_request = create(:authorization_request, :validated, authorization_request_trait, applicant: authorization_request.applicant)
+
+        authorization_request_event.entity.copied_from_request = copied_from_authorization_request
       end
     end
 

--- a/spec/features/instruction/events_spec.rb
+++ b/spec/features/instruction/events_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Instruction: habilitation events' do
   let(:user) { create(:user, :instructor) }
-  let(:authorization_request) { create(:authorization_request, applicant: user) }
+  let(:authorization_request) { create(:authorization_request, :api_entreprise, applicant: user) }
 
   before do
     sign_in(user)

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -172,4 +172,15 @@ RSpec.describe AuthorizationRequest do
       it { is_expected.to be_valid }
     end
   end
+
+  describe 'copy behaviour' do
+    subject!(:authorization_request_copy) do
+      create(:authorization_request, :api_entreprise, copied_from_request: authorization_request)
+    end
+
+    let(:authorization_request) { create(:authorization_request, :api_entreprise, :validated) }
+
+    it { expect(authorization_request_copy.copied_from_request).to eq(authorization_request) }
+    it { expect(authorization_request.next_request_copied).to eq(authorization_request_copy) }
+  end
 end

--- a/spec/queries/authorization_request_events_query_spec.rb
+++ b/spec/queries/authorization_request_events_query_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe AuthorizationRequestEventsQuery, type: :FEEDME do
   describe '#perform' do
     subject(:events) { described_class.new(authorization_request).perform }
 
-    let(:authorization_request) { create(:authorization_request).reload }
+    let(:authorization_request) { create(:authorization_request, :api_entreprise).reload }
 
     before do
       AuthorizationRequestEvent::NAMES.each_with_index do |event_name, index|


### PR DESCRIPTION
Mostly for migration from v1, displays only (no copy button for now, not required for API Entreprise).