### PR TITLE
Feature/dat 357 etq u si mon organisation a deja des scopes hubee dila

### DIFF
--- a/app/helpers/authorization_requests_helpers.rb
+++ b/app/helpers/authorization_requests_helpers.rb
@@ -52,4 +52,10 @@ module AuthorizationRequestsHelpers
 
     authorization_request.filling?
   end
+
+  def hubee_dila_selected_scopes_for_current_organization
+    authorization_requests = AuthorizationRequest.where(type: 'AuthorizationRequest::HubEEDila', organization: current_organization.id, state: %w[validated submitted changes_requested],)
+
+    authorization_requests.map(&:scopes).flatten.uniq.join(', ')
+  end
 end

--- a/app/helpers/authorization_requests_helpers.rb
+++ b/app/helpers/authorization_requests_helpers.rb
@@ -53,8 +53,10 @@ module AuthorizationRequestsHelpers
     authorization_request.filling?
   end
 
-  def hubee_dila_selected_scopes_for_current_organization
-    authorization_requests = AuthorizationRequest.where(type: 'AuthorizationRequest::HubEEDila', organization: current_organization.id, state: %w[validated submitted changes_requested],)
+  def hubee_dila_selected_scopes_for_current_organization(authorization_request = nil)
+    authorization_requests = AuthorizationRequest.where(type: 'AuthorizationRequest::HubEEDila', organization: current_organization.id, state: %w[draft validated submitted changes_requested])
+
+    authorization_requests = authorization_requests.where.not(id: authorization_request.id) if authorization_request.present?
 
     authorization_requests.map(&:scopes).flatten.uniq.join(', ')
   end

--- a/app/models/authorization_request/hubee_dila.rb
+++ b/app/models/authorization_request/hubee_dila.rb
@@ -14,7 +14,7 @@ class AuthorizationRequest::HubEEDila < AuthorizationRequest
       .where(
         organization:,
         type: 'AuthorizationRequest::HubEEDila',
-        state: %w[validated submitted changes_requested]
+        state: %w[draft validated submitted changes_requested]
       )
 
     existing_scopes = existing_requests.map(&:scopes).flatten.uniq

--- a/app/models/authorization_request/hubee_dila.rb
+++ b/app/models/authorization_request/hubee_dila.rb
@@ -11,11 +11,11 @@ class AuthorizationRequest::HubEEDila < AuthorizationRequest
 
   def unique_scope_request
     existing_requests = self.class.where.not(state: 'archived')
-                        .where(
-                          organization:,
-                          type: 'AuthorizationRequest::HubEEDila',
-                          state: %w[validated submitted changes_requested]
-                        )
+      .where(
+        organization:,
+        type: 'AuthorizationRequest::HubEEDila',
+        state: %w[validated submitted changes_requested]
+      )
 
     existing_scopes = existing_requests.map(&:scopes).flatten.uniq
 
@@ -24,6 +24,5 @@ class AuthorizationRequest::HubEEDila < AuthorizationRequest
     return unless required_scopes.intersect?(existing_scopes)
 
     errors.add(:base, 'Une demande d‘habilitation avec les mêmes scopes existe déjà pour cette organisation.')
-
   end
 end

--- a/app/models/authorization_request/hubee_dila.rb
+++ b/app/models/authorization_request/hubee_dila.rb
@@ -3,5 +3,5 @@ class AuthorizationRequest::HubEEDila < AuthorizationRequest
     presence: true, if: -> { need_complete_validation?(:scopes) }
   })
 
-  contact :administrateur_metier, validation_condition: ->(record) { record.need_complete_validation? }
+  contact :administrateur_metier, validation_condition: ->(record) { record.need_complete_validation?(:contacts) }
 end

--- a/app/models/authorization_request/hubee_dila.rb
+++ b/app/models/authorization_request/hubee_dila.rb
@@ -1,7 +1,29 @@
 class AuthorizationRequest::HubEEDila < AuthorizationRequest
+  validate :unique_scope_request, on: :create
+
   add_scopes(validation: {
     presence: true, if: -> { need_complete_validation?(:scopes) }
   })
 
   contact :administrateur_metier, validation_condition: ->(record) { record.need_complete_validation?(:contacts) }
+
+  private
+
+  def unique_scope_request
+    existing_requests = self.class.where.not(state: 'archived')
+                        .where(
+                          organization:,
+                          type: 'AuthorizationRequest::HubEEDila',
+                          state: %w[validated submitted changes_requested]
+                        )
+
+    existing_scopes = existing_requests.map(&:scopes).flatten.uniq
+
+    required_scopes = %w[etat_civil depot_dossier_pacs recensement_citoyen hebergement_tourisme je_change_de_coordonnees]
+
+    return unless required_scopes.intersect?(existing_scopes)
+
+    errors.add(:base, 'Une demande d‘habilitation avec les mêmes scopes existe déjà pour cette organisation.')
+
+  end
 end

--- a/app/models/authorization_request/hubee_dila.rb
+++ b/app/models/authorization_request/hubee_dila.rb
@@ -21,7 +21,7 @@ class AuthorizationRequest::HubEEDila < AuthorizationRequest
 
     required_scopes = %w[etat_civil depot_dossier_pacs recensement_citoyen hebergement_tourisme je_change_de_coordonnees]
 
-    return unless required_scopes.intersect?(existing_scopes)
+    return unless (required_scopes & existing_scopes) == required_scopes
 
     errors.add(:base, 'Une demande d‘habilitation avec les mêmes scopes existe déjà pour cette organisation.')
   end

--- a/app/models/authorization_request/hubee_dila.rb
+++ b/app/models/authorization_request/hubee_dila.rb
@@ -1,0 +1,7 @@
+class AuthorizationRequest::HubEEDila < AuthorizationRequest
+  add_scopes(validation: {
+    presence: true, if: -> { need_complete_validation?(:scopes) }
+  })
+
+  contact :administrateur_metier, validation_condition: ->(record) { record.need_complete_validation? }
+end

