### PR TITLE
Simplify single form config view

### DIFF
--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -193,6 +193,8 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
   def view_path(step = nil)
     if @authorization_request.form.multiple_steps?
       "authorization_request_forms/build/#{step || params[:id] || 'start'}"
+    elsif @authorization_request.form.single_page_view.present?
+      @authorization_request.form.single_page_view
     else
       @authorization_request.form.uid.underscore
     end

--- a/app/models/authorization_request_form.rb
+++ b/app/models/authorization_request_form.rb
@@ -5,6 +5,7 @@ class AuthorizationRequestForm < StaticApplicationRecord
     :default,
     :use_case,
     :authorization_request_class,
+    :single_page_view,
     :templates,
     :steps,
     :static_blocks
@@ -29,6 +30,7 @@ class AuthorizationRequestForm < StaticApplicationRecord
         :public,
         :use_case,
         :data,
+        :single_page_view,
         :startable_by_applicant
       ).merge(
         uid: uid.to_s,

--- a/app/views/authorization_request_forms/api_entreprise_achat_solution.html.erb
+++ b/app/views/authorization_request_forms/api_entreprise_achat_solution.html.erb
@@ -1,1 +1,0 @@
-api_entreprise_through_editor.html.erb

--- a/app/views/authorization_request_forms/api_entreprise_atexo.html.erb
+++ b/app/views/authorization_request_forms/api_entreprise_atexo.html.erb
@@ -1,1 +1,0 @@
-api_entreprise_through_editor.html.erb

--- a/app/views/authorization_request_forms/api_entreprise_e_attestations.html.erb
+++ b/app/views/authorization_request_forms/api_entreprise_e_attestations.html.erb
@@ -1,1 +1,0 @@
-api_entreprise_through_editor.html.erb

--- a/app/views/authorization_request_forms/api_entreprise_mgdis.html.erb
+++ b/app/views/authorization_request_forms/api_entreprise_mgdis.html.erb
@@ -1,1 +1,0 @@
-api_entreprise_through_editor.html.erb

--- a/app/views/authorization_request_forms/api_entreprise_provigis.html.erb
+++ b/app/views/authorization_request_forms/api_entreprise_provigis.html.erb
@@ -1,1 +1,0 @@
-api_entreprise_through_editor.html.erb

--- a/app/views/authorization_request_forms/api_entreprise_setec_atexo.html.erb
+++ b/app/views/authorization_request_forms/api_entreprise_setec_atexo.html.erb
@@ -1,1 +1,0 @@
-api_entreprise_through_editor.html.erb

--- a/config/authorization_request_forms.yml
+++ b/config/authorization_request_forms.yml
@@ -138,6 +138,7 @@ shared:
     description: "Logiciel de contrôle de conformité des opérateurs économiques en vue de l’attribution ou du suivi des marchés"
     use_case: 'marches_publics'
     authorization_request: 'APIEntreprise'
+    single_page_view: 'api_entreprise_through_editor'
     editor_id: 'e_attestations'
     static_blocks:
       - name: 'basic_infos'
@@ -174,6 +175,7 @@ shared:
     description: "Outil de contrôle de conformité des titulaires de marchés"
     use_case: 'marches_publics'
     authorization_request: 'APIEntreprise'
+    single_page_view: 'api_entreprise_through_editor'
     editor_id: 'provigis'
     static_blocks:
       - name: 'basic_infos'
@@ -211,6 +213,7 @@ shared:
     description: "Outil de contrôle de conformité des candidats et titulaires de marchés publics"
     use_case: 'marches_publics'
     authorization_request: 'APIEntreprise'
+    single_page_view: 'api_entreprise_through_editor'
     editor_id: 'achat_solution'
     static_blocks:
       - name: 'basic_infos'
@@ -247,6 +250,7 @@ shared:
     description: "Solution logicielle fournie par l'éditeur MGDIS."
     use_case: 'aides_publiques'
     authorization_request: 'APIEntreprise'
+    single_page_view: 'api_entreprise_through_editor'
     editor_id: 'mgdis'
     static_blocks:
       - name: 'basic_infos'
@@ -281,6 +285,7 @@ La plateforme, mise en place pour permettre le dépôt de ces aides publiques et
     name: "Dématérialisation des marchés publics"
     description: "Outil de dématérialisation des appels d’offres des marchés publics - Solution LOCAL TRUST MPE"
     use_case: 'marches_publics'
+    single_page_view: 'api_entreprise_through_editor'
     authorization_request: 'APIEntreprise'
     editor_id: 'atexo'
     static_blocks:
@@ -324,6 +329,7 @@ La plateforme, mise en place pour permettre le dépôt de ces aides publiques et
     name: "Dématérialisation des marchés publics"
     description: "Solution logicielle fournie par l'éditeur Setec."
     authorization_request: 'APIEntreprise'
+    single_page_view: 'api_entreprise_through_editor'
     use_case: 'marches_publics'
     editor_id: 'setec'
     data:

--- a/docs/new_provider.md
+++ b/docs/new_provider.md
@@ -84,6 +84,9 @@ Pour [le formulaire](../config/authorization_request_forms.yml):
     # Nom de la classe du modèle associé (défini dans l'étape 2). Permet de
     # faire le lien avec la définition plus haut
     authorization_request: MonAPI
+    # Optionnel: Permet de spécifier la vue à utiliser dans le cas d'un
+    # formulaire sur une seule page. Cette vue doit être placée dans `app/views/authorization_request_forms`
+    single_page_view: 'api_entreprise_through_editor'
     # Optionnel. Prend celui de l'habilitation par défaut
     public: true
     # Optionnel. Prend celui de l'habilitation par défaut


### PR DESCRIPTION
Instead of adding multiple times the same template, can be specified within the config file. It's easier for non-tech to add forms with same logic (for instance: editors).

Old way still works.