### PR TITLE
Harden EmailRecentlyVerifiedValidator

### DIFF
--- a/app/validators/email_recently_verified_validator.rb
+++ b/app/validators/email_recently_verified_validator.rb
@@ -2,10 +2,15 @@ class EmailRecentlyVerifiedValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    verified_email = VerifiedEmail.find_by(email: value)
-    verified_email = create_or_refresh_verified_email!(value) if verified_email.blank? || verified_email.old?
+    create_or_refresh_verified_email!(value)
 
-    record.errors.add(attribute, :email_unreachable) if verified_email.unreachable?
+    verified_email = VerifiedEmail.find_by(email: value)
+
+    if verified_email.blank?
+      record.errors.add(attribute, :email_deliverability_unknown)
+    elsif verified_email.unreachable?
+      record.errors.add(attribute, :email_unreachable)
+    end
   end
 
   private

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -121,9 +121,9 @@ ignore_missing:
 
 ## Consider these keys used:
 ignore_unused:
-- 'activerecord.attributes.*'
+- '{activerecord,activemodel}.attributes.*'
+- '{activerecord,activemodel}.errors.*'
 - 'ransack.attributes.*'
-- 'activerecord.errors.*'
 - 'errors.messages.*'
 - 'validates_timeliness.error_value_formats.*'
 - 'authorization_request_forms.*.*.info.{title,content}'

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -1,4 +1,9 @@
 fr:
+  activemodel:
+    errors:
+      messages:
+        email_unreachable: "n'est pas une adresse email joignable : celle-ci n'existe probablement pas. Veuillez soit mettre à jour cette adresse email, soit contacter le support à l'adresse datapass@api.gouv.fr en précisant votre numéro d'habilitation"
+        email_deliverability_unknown: "n'a pas pu être vérifiée : merci de contacter le support à l'adresse datapass@api.gouv.fr en précisant votre numéro d'habilitation"
   activerecord:
     attributes:
       user:
@@ -75,8 +80,6 @@ fr:
       instructor_modification_request:
         reason: Raison de la demande de modification
     errors:
-      messages:
-        email_unreachable: "n'est pas une adresse email joignable : celle-ci n'existe probablement pas. Veuillez soit mettre à jour cette adresse email, soit contacter le support."
       models:
         authorization_request:
           all_terms_not_accepted: Vous devez acceptez les conditions générales avant de continuer

--- a/spec/validators/email_recently_verified_validator_spec.rb
+++ b/spec/validators/email_recently_verified_validator_spec.rb
@@ -1,0 +1,101 @@
+class EmailRecentlyVerifiedValidatable
+  include ActiveModel::Validations
+  attr_accessor :email
+
+  def initialize(email:)
+    @email = email
+  end
+
+  validates :email, email_recently_verified: true
+end
+
+RSpec.describe EmailRecentlyVerifiedValidator do
+  subject { EmailRecentlyVerifiedValidatable.new(email:) }
+
+  let(:email_verifier_job) { instance_double(EmailVerifierJob, perform: nil) }
+
+  before do
+    allow(EmailVerifierJob).to receive(:new).and_return(email_verifier_job)
+  end
+
+  context 'when there is a verified email' do
+    let!(:verified_email) { create(:verified_email, status:, verified_at:) }
+    let(:email) { verified_email.email }
+
+    context 'when the email was verified less than 1 month ago' do
+      let(:status) { :deliverable }
+      let(:verified_at) { 1.minute.ago }
+
+      it { is_expected.to be_valid }
+
+      it 'calls EmailVerifierJob' do
+        subject.valid?
+
+        expect(email_verifier_job).to have_received(:perform)
+      end
+    end
+
+    context 'when the email was verified more than 1 month ago' do
+      let(:status) { :deliverable }
+      let(:verified_at) { 3.months.ago }
+
+      it { is_expected.to be_valid }
+
+      it 'calls EmailVerifierJob' do
+        subject.valid?
+
+        expect(email_verifier_job).to have_received(:perform)
+      end
+    end
+  end
+
+  context 'when there is no verified email' do
+    let(:email) { 'whate@ever.com' }
+
+    it 'calls EmailVerifierJob' do
+      subject.valid?
+
+      expect(email_verifier_job).to have_received(:perform)
+    end
+
+    context 'when EmailVerifierJob creates a verified email' do
+      let(:email_verifier_job) do
+        email_verifier_job = instance_double(EmailVerifierJob)
+
+        allow(email_verifier_job).to receive(:perform) do
+          create(:verified_email, email:, status:)
+        end
+
+        email_verifier_job
+      end
+
+      context 'when the email is deliverable' do
+        let(:status) { :deliverable }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when the email is undeliverable' do
+        let(:status) { :undeliverable }
+
+        it { is_expected.not_to be_valid }
+
+        it 'adds email_unreachable error on attribute' do
+          subject.valid?
+
+          expect(subject.errors[:email].to_s).to include('une adresse email joignable')
+        end
+      end
+    end
+
+    context 'when EmailVerifierJob does not create a verified email' do
+      it { is_expected.not_to be_valid }
+
+      it 'adds email_deliverability_unknown error on attribute' do
+        subject.valid?
+
+        expect(subject.errors[:email].to_s).to include('pu être vérifiée')
+      end
+    end
+  end
+end


### PR DESCRIPTION
No longer failed if there is no verified email. Add explicit messages to guide the user.

FIX https://errors.data.gouv.fr/organizations/sentry/issues/139907/