--- a/app/policies/authorization_request_form_policy.rb
+++ b/app/policies/authorization_request_form_policy.rb
@@ -6,4 +6,8 @@ class AuthorizationRequestFormPolicy < ApplicationPolicy
   def authorization_request_class
     record.authorization_request_class.to_s
   end
+
+  def scopes
+    record.authorization_definition.scopes
+  end
 end

--- a/app/policies/authorization_request_policy.rb
+++ b/app/policies/authorization_request_policy.rb
@@ -57,6 +57,10 @@ class AuthorizationRequestPolicy < ApplicationPolicy
     record.to_s
   end
 
+  def scopes
+    record.scopes
+  end
+
   private
 
   def same_current_organization?

--- a/app/policies/concerns/common_authorization_models_policies.rb
+++ b/app/policies/concerns/common_authorization_models_policies.rb
@@ -37,7 +37,7 @@ module CommonAuthorizationModelsPolicies
   end
 
   def requested_scopes?
-    existing_requests = current_organization&.active_authorization_requests&.where(type: authorization_request_class, state: %w[validated submitted changes_requested])
+    existing_requests = current_organization&.active_authorization_requests&.where(type: authorization_request_class, state: %w[draft validated submitted changes_requested])
 
     return false unless existing_requests.any?
 

--- a/app/policies/concerns/common_authorization_models_policies.rb
+++ b/app/policies/concerns/common_authorization_models_policies.rb
@@ -14,6 +14,10 @@ module CommonAuthorizationModelsPolicies
     fail NoImplementedError
   end
 
+  def scopes
+    fail NoImplementedError
+  end
+
   private
 
   def unicity_constraint_violated?
@@ -33,14 +37,14 @@ module CommonAuthorizationModelsPolicies
   end
 
   def requested_scopes?
-    existing_requests = current_organization.active_authorization_requests.where(type: authorization_request_class, state: %w[validated submitted changes_requested])
+    existing_requests = current_organization&.active_authorization_requests&.where(type: authorization_request_class, state: %w[validated submitted changes_requested])
 
-    return false unless current_organization && existing_requests.any?
+    return false unless existing_requests.any?
 
     existing_scopes = existing_requests.map(&:scopes).flatten.uniq
     required_scopes = %w[etat_civil depot_dossier_pacs recensement_citoyen hebergement_tourisme je_change_de_coordonnees]
 
-    required_scopes.intersect?(existing_scopes)
+    (required_scopes & existing_scopes) == required_scopes
   end
 
   def hubee_cert_dc?

--- a/app/policies/concerns/common_authorization_models_policies.rb
+++ b/app/policies/concerns/common_authorization_models_policies.rb
@@ -35,12 +35,12 @@ module CommonAuthorizationModelsPolicies
   def requested_scopes?
     existing_requests = current_organization.active_authorization_requests.where(type: authorization_request_class, state: %w[validated submitted changes_requested])
 
-    if current_organization && existing_requests.any?
-      existing_scopes = existing_requests.map(&:scopes).flatten.uniq
-      required_scopes = %w[etat_civil depot_dossier_pacs recensement_citoyen hebergement_tourisme je_change_de_coordonnees]
+    return false unless current_organization && existing_requests.any?
 
-      required_scopes.intersect?(existing_scopes)
-    end
+    existing_scopes = existing_requests.map(&:scopes).flatten.uniq
+    required_scopes = %w[etat_civil depot_dossier_pacs recensement_citoyen hebergement_tourisme je_change_de_coordonnees]
+
+    required_scopes.intersect?(existing_scopes)
   end
 
   def hubee_cert_dc?

--- a/app/views/authorization_request_forms/portail_hubee_dila.html.erb
+++ b/app/views/authorization_request_forms/portail_hubee_dila.html.erb
@@ -1,0 +1,4 @@
+<%= authorization_request_form(@authorization_request) do |f| %>
+  <%= render partial: 'authorization_request_forms/shared/contacts', locals: { f: } %>
+  <%= render partial: 'authorization_request_forms/shared/submit_buttons', locals: { f: } %>
+<% end %>

--- a/app/views/authorization_request_forms/shared/_scopes.html.erb
+++ b/app/views/authorization_request_forms/shared/_scopes.html.erb
@@ -20,7 +20,7 @@
 
     <div class="scopes-group__grid">
       <% scopes.each do |scope| %>
-        <% if hubee_dila_selected_scopes_for_current_organization.include? scope.value %>
+        <% if hubee_dila_selected_scopes_for_current_organization(@authorization_request).include? scope.value %>
           <%= f.dsfr_scope(scope, disabled: true) %>
         <% else %>
           <%= f.dsfr_scope scope %>

--- a/app/views/authorization_request_forms/shared/_scopes.html.erb
+++ b/app/views/authorization_request_forms/shared/_scopes.html.erb
@@ -3,7 +3,7 @@
 <% @authorization_request.available_scopes.group_by(&:group).each do |group_name, scopes| %>
   <div class="fr-form-group scopes-group">
     <% if @authorization_request.errors.key?(:scopes) %>
-      <div class="fr-alert fr-alert--warning fr-alert--sm" role="alert">
+      <div class="fr-alert fr-alert--warning fr-alert--sm fr-mb-3w" role="alert">
         <ul>
           <% @authorization_request.errors.full_messages.each do |message| %>
             <li>

--- a/app/views/authorization_request_forms/shared/_scopes.html.erb
+++ b/app/views/authorization_request_forms/shared/_scopes.html.erb
@@ -20,7 +20,11 @@
 
     <div class="scopes-group__grid">
       <% scopes.each do |scope| %>
