### PR TITLE
Add admin_update event to AuthorizationRequestEvent

### DIFF
--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -26,7 +26,7 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
     case name
     when 'refuse', 'request_changes', 'revoke'
       h.simple_format(entity.reason)
-    when 'submit'
+    when 'submit', 'admin_update'
       humanized_changelog
     when 'initial_submit_with_changed_prefilled'
       humanized_changelog_without_blank_values

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -15,6 +15,8 @@ class AuthorizationRequestEvent < ApplicationRecord
     applicant_message
     instructor_message
 
+    admin_update
+
     system_reminder
     system_archive
   ].freeze
@@ -34,7 +36,7 @@ class AuthorizationRequestEvent < ApplicationRecord
     return if name == 'refuse' && entity_type == 'DenialOfAuthorization'
     return if name == 'revoke' && entity_type == 'RevocationOfAuthorization'
     return if name == 'request_changes' && entity_type == 'InstructorModificationRequest'
-    return if name == 'submit' && entity_type == 'AuthorizationRequestChangelog'
+    return if %w[submit admin_update].include?(name) && entity_type == 'AuthorizationRequestChangelog'
     return if %w[approve reopen].include?(name) && entity_type == 'Authorization'
     return if %w[applicant_message instructor_message].include?(name) && entity_type == 'Message'
     return if %w[approve refuse request_changes revoke].exclude?(name) && entity_type == 'AuthorizationRequest'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -498,6 +498,15 @@ fr:
               %{text}
             </blockquote>
 
+        admin_update:
+          text: |
+            L'administrateur <strong>%{user_full_name}</strong> a mis à jour la demande.
+
+            <br />
+
+            La liste des changements est :
+            %{text}
+
         system_reminder:
           text: Une relance a été envoyé au demandeur
 

--- a/db/migrate/20240514094958_more_and_more_constraints_to_authorization_request_events.rb
+++ b/db/migrate/20240514094958_more_and_more_constraints_to_authorization_request_events.rb
@@ -1,0 +1,48 @@
+class MoreAndMoreConstraintsToAuthorizationRequestEvents < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'admin_update' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'applicant_message' AND entity_type = 'Message') OR
+        (name = 'instructor_message' AND entity_type = 'Message') OR
+        (name = 'revoke' AND entity_type = 'RevocationOfAuthorization') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'applicant_message' AND entity_type = 'Message') OR
+        (name = 'instructor_message' AND entity_type = 'Message') OR
+        (name = 'revoke' AND entity_type = 'RevocationOfAuthorization') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_24_133631) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_094958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_24_133631) do
     t.index ["entity_type", "entity_id"], name: "index_authorization_request_events_on_entity"
     t.index ["user_id"], name: "index_authorization_request_events_on_user_id"
     t.check_constraint "name::text !~~ 'system_%'::text AND user_id IS NOT NULL OR name::text ~~ 'system_%'::text", name: "user_id_not_null_unless_system_event"
-    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'RevocationOfAuthorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
+    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'admin_update'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'RevocationOfAuthorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
   end
 
   create_table "authorization_requests", force: :cascade do |t|

--- a/spec/factories/authorization_request_events.rb
+++ b/spec/factories/authorization_request_events.rb
@@ -144,6 +144,18 @@ FactoryBot.define do
       end
     end
 
+    trait :admin_update do
+      name { 'admin_update' }
+
+      entity factory: %i[authorization_request_changelog]
+
+      after(:build) do |authorization_request_event, evaluator|
+        authorization_request_event.entity = build(:authorization_request_changelog, authorization_request: evaluator.authorization_request) if evaluator.authorization_request.present?
+
+        authorization_request_event.entity.diff.delete 'scopes'
+      end
+    end
+
     trait :system_reminder do
       name { 'system_reminder' }
 

--- a/spec/features/instruction/events_spec.rb
+++ b/spec/features/instruction/events_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe 'Instruction: habilitation events' do
     AuthorizationRequestEvent::NAMES.each_with_index do |event_name, index|
       create(:authorization_request_event, event_name, authorization_request:, created_at: index.days.ago)
     end
+
+    Bullet.enable = false
+  end
+
+  after do
+    Bullet.enable = true
   end
 
   it 'works for all events' do


### PR DESCRIPTION
Because of the change of diff management (on v1 it was on each update, v2 is on submit), changes from admin (without submit) is no longer displayed nor imported.

We have to introduce a new event to store these diffs within changelog model.