### PR TITLE
Instruction: Can search authorization request by ID (use contains, partial match)

### DIFF
--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -189,6 +189,10 @@ class AuthorizationRequest < ApplicationRecord
     ]
   end
 
+  ransacker :id do
+    Arel.sql("to_char(\"#{table_name}\".\"id\", '99999999')")
+  end
+
   ransacker :within_data do |_parent|
     Arel.sql('authorization_requests.data::text')
   end

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -2,9 +2,10 @@
 
 <%= search_form_for(@q, url: instruction_authorization_requests_path, html: { method: :get, data: { turbo: false }, class: %w[search-box] }) do |f| %>
   <div class="search-inputs">
-    <div class="fr-input-group input">
-      <%= f.label :within_data_or_organization_siret_cont, t('.search.main_input'), class: %w[fr-label] %>
-      <%= f.search_field :within_data_or_organization_siret_cont, id: 'search_main_input', class: %[fr-input] %>
+
+    <div class="fr-input-group main-input input">
+      <%= f.label :within_data_or_organization_siret_or_id_cont, t('.search.main_input.label'), class: %w[fr-label] %>
+      <%= f.search_field :within_data_or_organization_siret_or_id_cont, class: %[fr-input], placeholder: t('.search.main_input.placeholder') %>
     </div>
 
     <% if current_user.authorization_definition_roles_as(:instructor).count > 1 %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -287,7 +287,9 @@ fr:
     authorization_requests:
       index:
         search:
-          main_input: Rechercher dans les infos des habilitations
+          main_input:
+            label: Rechercher dans les infos des habilitations
+            placeholder: id, numéro de siret, intitulé...
           btn: Rechercher
         table:
           caption: Liste des demandes en cours

--- a/features/instructeurs/liste_des_habilitations.feature
+++ b/features/instructeurs/liste_des_habilitations.feature
@@ -27,3 +27,11 @@ Fonctionnalité: Instruction: liste des habilitations
     Et que je sélectionne "Validée" pour "État égal à"
     Et que je clique sur "Rechercher"
     Alors je vois 1 demande d'habilitation
+
+  Scénario: Je cherche une habilitation avec son ID
+    Sachant qu'il y a 1 demande d'habilitation "API Entreprise" en attente
+    Et qu'il y a 1 demande d'habilitation "API Entreprise" validée
+    Et que je vais sur la page instruction
+    Et que je renseigne l'identifiant de la dernière demande dans le champ "Rechercher dans les infos des habilitations"
+    Et que je clique sur "Rechercher"
+    Alors je vois 1 demande d'habilitation

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -279,3 +279,7 @@ end
 Et('je peux voir le bouton {string} grisé et désactivé') do |string|
   expect(page).to have_css('button[disabled]', text: string)
 end
+
+Et('je renseigne l\'identifiant de la dernière demande dans le champ {string}') do |field|
+  fill_in field, with: AuthorizationRequest.last.id
+end

--- a/spec/features/instruction/search_spec.rb
+++ b/spec/features/instruction/search_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'Instruction: habilitation search' do
     visit instruction_authorization_requests_path
 
     within('#authorization_request_search') do
-      fill_in 'search_main_input', with: search_text if use_search_text
+      fill_in 'q_within_data_or_organization_siret_or_id_cont', with: search_text if use_search_text
       select state, from: 'q_state_eq' if state
       select type, from: 'q_type_eq' if type
 


### PR DESCRIPTION
Use existing input with contains (not an exact match).

<img width="1296" alt="Screenshot 2024-06-04 at 16 21 55" src="https://github.com/etalab/data_pass/assets/1279968/e7612d5d-2fb0-4cec-b027-0dd352fd48df">

Related https://github.com/etalab/data_pass/pull/222