-        <%= f.dsfr_scope scope %>
+        <% if hubee_dila_selected_scopes_for_current_organization.include? scope.value %>
+          <%= f.dsfr_scope(scope, disabled: true) %>
+        <% else %>
+          <%= f.dsfr_scope scope %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/authorization_requests/new.html.erb
+++ b/app/views/authorization_requests/new.html.erb
@@ -53,8 +53,8 @@
     <% if @authorization_request_form || @authorization_definition.available_forms.one? %>
       <% authorization_request_form = @authorization_request_form || @authorization_definition.available_forms.first %>
 
-      <% if policy(authorization_request_form).new? %>
-        <% if authorization_request_form.multiple_steps? %>
+      <% if authorization_request_form.multiple_steps? %>
+        <% if policy(authorization_request_form).new? %>
           <p>
             <%= t('.multiple_steps.description') %>
 

--- a/app/views/authorization_requests/new.html.erb
+++ b/app/views/authorization_requests/new.html.erb
@@ -53,9 +53,10 @@
     <% if @authorization_request_form || @authorization_definition.available_forms.one? %>
       <% authorization_request_form = @authorization_request_form || @authorization_definition.available_forms.first %>
 
-      <% if authorization_request_form.multiple_steps? %>
-        <p>
-          <%= t('.multiple_steps.description') %>
+      <% if policy(authorization_request_form).new? %>
+        <% if authorization_request_form.multiple_steps? %>
+          <p>
+            <%= t('.multiple_steps.description') %>
 
           <ol>
             <% authorization_request_form.steps.each do |step| %>
@@ -66,7 +67,14 @@
           </ol>
 
           <%= start_authorization_request_form(authorization_request_form) %>
-        </p>
+
+        <% else %>
+          <div class="flex">
+            <%= link_to t('.back_to_dashboard'), dashboard_path, class: %w[fr-btn fr-btn--secondary fr-mr-2w] %>
+            <%= start_authorization_request_form(authorization_request_form, disabled: true) %>
+          </div>
+          </p>
+        <% end %>
       <% else %>
         <p>
           <%= t('.single_form.description') %>

--- a/config/authorization_definitions.yml
+++ b/config/authorization_definitions.yml
@@ -22,51 +22,18 @@ shared:
       - name: "AEC - Acte d’Etat Civil"
         value: "etat_civil"
         group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
-#        group: "Ce service donne la possibilité aux usagers d’effectuer sur internet leurs demandes d’actes de naissance, de mariage, de décès."
       - name: "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
         value: "depot_dossier_pacs"
         group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
-#        group: "Ce service permet à des usagers souhaitant se pacser de compléter en
-#        ligne les informations nécessaires à cette union (actuellement contenues
-#        dans les Cerfa) et de télécharger leurs pièces justificatives (actes de
-#        naissance convention spécifique de PACS le cas échéant). L’ensemble est
-#        envoyé à la commune chargée de conclure le PACS (à savoir la mairie de
-#        résidence commune des partenaires)."
       - name: "RCO - Recensement Citoyen Obligatoire"
         value: "recensement_citoyen"
         group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
-#        group: "Ce service permet à un jeune de transmettre son dossier en ligne à la
-#        mairie, sans déplacement et à tout moment de la journée. La commune peut
-#        en retour envoyer l’attestation de recensement vers le porte-documents
-#        sécurisé sur le compte personnel de l’usager. Tout français âgé de 16
-#        ans doit spontanément se faire recenser auprès de sa mairie (ou auprès
-#        de son Consulat, lorsqu’il réside à l’étranger) en vue de participer à
-#        la Journée Défense et Citoyenneté (JDC). Tous les jeunes français,
-#        garçons et filles, sont concernés. Cette formalité est obligatoire pour
-#        avoir le droit de se présenter aux concours et examens publics
-#        (Baccalauréat, permis de conduire, etc.)."
       - name: "DHTOUR - Déclaration d’hébergement touristique"
         value: "hebergement_tourisme"
         group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
-#        group: "Ce service permet aux particuliers et professionnels de déclarer en
-#        ligne un meublé de tourisme ou une chambre d’hôtes. Ce service peut être
-#        proposé par les municipalités qui collectent la taxe de séjour
-#        uniquement (métropoles de droit commun)."
       - name: "JCC - Déclaration de Changement de Coordonnées"
         value: "je_change_de_coordonnees"
         group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
-#        group: "Ce service permet à un usager de déclarer rapidement et facilement un
-#        changement d’adresse postale lors d’un déménagement ou d’une
-#        modification administrative. Via ce service, l’usager peut également
-#        procéder à la mise à jour de son adresse électronique, ses numéros de
-#        téléphone fixe et de portable. Il peut ainsi signaler à sa commune son
-#        changement de coordonnées. Tout nouvel arrivant a par ailleurs la
-#        possibilité de préciser la composition de son foyer (nombre d’adultes et
-#        d’enfants, âge des enfants). Tout opérateur de service, public ou privé
-#        (téléphonie, énergie, etc.), peut faire une demande d’abonnement auprès
-#        de la direction de l’information légale et administrative (DILA) qui en
-#        étudiera la faisabilité juridique (demande réalisée via le portail du
-#        Hub d’Échange de l’État)."
 
   api_entreprise:
     name: "API Entreprise"

--- a/config/authorization_definitions.yml
+++ b/config/authorization_definitions.yml
@@ -10,7 +10,7 @@ shared:
       - name: 'contacts'
 
   hubee_dila:
-    name: "Portail HubEE - DILA"
+    name: "Portail HubEE - Démarches DILA"
     description: "Acte d’État Civil, Démarche en ligne de préparation à la conclusion d’un Pacs, Recensement Citoyen Obligatoire, Déclaration d'hébergement touristique, Déclaration de Changement de Coordonnées"
     cgu_link: '/cgus/20210212_dinum_hubee_cgu_v2_1_0_version_site.pdf'
     provider: 'hubee'
@@ -20,48 +20,53 @@ shared:
       - name: 'contacts'
     scopes:
       - name: "AEC - Acte d’Etat Civil"
