### PR TITLE
Bugfix RegisterOrganizationWithContactsOnCRMJob 400 error

### DIFF
--- a/app/jobs/register_organization_with_contacts_on_crm_job.rb
+++ b/app/jobs/register_organization_with_contacts_on_crm_job.rb
@@ -35,7 +35,7 @@ class RegisterOrganizationWithContactsOnCRMJob < ApplicationJob
     crm_client.create_company(
       siret: organization.siret,
       name: organization.raison_sociale,
-      categorie_juridique: organization.categorie_juridique_label,
+      categorie_juridique: organization.categorie_juridique.try(:libelle),
       n_datapass: authorization_request.id.to_s,
       bouquets_utilises: extract_bouquet(:company)
     )

--- a/app/jobs/register_organization_with_contacts_on_crm_job.rb
+++ b/app/jobs/register_organization_with_contacts_on_crm_job.rb
@@ -35,7 +35,7 @@ class RegisterOrganizationWithContactsOnCRMJob < ApplicationJob
     crm_client.create_company(
       siret: organization.siret,
       name: organization.raison_sociale,
-      categorie_juridique: organization.categorie_juridique.try(:libelle),
+      categorie_juridique: organization.categorie_juridique.try(:code),
       n_datapass: authorization_request.id.to_s,
       bouquets_utilises: extract_bouquet(:company)
     )

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,10 +22,10 @@ class Organization < ApplicationRecord
     mon_compte_pro_payload['label']
   end
 
-  def categorie_juridique_label
+  def categorie_juridique
     return unless insee_payload
 
-    CategorieJuridique.find(insee_payload['etablissement']['uniteLegale']['categorieJuridiqueUniteLegale']).libelle
+    CategorieJuridique.find(insee_payload['etablissement']['uniteLegale']['categorieJuridiqueUniteLegale'])
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -3,13 +3,18 @@ RSpec.describe Organization do
     expect(build(:organization, siret: '21920023500014')).to be_valid
   end
 
-  describe '#categorie_juridique_label' do
-    subject { organization.categorie_juridique_label }
+  describe '#categorie_juridique' do
+    subject { organization.categorie_juridique }
 
     context 'with an organization with an insee payload' do
       let(:organization) { build(:organization, siret: '13002526500013') }
 
-      it { is_expected.to eq('Service central d\'un ministère') }
+      it { is_expected.to be_a(CategorieJuridique) }
+
+      it 'returns the correct categorie juridique' do
+        expect(subject.code).to eq('7120')
+        expect(subject.libelle).to eq('Service central d\'un ministère')
+      end
     end
 
     context 'with an organization without an insee payload' do


### PR DESCRIPTION
CRM use id (which is the code), not label

Closes https://errors.data.gouv.fr/organizations/sentry/issues/140500/