### PR TITLE
Reporter is redirect to instruction namespace on visit on the user namespace

### DIFF
--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -61,9 +61,13 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
     authorize @authorization_request
     @summary_before_submit = @authorization_request.filling?
   rescue Pundit::NotAuthorizedError
-    raise unless AuthorizationRequestPolicy.new(pundit_user, @authorization_request).show?
-
-    redirect_to authorization_request_form_path(form_uid: @authorization_request_form.uid, id: @authorization_request.id)
+    if AuthorizationRequestPolicy.new(pundit_user, @authorization_request).show?
+      redirect_to authorization_request_form_path(form_uid: @authorization_request_form.uid, id: @authorization_request.id)
+    elsif Instruction::AuthorizationRequestPolicy.new(pundit_user, @authorization_request).show?
+      redirect_to instruction_authorization_request_path(@authorization_request)
+    else
+      raise
+    end
   end
 
   private

--- a/features/consultation_habilitation_en_tant_que_reporter.feature
+++ b/features/consultation_habilitation_en_tant_que_reporter.feature
@@ -1,0 +1,21 @@
+# language: fr
+
+Fonctionnalité: Consultation d'une demande d'habilitation en tant que reporter
+  Un reporter peut se retrouver à consulter une demande d'habilitation via le lien utiliser par
+  un utilisateur normal.
+
+  Contexte:
+    Sachant que je suis un rapporteur "API Entreprise"
+    Et que je me connecte
+
+  Scénario: Je consulte une demande d'habilitation où je suis reporter via un lien direct
+    Quand je me rends via l'espace usager sur une demande d'habilitation "API Entreprise"
+    Alors la page contient "API Entreprise"
+    Et la page contient "Les informations renseignées par le demandeur"
+
+  Scénario: Je consulte une demande d'habilitation où je ne suis pas reporter via un lien direct
+    Quand je me rends via l'espace usager sur une demande d'habilitation "API Particulier"
+    Alors il y a un message d'erreur contenant "Vous n'avez pas le droit d'accéder à cette page"
+
+
+

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -109,6 +109,12 @@ Quand('je me rends sur cette demande d\'habilitation') do
   end
 end
 
+Quand(/je me rends via l'espace usager sur une demande d'habilitation "([^"]+)"/) do |type|
+  authorization_request = create_authorization_requests_with_status(type).first
+
+  visit authorization_request_path(authorization_request)
+end
+
 # https://rubular.com/r/0orApA5lrXMtTA
 Quand(/je me rends sur une demande d'habilitation "([^"]+)"(?: de l'organisation "([^"]+)")?(?: (?:en|à))? ?(.+)?/) do |type, organization_name, status|
   attributes = {}


### PR DESCRIPTION
When a reporter or an instructor tries to access an authorization request associated to his role, he is redirect to the instruction namespace instead of redirect to dashboard with a 404 error.