-        value: "EtatCivil"
-        group: "Ce service donne la possibilité aux usagers d’effectuer sur internet leurs demandes d’actes de naissance, de mariage, de décès."
+        value: "etat_civil"
+        group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+#        group: "Ce service donne la possibilité aux usagers d’effectuer sur internet leurs demandes d’actes de naissance, de mariage, de décès."
       - name: "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
-        value: "depotDossierPACS"
-        group: "Ce service permet à des usagers souhaitant se pacser de compléter en
-        ligne les informations nécessaires à cette union (actuellement contenues
-        dans les Cerfa) et de télécharger leurs pièces justificatives (actes de
-        naissance convention spécifique de PACS le cas échéant). L’ensemble est
-        envoyé à la commune chargée de conclure le PACS (à savoir la mairie de
-        résidence commune des partenaires)."
+        value: "depot_dossier_pacs"
+        group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+#        group: "Ce service permet à des usagers souhaitant se pacser de compléter en
+#        ligne les informations nécessaires à cette union (actuellement contenues
+#        dans les Cerfa) et de télécharger leurs pièces justificatives (actes de
+#        naissance convention spécifique de PACS le cas échéant). L’ensemble est
+#        envoyé à la commune chargée de conclure le PACS (à savoir la mairie de
+#        résidence commune des partenaires)."
       - name: "RCO - Recensement Citoyen Obligatoire"
-        value: "recensementCitoyen"
-        group: "Ce service permet à un jeune de transmettre son dossier en ligne à la
-        mairie, sans déplacement et à tout moment de la journée. La commune peut
-        en retour envoyer l’attestation de recensement vers le porte-documents
-        sécurisé sur le compte personnel de l’usager. Tout français âgé de 16
-        ans doit spontanément se faire recenser auprès de sa mairie (ou auprès
-        de son Consulat, lorsqu’il réside à l’étranger) en vue de participer à
-        la Journée Défense et Citoyenneté (JDC). Tous les jeunes français,
-        garçons et filles, sont concernés. Cette formalité est obligatoire pour
-        avoir le droit de se présenter aux concours et examens publics
-        (Baccalauréat, permis de conduire, etc.)."
+        value: "recensement_citoyen"
+        group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+#        group: "Ce service permet à un jeune de transmettre son dossier en ligne à la
+#        mairie, sans déplacement et à tout moment de la journée. La commune peut
+#        en retour envoyer l’attestation de recensement vers le porte-documents
+#        sécurisé sur le compte personnel de l’usager. Tout français âgé de 16
+#        ans doit spontanément se faire recenser auprès de sa mairie (ou auprès
+#        de son Consulat, lorsqu’il réside à l’étranger) en vue de participer à
+#        la Journée Défense et Citoyenneté (JDC). Tous les jeunes français,
+#        garçons et filles, sont concernés. Cette formalité est obligatoire pour
+#        avoir le droit de se présenter aux concours et examens publics
+#        (Baccalauréat, permis de conduire, etc.)."
       - name: "DHTOUR - Déclaration d’hébergement touristique"
-        value: "HebergementTourisme"
-        group: "Ce service permet aux particuliers et professionnels de déclarer en
-        ligne un meublé de tourisme ou une chambre d’hôtes. Ce service peut être
-        proposé par les municipalités qui collectent la taxe de séjour
-        uniquement (métropoles de droit commun)."
+        value: "hebergement_tourisme"
+        group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+#        group: "Ce service permet aux particuliers et professionnels de déclarer en
+#        ligne un meublé de tourisme ou une chambre d’hôtes. Ce service peut être
+#        proposé par les municipalités qui collectent la taxe de séjour
+#        uniquement (métropoles de droit commun)."
       - name: "JCC - Déclaration de Changement de Coordonnées"
-        value: "JeChangeDeCoordonnees"
-        group: "Ce service permet à un usager de déclarer rapidement et facilement un
-        changement d’adresse postale lors d’un déménagement ou d’une
-        modification administrative. Via ce service, l’usager peut également
-        procéder à la mise à jour de son adresse électronique, ses numéros de
-        téléphone fixe et de portable. Il peut ainsi signaler à sa commune son
-        changement de coordonnées. Tout nouvel arrivant a par ailleurs la
-        possibilité de préciser la composition de son foyer (nombre d’adultes et
-        d’enfants, âge des enfants). Tout opérateur de service, public ou privé
-        (téléphonie, énergie, etc.), peut faire une demande d’abonnement auprès
-        de la direction de l’information légale et administrative (DILA) qui en
-        étudiera la faisabilité juridique (demande réalisée via le portail du
-        Hub d’Échange de l’État)."
+        value: "je_change_de_coordonnees"
+        group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+#        group: "Ce service permet à un usager de déclarer rapidement et facilement un
+#        changement d’adresse postale lors d’un déménagement ou d’une
+#        modification administrative. Via ce service, l’usager peut également
+#        procéder à la mise à jour de son adresse électronique, ses numéros de
+#        téléphone fixe et de portable. Il peut ainsi signaler à sa commune son
+#        changement de coordonnées. Tout nouvel arrivant a par ailleurs la
+#        possibilité de préciser la composition de son foyer (nombre d’adultes et
+#        d’enfants, âge des enfants). Tout opérateur de service, public ou privé
+#        (téléphonie, énergie, etc.), peut faire une demande d’abonnement auprès
+#        de la direction de l’information légale et administrative (DILA) qui en
+#        étudiera la faisabilité juridique (demande réalisée via le portail du
+#        Hub d’Échange de l’État)."
 
   api_entreprise:
     name: "API Entreprise"

--- a/config/authorization_definitions.yml
+++ b/config/authorization_definitions.yml
@@ -9,6 +9,60 @@ shared:
     blocks:
       - name: 'contacts'
 
