### PR TITLE
DAT-373 Move applicant informations to dashboard cards so all cards can display it

### DIFF
--- a/app/views/dashboard/_authorization_request_card.html.erb
+++ b/app/views/dashboard/_authorization_request_card.html.erb
@@ -33,18 +33,20 @@
     <% if authorization_request.respond_to?(:description) %>
       <div class="card-description">
         <%= truncate(authorization_request.description, length: 30) %>
-
-        <% if authorization_request.only_in_contacts?(current_user) %>
-          <p class="fr-text--xs fr-text-grey fr-my-2v">
-            <%= t('.current_user_mentions', contact_types: authorization_request.humanized_contact_types_for(current_user).to_sentence) %>
-          </p>
-        <% elsif authorization_request.applicant == current_user %>
-          <p class="fr-text--xs fr-text-grey fr-my-2v">
-            <%= t('.current_user_is_applicant') %>
-          </p>
-        <% end %>
       </div>
     <% end %>
+
+    <div class="card-applicant-information">
+      <% if authorization_request.only_in_contacts?(current_user) %>
+        <p class="fr-text--xs fr-text-grey fr-my-2v">
+          <%= t('.current_user_mentions', contact_types: authorization_request.humanized_contact_types_for(current_user).to_sentence) %>
+        </p>
+      <% elsif authorization_request.applicant == current_user %>
+        <p class="fr-text--xs fr-text-grey fr-my-2v">
+          <%= t('.current_user_is_applicant') %>
+        </p>
+      <% end %>
+    </div>
 
     <% if authorization_request.already_been_validated? %>
       <%= link_to t('.show_cta'), authorization_path(authorization_request.latest_authorization), class: %w(fr-btn fr-btn--sm) %>


### PR DESCRIPTION
  - if a request has no description in it, the current_user_mentions of current_user_is_applicant information will not display
  
  **Before :** 
  
<img width="962" alt="Capture d’écran 2024-05-22 à 12 54 45" src="https://github.com/etalab/data_pass/assets/43042737/211982b2-4bf1-458b-b2a9-cc30900ec5b8">


**After:** 

<img width="962" alt="Capture d’écran 2024-05-22 à 12 54 24" src="https://github.com/etalab/data_pass/assets/43042737/2a05717d-aad0-40ef-8aab-20d8d4661f7e">