+  hubee_dila:
+    name: "Portail HubEE - DILA"
+    description: "Acte d’État Civil, Démarche en ligne de préparation à la conclusion d’un Pacs, Recensement Citoyen Obligatoire, Déclaration d'hébergement touristique, Déclaration de Changement de Coordonnées"
+    cgu_link: '/cgus/20210212_dinum_hubee_cgu_v2_1_0_version_site.pdf'
+    provider: 'hubee'
+    public: true
+    blocks:
+      - name: 'scopes'
+      - name: 'contacts'
+    scopes:
+      - name: "AEC - Acte d’Etat Civil"
+        value: "EtatCivil"
+        group: "Ce service donne la possibilité aux usagers d’effectuer sur internet leurs demandes d’actes de naissance, de mariage, de décès."
+      - name: "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
+        value: "depotDossierPACS"
+        group: "Ce service permet à des usagers souhaitant se pacser de compléter en
+        ligne les informations nécessaires à cette union (actuellement contenues
+        dans les Cerfa) et de télécharger leurs pièces justificatives (actes de
+        naissance convention spécifique de PACS le cas échéant). L’ensemble est
+        envoyé à la commune chargée de conclure le PACS (à savoir la mairie de
+        résidence commune des partenaires)."
+      - name: "RCO - Recensement Citoyen Obligatoire"
+        value: "recensementCitoyen"
+        group: "Ce service permet à un jeune de transmettre son dossier en ligne à la
+        mairie, sans déplacement et à tout moment de la journée. La commune peut
+        en retour envoyer l’attestation de recensement vers le porte-documents
+        sécurisé sur le compte personnel de l’usager. Tout français âgé de 16
+        ans doit spontanément se faire recenser auprès de sa mairie (ou auprès
+        de son Consulat, lorsqu’il réside à l’étranger) en vue de participer à
+        la Journée Défense et Citoyenneté (JDC). Tous les jeunes français,
+        garçons et filles, sont concernés. Cette formalité est obligatoire pour
+        avoir le droit de se présenter aux concours et examens publics
+        (Baccalauréat, permis de conduire, etc.)."
+      - name: "DHTOUR - Déclaration d’hébergement touristique"
+        value: "HebergementTourisme"
+        group: "Ce service permet aux particuliers et professionnels de déclarer en
+        ligne un meublé de tourisme ou une chambre d’hôtes. Ce service peut être
+        proposé par les municipalités qui collectent la taxe de séjour
+        uniquement (métropoles de droit commun)."
+      - name: "JCC - Déclaration de Changement de Coordonnées"
+        value: "JeChangeDeCoordonnees"
+        group: "Ce service permet à un usager de déclarer rapidement et facilement un
+        changement d’adresse postale lors d’un déménagement ou d’une
+        modification administrative. Via ce service, l’usager peut également
+        procéder à la mise à jour de son adresse électronique, ses numéros de
+        téléphone fixe et de portable. Il peut ainsi signaler à sa commune son
+        changement de coordonnées. Tout nouvel arrivant a par ailleurs la
+        possibilité de préciser la composition de son foyer (nombre d’adultes et
+        d’enfants, âge des enfants). Tout opérateur de service, public ou privé
+        (téléphonie, énergie, etc.), peut faire une demande d’abonnement auprès
+        de la direction de l’information légale et administrative (DILA) qui en
+        étudiera la faisabilité juridique (demande réalisée via le portail du
+        Hub d’Échange de l’État)."
+
   api_entreprise:
     name: "API Entreprise"
     description: "Entités administratives, simplifiez les démarches des entreprises et des associations en récupérant pour elles leurs informations administratives."

--- a/config/authorization_request_forms.yml
+++ b/config/authorization_request_forms.yml
@@ -3,18 +3,18 @@ shared:
   portail-hubee-demarche-certdc:
     authorization_request: 'HubEECertDC'
 
-  portail-hubee-dila:
+  portail-hubee-demarches-dila:
     name: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
     authorization_request: 'HubEEDila'
     steps:
       - name: 'scopes'
       - name: 'contacts'
     scopes:
-      - EtatCivil
-      - depotDossierPACS
-      - recensementCitoyen
-      - HebergementTourisme
-      - JeChangeDeCoordonnees
+      - etat_civil
+      - depot_dossier_pacs
+      - recensement_citoyen
+      - hebergement_tourisme
+      - je_change_de_coordonnees
 
   api-entreprise:
     name: "Demande libre"

--- a/config/authorization_request_forms.yml
+++ b/config/authorization_request_forms.yml
@@ -4,8 +4,8 @@ shared:
     authorization_request: 'HubEECertDC'
 
   portail-hubee-dila:
-    authorization_request: 'HubEEDila'
     name: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+    authorization_request: 'HubEEDila'
     steps:
       - name: 'scopes'
       - name: 'contacts'

--- a/config/authorization_request_forms.yml
+++ b/config/authorization_request_forms.yml
@@ -3,6 +3,19 @@ shared:
   portail-hubee-demarche-certdc:
     authorization_request: 'HubEECertDC'
 
+  portail-hubee-dila:
+    authorization_request: 'HubEEDila'
+    name: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+    steps:
+      - name: 'scopes'
+      - name: 'contacts'
+    scopes:
+      - EtatCivil
+      - depotDossierPACS
+      - recensementCitoyen
+      - HebergementTourisme
+      - JeChangeDeCoordonnees
+
   api-entreprise:
     name: "Demande libre"
     default: true

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -21,7 +21,6 @@ ActiveSupport::Inflector.inflections do |inflect|
 
   inflect.acronym 'HubEE'
   inflect.acronym 'DC'
-  inflect.acronym 'DILA'
 
   inflect.acronym 'CaptchEtat'
 end

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -87,6 +87,13 @@ fr:
         info: |
           <strong>L’administrateur métier</strong> disposera des droits d’administration portail HubEE : gestion des abonnements et gestion des utilisateurs.
 
+    hubee_dila:
+      scopes:
+        info:
+          title: En quoi consistent ces démarches?
+          content: |
+            
+
     api_entreprise:
       volumetrie_approximative:
         hint: Nombre de démarches ou dossiers traités dans l'année

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -92,7 +92,49 @@ fr:
         info:
           title: En quoi consistent ces démarches?
           content: |
-            
+            <p>
+              <strong> AEC - Acte d’Etat Civil </strong> : Ce service donne la possibilité aux usagers d’effectuer sur internet leurs demandes d’actes de naissance, de mariage, de décès.
+            </p>
+            <p>
+              <strong> DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs </strong> : Ce service permet à des usagers souhaitant se pacser de compléter en
+              ligne les informations nécessaires à cette union (actuellement contenues
+              dans les Cerfa) et de télécharger leurs pièces justificatives (actes de
+              naissance convention spécifique de PACS le cas échéant). L’ensemble est
+              envoyé à la commune chargée de conclure le PACS (à savoir la mairie de
+              résidence commune des partenaires).
+            </p>
+            <p>
+              <strong> RCO - Recensement Citoyen Obligatoire </strong> : Ce service permet à un jeune de transmettre son dossier en ligne à la
+              mairie, sans déplacement et à tout moment de la journée. La commune peut
+              en retour envoyer l’attestation de recensement vers le porte-documents
+              sécurisé sur le compte personnel de l’usager. Tout français âgé de 16
+              ans doit spontanément se faire recenser auprès de sa mairie (ou auprès
+              de son Consulat, lorsqu’il réside à l’étranger) en vue de participer à
+              la Journée Défense et Citoyenneté (JDC). Tous les jeunes français,
+              garçons et filles, sont concernés. Cette formalité est obligatoire pour
+              avoir le droit de se présenter aux concours et examens publics
+              Baccalauréat, permis de conduire, etc.).
+            </p>
+            <p>
+              <strong>DHTOUR - Déclaration d’hébergement touristique</strong> : Ce service permet aux particuliers et professionnels de déclarer en
+              ligne un meublé de tourisme ou une chambre d’hôtes. Ce service peut être
+              proposé par les municipalités qui collectent la taxe de séjour
+              uniquement (métropoles de droit commun).
+            </p>
+            <p>
+              <strong>JCC - Déclaration de Changement de Coordonnées</strong> : Ce service permet à un usager de déclarer rapidement et facilement un
+              changement d’adresse postale lors d’un déménagement ou d’une
+              modification administrative. Via ce service, l’usager peut également
+              procéder à la mise à jour de son adresse électronique, ses numéros de
+              téléphone fixe et de portable. Il peut ainsi signaler à sa commune son
+              changement de coordonnées. Tout nouvel arrivant a par ailleurs la
+              possibilité de préciser la composition de son foyer (nombre d’adultes et
+              d’enfants, âge des enfants). Tout opérateur de service, public ou privé
+              (téléphonie, énergie, etc.), peut faire une demande d’abonnement auprès
+              de la direction de l’information légale et administrative (DILA) qui en
+              étudiera la faisabilité juridique (demande réalisée via le portail du
+              Hub d’Échange de l’État).
+            </p>
 
     api_entreprise:
       volumetrie_approximative:

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -88,6 +88,9 @@ fr:
           <strong>L’administrateur métier</strong> disposera des droits d’administration portail HubEE : gestion des abonnements et gestion des utilisateurs.
 
     hubee_dila:
+      administrateur_metier:
+        info: |
+          <strong>L’administrateur métier</strong> disposera des droits d’administration portail HubEE : gestion des abonnements et gestion des utilisateurs.
       scopes:
         info:
           title: En quoi consistent ces démarches?

--- a/features/consultation_habilitation.feature
+++ b/features/consultation_habilitation.feature
@@ -36,6 +36,12 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Et il y a un bouton "Enregistrer"
 
   Scénario: Je consulte une demande d'habilitation en plusieurs étapes en brouillon m'appartenant
+    Quand je me rends sur une demande d'habilitation "Portail HubEE - Démarche DILA" en brouillon
+    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
+    Et il y a un formulaire en plusieurs étapes
+    Et il y a un bouton "Enregistrer"
+
+  Scénario: Je consulte une demande d'habilitation en plusieurs étapes en brouillon m'appartenant
     Quand je me rends sur une demande d'habilitation "API Entreprise" en brouillon
     Alors il y a un titre contenant "API Entreprise"
     Et il y a un formulaire en plusieurs étapes
@@ -46,6 +52,14 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Et que je clique sur "Toutes celles de l'organisation"
     Et que je clique sur "Consulter"
     Alors il y a un titre contenant "Portail HubEE - Démarche CertDC"
+    Et il y a un formulaire en mode résumé
+    Et il n'y a pas de bouton "Enregistrer"
+
+  Scénario: Je consulte une demande d'habilitation en plusieurs étapes en brouillon de l'organisation
+    Quand mon organisation a 1 demande d'habilitation "Portail HubEE - Démarche DILA"
+    Et que je clique sur "Toutes celles de l'organisation"
+    Et que je clique sur "Consulter"
+    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
     Et il y a un formulaire en mode résumé
     Et il n'y a pas de bouton "Enregistrer"
 
@@ -63,6 +77,16 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Et que je clique sur "J'y suis mentionné en contact"
     Et que je clique sur "Consulter"
     Alors il y a un titre contenant "Portail HubEE - Démarche CertDC"
+    Et il y a un formulaire en mode résumé
+    Et il n'y a pas de bouton "Enregistrer"
+    Et il y a un message d'info contenant "Vous avez été référencé comme administrateur métier"
+
+  Scénario: Je consulte une demande d'habilitation en plusieurs étapes où je suis mentionné
+    Quand je suis mentionné dans 1 demande d'habilitation "Portail HubEE - Démarche DILA" en tant que "Administrateur métier"
+    Et que je vais sur la page du tableau de bord
+    Et que je clique sur "J'y suis mentionné en contact"
+    Et que je clique sur "Consulter"
+    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
     Et il y a un formulaire en mode résumé
     Et il n'y a pas de bouton "Enregistrer"
     Et il y a un message d'info contenant "Vous avez été référencé comme administrateur métier"

--- a/features/consultation_habilitation.feature
+++ b/features/consultation_habilitation.feature
@@ -36,8 +36,8 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Et il y a un bouton "Enregistrer"
 
   Scénario: Je consulte une demande d'habilitation en plusieurs étapes en brouillon m'appartenant
-    Quand je me rends sur une demande d'habilitation "Portail HubEE - Démarche DILA" en brouillon
-    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
+    Quand je me rends sur une demande d'habilitation "Portail HubEE - Démarches DILA" en brouillon
+    Alors il y a un titre contenant "Portail HubEE - Démarches DILA"
     Et il y a un formulaire en plusieurs étapes
     Et il y a un bouton "Enregistrer"
 
@@ -56,10 +56,10 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Et il n'y a pas de bouton "Enregistrer"
 
   Scénario: Je consulte une demande d'habilitation en plusieurs étapes en brouillon de l'organisation
-    Quand mon organisation a 1 demande d'habilitation "Portail HubEE - Démarche DILA"
+    Quand mon organisation a 1 demande d'habilitation "Portail HubEE - Démarches DILA"
     Et que je clique sur "Toutes celles de l'organisation"
     Et que je clique sur "Consulter"
-    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
+    Alors il y a un titre contenant "Portail HubEE - Démarches DILA"
     Et il y a un formulaire en mode résumé
     Et il n'y a pas de bouton "Enregistrer"
 
@@ -82,11 +82,11 @@ Fonctionnalité: Consultation d'une demande d'habilitation
     Et il y a un message d'info contenant "Vous avez été référencé comme administrateur métier"
 
   Scénario: Je consulte une demande d'habilitation en plusieurs étapes où je suis mentionné
-    Quand je suis mentionné dans 1 demande d'habilitation "Portail HubEE - Démarche DILA" en tant que "Administrateur métier"
+    Quand je suis mentionné dans 1 demande d'habilitation "Portail HubEE - Démarches DILA" en tant que "Administrateur métier"
     Et que je vais sur la page du tableau de bord
     Et que je clique sur "J'y suis mentionné en contact"
     Et que je clique sur "Consulter"
-    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
+    Alors il y a un titre contenant "Portail HubEE - Démarches DILA"
     Et il y a un formulaire en mode résumé
     Et il n'y a pas de bouton "Enregistrer"
     Et il y a un message d'info contenant "Vous avez été référencé comme administrateur métier"

--- a/features/habilitations/portail_hubee_demarches_dila.feature
+++ b/features/habilitations/portail_hubee_demarches_dila.feature
@@ -50,3 +50,19 @@ Fonctionnalité: Soumission d'une demande d'habilitation Portail HubEE - Démarc
     Alors il y a un message d'erreur contenant "Une erreur est survenue lors de la sauvegarde de la demande d'habilitation"
     Et il y a au moins une erreur sur un champ
     Et je suis sur la page "Portail HubEE - Démarches DILA"
+
+  Scénario: Je soumets une demande d'habilitation valide
+    Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
+    * je coche "AEC - Acte d’Etat Civil"
+    * je clique sur "Suivant"
+
+    * je remplis les informations du contact "Administrateur métier" avec :
+      | Nom    | Prénom | Email               | Téléphone   | Fonction              |
+      | Dupont | Jean   | dupont.jean@gouv.fr | 0836656565  | Administrateur métier |
+    * je clique sur "Suivant"
+
+    * j'adhère aux conditions générales
+    * je clique sur "Soumettre la demande d'habilitation"
+
+    * je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
+    Alors je ne peux pas cocher "AEC - Acte d’Etat Civil"

--- a/features/habilitations/portail_hubee_demarches_dila.feature
+++ b/features/habilitations/portail_hubee_demarches_dila.feature
@@ -1,0 +1,52 @@
+# language: fr
+
+Fonctionnalité: Soumission d'une demande d'habilitation Portail HubEE - Démarches DILA
+  Contexte:
+    Sachant que je suis un demandeur
+    Et que je me connecte
+
+  Scénario: Je soumets une demande d'habilitation valide
+    Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
+    * je coche "AEC - Acte d’Etat Civil"
+    * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
+    * je coche "RCO - Recensement Citoyen Obligatoire"
+    * je coche "DHTOUR - Déclaration d’hébergement touristique"
+    * je coche "JCC - Déclaration de Changement de Coordonnées"
+    * je clique sur "Suivant"
+
+    * je remplis les informations du contact "Administrateur métier" avec :
+      | Nom    | Prénom | Email               | Téléphone   | Fonction              |
+      | Dupont | Jean   | dupont.jean@gouv.fr | 0836656565  | Administrateur métier |
+    * je clique sur "Suivant"
+
+    * j'adhère aux conditions générales
+    * je clique sur "Soumettre la demande d'habilitation"
+
+    Alors il y a un message de succès contenant "soumise avec succès"
+    Et je suis sur la page "Demandes et habilitations"
+
+  Scénario: Je remplis une demande d'habilitation avec aucune démarche DILA cochée
+    Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
+    Et que je clique sur "Suivant"
+
+    Alors il y a un message d'erreur contenant "Une erreur est survenue lors de la sauvegarde de la demande d'habilitation"
+    Et il y a un message d'attention contenant "Les données doivent au moins contenir un élément sélectionné ci-dessous"
+    Et je suis sur la page "Portail HubEE - Démarches DILA"
+
+  Scénario: Je remplis une demande d'habilitation avec un champ du contact manquant
+    Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
+    * je coche "AEC - Acte d’Etat Civil"
+    * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
+    * je coche "RCO - Recensement Citoyen Obligatoire"
+    * je coche "DHTOUR - Déclaration d’hébergement touristique"
+    * je coche "JCC - Déclaration de Changement de Coordonnées"
+    * je clique sur "Suivant"
+
+    * je remplis les informations du contact "Administrateur métier" avec :
+      | Nom    | Prénom | Email               | Téléphone   | Fonction de l'administrateur système |
+      | Dupont |        | dupont.jean@gouv.fr | 0836656565  | Administrateur métier |
+    Et que je clique sur "Suivant"
+
+    Alors il y a un message d'erreur contenant "Une erreur est survenue lors de la sauvegarde de la demande d'habilitation"
+    Et il y a au moins une erreur sur un champ
+    Et je suis sur la page "Portail HubEE - Démarches DILA"

--- a/features/liste_des_habilitations.feature
+++ b/features/liste_des_habilitations.feature
@@ -13,7 +13,7 @@ Fonctionnalité: Liste des habilitations
     Alors il y a un titre contenant "Demander une nouvelle habilitation"
     Et la page contient "API Entreprise"
     Et la page contient "Portail HubEE - Démarche CertDC"
-    Et la page contient "Portail HubEE - Démarche DILA"
+    Et la page contient "Portail HubEE - Démarches DILA"
     Et la page contient "API Service National"
 
   Scénario: Je démarre une nouvelle demande d'habilitation
@@ -25,7 +25,7 @@ Fonctionnalité: Liste des habilitations
 
   Scénario: Je démarre une nouvelle demande d'habilitation
     Quand je vais sur la page des demandes
-    Et que je clique sur "Remplir une demande" pour l'habilitation "Portail HubEE - Démarche DILA"
+    Et que je clique sur "Remplir une demande" pour l'habilitation "Portail HubEE - Démarches DILA"
     Et que je clique sur "Débuter"
-    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
+    Alors il y a un titre contenant "Portail HubEE - Démarches DILA"
     Et il y a un bouton "Suivant"

--- a/features/liste_des_habilitations.feature
+++ b/features/liste_des_habilitations.feature
@@ -13,6 +13,7 @@ Fonctionnalité: Liste des habilitations
     Alors il y a un titre contenant "Demander une nouvelle habilitation"
     Et la page contient "API Entreprise"
     Et la page contient "Portail HubEE - Démarche CertDC"
+    Et la page contient "Portail HubEE - Démarche DILA"
     Et la page contient "API Service National"
 
   Scénario: Je démarre une nouvelle demande d'habilitation
@@ -21,3 +22,10 @@ Fonctionnalité: Liste des habilitations
     Et que je clique sur "Débuter"
     Alors il y a un titre contenant "Portail HubEE - Démarche CertDC"
     Et il y a un bouton "Enregistrer les modifications"
+
+  Scénario: Je démarre une nouvelle demande d'habilitation
+    Quand je vais sur la page des demandes
+    Et que je clique sur "Remplir une demande" pour l'habilitation "Portail HubEE - Démarche DILA"
+    Et que je clique sur "Débuter"
+    Alors il y a un titre contenant "Portail HubEE - Démarche DILA"
+    Et il y a un bouton "Suivant"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -182,3 +182,9 @@ Alors('la page contient le logo du fournisseur de données {string}') do |author
   provider_logo = find_authorization_definition_from_name(authorization_definition).provider.name
   expect(page).to have_xpath("//img[contains(@alt, \"#{provider_logo}\")]")
 end
+
+Alors('je ne peux pas cocher {string}') do |checkbox_label|
+  checkbox_id = "##{find('label', text: checkbox_label)[:for]}"
+
+  expect(page.find(checkbox_id, visible: :all)[:disabled]).to be_truthy
+end

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -199,7 +199,7 @@ FactoryBot.define do
 
     trait :hubee_dila do
       type { 'AuthorizationRequest::HubEEDila' }
-      form_uid { 'portail-hubee-dila' }
+      form_uid { 'portail-hubee-demarche-dila' }
       with_scopes
     end
 

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -193,14 +193,18 @@ FactoryBot.define do
 
     trait :portail_hubee_demarche_certdc do
       hubee_cert_dc
-
       form_uid { 'portail-hubee-demarche-certdc' }
     end
 
     trait :hubee_dila do
       type { 'AuthorizationRequest::HubEEDila' }
-      form_uid { 'portail-hubee-demarche-dila' }
+
       with_scopes
+    end
+
+    trait :portail_hubee_demarches_dila do
+      hubee_dila
+      form_uid { 'portail-hubee-demarches-dila' }
     end
 
     trait :api_entreprise do

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -197,6 +197,12 @@ FactoryBot.define do
       form_uid { 'portail-hubee-demarche-certdc' }
     end
 
+    trait :hubee_dila do
+      type { 'AuthorizationRequest::HubEEDila' }
+      form_uid { 'portail-hubee-dila' }
+      with_scopes
+    end
+
     trait :api_entreprise do
       type { 'AuthorizationRequest::APIEntreprise' }
       form_uid { 'api-entreprise' }

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -198,13 +198,12 @@ FactoryBot.define do
 
     trait :hubee_dila do
       type { 'AuthorizationRequest::HubEEDila' }
-
+      form_uid { 'portail-hubee-demarches-dila' }
       with_scopes
     end
 
     trait :portail_hubee_demarches_dila do
       hubee_dila
-      form_uid { 'portail-hubee-demarches-dila' }
     end
 
     trait :api_entreprise do


### PR DESCRIPTION
- [x] Grisé les scopes si déjà sélectionné pour la même organisation

<img width="1356" alt="Capture d’écran 2024-05-06 à 16 16 02" src="https://github.com/etalab/data_pass/assets/43042737/d0cc0b94-cb81-4c2d-a7af-3d6c5949670d">

- [x] Ne pas permettre à l'utilisateur de démarrer une demande de formulaire si tous les scopes ont déjà été soumis / validés et que les habilitations / demandes sont toujours valide.
- [x] Tester en local que tout fonctionne
- [ ] Afficher une alert explicative sur l'URL `/demandes/hubee-dila/nouveau` -> **A faire dans un autre ticket pour couvrir HubEE Dila et HubEE CertDC**
- [ ] Ajout de test cucumber 