### PR TITLE
Backend only: introduce TransferAuthorizationRequestToNewApplicant

### DIFF
--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -22,6 +22,7 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def text
     case name
     when 'refuse', 'request_changes', 'revoke'
@@ -32,8 +33,12 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
       humanized_changelog_without_blank_values
     when 'applicant_message', 'instructor_message'
       h.simple_format(entity.body)
+    when 'transfer'
+      "#{entity.to.full_name} (#{entity.to.email})"
     end
   end
+  # rubocop:enable Metrics/AbcSize
+
   alias comment text # see WebhookEventSerializer
 
   def copied_from_authorization_request_id

--- a/app/interactors/create_authorization_request_transfer_model.rb
+++ b/app/interactors/create_authorization_request_transfer_model.rb
@@ -1,0 +1,19 @@
+class CreateAuthorizationRequestTransferModel < ApplicationInteractor
+  def call
+    context.authorization_request_transfer = AuthorizationRequestTransfer.new(
+      authorization_request_transfer_params,
+    )
+
+    context.fail!(error: :invalid_transfer) unless context.authorization_request_transfer.save
+  end
+
+  private
+
+  def authorization_request_transfer_params
+    {
+      authorization_request: context.authorization_request,
+      from: context.old_applicant,
+      to: context.new_applicant
+    }
+  end
+end

--- a/app/interactors/update_applicant_on_authorization_request.rb
+++ b/app/interactors/update_applicant_on_authorization_request.rb
@@ -1,0 +1,9 @@
+class UpdateApplicantOnAuthorizationRequest < ApplicationInteractor
+  def call
+    context.authorization_request.applicant = context.new_applicant
+
+    return if context.authorization_request.save
+
+    context.fail!(error: :invalid_new_applicant)
+  end
+end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -53,6 +53,11 @@ class AuthorizationRequest < ApplicationRecord
     inverse_of: :authorization_request,
     dependent: :destroy
 
+  has_many :transfers,
+    class_name: 'AuthorizationRequestTransfer',
+    inverse_of: :authorization_request,
+    dependent: :destroy
+
   has_many :authorizations,
     class_name: 'Authorization',
     inverse_of: :request,

--- a/app/models/authorization_request_event.rb
+++ b/app/models/authorization_request_event.rb
@@ -9,6 +9,7 @@ class AuthorizationRequestEvent < ApplicationRecord
     revoke
     submit
     update
+    transfer
 
     copy
 
@@ -36,6 +37,7 @@ class AuthorizationRequestEvent < ApplicationRecord
     return if name == 'refuse' && entity_type == 'DenialOfAuthorization'
     return if name == 'revoke' && entity_type == 'RevocationOfAuthorization'
     return if name == 'request_changes' && entity_type == 'InstructorModificationRequest'
+    return if name == 'transfer' && entity_type == 'AuthorizationRequestTransfer'
     return if %w[submit admin_update].include?(name) && entity_type == 'AuthorizationRequestChangelog'
     return if %w[approve reopen].include?(name) && entity_type == 'Authorization'
     return if %w[applicant_message instructor_message].include?(name) && entity_type == 'Message'

--- a/app/models/authorization_request_transfer.rb
+++ b/app/models/authorization_request_transfer.rb
@@ -1,0 +1,32 @@
+class AuthorizationRequestTransfer < ApplicationRecord
+  belongs_to :authorization_request
+  belongs_to :from,
+    class_name: 'User'
+  belongs_to :to,
+    class_name: 'User'
+
+  has_one :event,
+    class_name: 'AuthorizationRequestEvent',
+    inverse_of: :entity,
+    dependent: :destroy
+
+  has_one :initiator,
+    through: :event,
+    source: :user,
+    class_name: 'User'
+
+  validate :users_are_from_the_same_organization
+  validate :users_are_different
+
+  def users_are_from_the_same_organization
+    return if from.organization_ids.intersect?(to.organization_ids)
+
+    errors.add(:to, :different_organization)
+  end
+
+  def users_are_different
+    return if from_id != to_id
+
+    errors.add(:to, :different_user)
+  end
+end

--- a/app/organizers/transfer_authorization_request_to_new_applicant.rb
+++ b/app/organizers/transfer_authorization_request_to_new_applicant.rb
@@ -1,0 +1,11 @@
+class TransferAuthorizationRequestToNewApplicant < ApplicationOrganizer
+  before do
+    context.event_entity = :authorization_request_transfer
+    context.event_name = 'transfer'
+    context.old_applicant = context.authorization_request.applicant
+  end
+
+  organize UpdateApplicantOnAuthorizationRequest,
+    CreateAuthorizationRequestTransferModel,
+    CreateAuthorizationRequestEventModel
+end

--- a/app/organizers/transfer_authorization_request_to_new_applicant.rb
+++ b/app/organizers/transfer_authorization_request_to_new_applicant.rb
@@ -7,5 +7,6 @@ class TransferAuthorizationRequestToNewApplicant < ApplicationOrganizer
 
   organize UpdateApplicantOnAuthorizationRequest,
     CreateAuthorizationRequestTransferModel,
-    CreateAuthorizationRequestEventModel
+    CreateAuthorizationRequestEventModel,
+    DeliverAuthorizationRequestWebhook
 end

--- a/app/queries/authorization_request_events_query.rb
+++ b/app/queries/authorization_request_events_query.rb
@@ -10,17 +10,24 @@ class AuthorizationRequestEventsQuery
       .includes(%i[user entity])
       .where(
         sql_query,
-        authorization_request.id,
-        authorization_request.denial_ids,
-        authorization_request.modification_request_ids,
-        authorization_request.changelog_ids,
-        authorization_request.message_ids,
-        authorization_request.authorization_ids,
-        authorization_request.revocation_ids
+        *model_ids,
       )
   end
 
   private
+
+  def model_ids
+    [
+      authorization_request.id,
+      authorization_request.denial_ids,
+      authorization_request.modification_request_ids,
+      authorization_request.changelog_ids,
+      authorization_request.message_ids,
+      authorization_request.authorization_ids,
+      authorization_request.revocation_ids,
+      authorization_request.transfer_ids,
+    ]
+  end
 
   def sql_query
     "(entity_id = ? and entity_type = 'AuthorizationRequest') or " \
@@ -29,6 +36,7 @@ class AuthorizationRequestEventsQuery
       "(entity_id in (?) and entity_type = 'AuthorizationRequestChangelog') or " \
       "(entity_id in (?) and entity_type = 'Message') or " \
       "(entity_id in (?) and entity_type = 'Authorization') or" \
-      "(entity_id in (?) and entity_type = 'RevocationOfAuthorization')"
+      "(entity_id in (?) and entity_type = 'RevocationOfAuthorization') or" \
+      "(entity_id in (?) and entity_type = 'AuthorizationRequestTransfer')"
   end
 end

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -4,6 +4,12 @@ fr:
       messages:
         email_unreachable: "n'est pas une adresse email joignable : celle-ci n'existe probablement pas. Veuillez soit mettre à jour cette adresse email, soit contacter le support à l'adresse datapass@api.gouv.fr en précisant votre numéro d'habilitation"
         email_deliverability_unknown: "n'a pas pu être vérifiée : merci de contacter le support à l'adresse datapass@api.gouv.fr en précisant votre numéro d'habilitation"
+      models:
+        authorization_request_transfer:
+          attributes:
+            to:
+              different_user: "doit être différent du demandeur actuel"
+              different_organization: "n'appartient pas à la même organisation que le demandeur actuel."
   activerecord:
     attributes:
       user:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -432,6 +432,9 @@ fr:
           text: "<strong>%{user_full_name}</strong> a crée la demande"
         update:
           text: "<strong>%{user_full_name}</strong> a mis à jour la demande"
+
+        transfer:
+          text: "<strong>%{user_full_name}</strong> a transféré la demande à <strong>%{text}</strong>"
         archive:
           text: "<strong>%{user_full_name}</strong> a supprimé la demande"
         initial_submit:

--- a/db/migrate/20240606140028_create_authorization_request_transfers.rb
+++ b/db/migrate/20240606140028_create_authorization_request_transfers.rb
@@ -1,0 +1,11 @@
+class CreateAuthorizationRequestTransfers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :authorization_request_transfers do |t|
+      t.references :authorization_request, null: false, foreign_key: true
+      t.references :from, null: false, foreign_key: { to_table: :users }
+      t.references :to, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240606144601_more_and_more_and_more_constraints_to_authorization_request_events.rb
+++ b/db/migrate/20240606144601_more_and_more_and_more_constraints_to_authorization_request_events.rb
@@ -1,0 +1,50 @@
+class MoreAndMoreAndMoreConstraintsToAuthorizationRequestEvents < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'admin_update' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'applicant_message' AND entity_type = 'Message') OR
+        (name = 'instructor_message' AND entity_type = 'Message') OR
+        (name = 'revoke' AND entity_type = 'RevocationOfAuthorization') OR
+        (name = 'transfer' AND entity_type = 'AuthorizationRequestTransfer') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      DROP CONSTRAINT entity_type_validation
+    SQL
+
+    execute <<-SQL
+      ALTER TABLE authorization_request_events
+      ADD CONSTRAINT entity_type_validation
+      CHECK (
+        (name = 'refuse' AND entity_type = 'DenialOfAuthorization') OR
+        (name = 'request_changes' AND entity_type = 'InstructorModificationRequest') OR
+        (name = 'approve' AND entity_type = 'Authorization') OR
+        (name = 'reopen' AND entity_type = 'Authorization') OR
+        (name = 'submit' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'admin_update' AND entity_type = 'AuthorizationRequestChangelog') OR
+        (name = 'applicant_message' AND entity_type = 'Message') OR
+        (name = 'instructor_message' AND entity_type = 'Message') OR
+        (name = 'revoke' AND entity_type = 'RevocationOfAuthorization') OR
+        (entity_type = 'AuthorizationRequest')
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_20_092639) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_140028) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -71,6 +71,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_092639) do
     t.index ["user_id"], name: "index_authorization_request_events_on_user_id"
     t.check_constraint "name::text !~~ 'system_%'::text AND user_id IS NOT NULL OR name::text ~~ 'system_%'::text", name: "user_id_not_null_unless_system_event"
     t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'admin_update'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'RevocationOfAuthorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
+  end
+
+  create_table "authorization_request_transfers", force: :cascade do |t|
+    t.bigint "authorization_request_id", null: false
+    t.bigint "from_id", null: false
+    t.bigint "to_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["authorization_request_id"], name: "idx_on_authorization_request_id_a4275ef675"
+    t.index ["from_id"], name: "index_authorization_request_transfers_on_from_id"
+    t.index ["to_id"], name: "index_authorization_request_transfers_on_to_id"
   end
 
   create_table "authorization_requests", force: :cascade do |t|
@@ -270,6 +281,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_092639) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authorization_documents", "authorizations"
   add_foreign_key "authorization_request_changelogs", "authorization_requests"
+  add_foreign_key "authorization_request_transfers", "authorization_requests"
+  add_foreign_key "authorization_request_transfers", "users", column: "from_id"
+  add_foreign_key "authorization_request_transfers", "users", column: "to_id"
   add_foreign_key "authorization_requests", "authorization_requests", column: "next_request_copied_id"
   add_foreign_key "authorizations", "authorization_requests", column: "request_id"
   add_foreign_key "authorizations", "users", column: "applicant_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_06_140028) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_144601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_140028) do
     t.index ["entity_type", "entity_id"], name: "index_authorization_request_events_on_entity"
     t.index ["user_id"], name: "index_authorization_request_events_on_user_id"
     t.check_constraint "name::text !~~ 'system_%'::text AND user_id IS NOT NULL OR name::text ~~ 'system_%'::text", name: "user_id_not_null_unless_system_event"
-    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'admin_update'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'RevocationOfAuthorization'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
+    t.check_constraint "name::text = 'refuse'::text AND entity_type::text = 'DenialOfAuthorization'::text OR name::text = 'request_changes'::text AND entity_type::text = 'InstructorModificationRequest'::text OR name::text = 'approve'::text AND entity_type::text = 'Authorization'::text OR name::text = 'reopen'::text AND entity_type::text = 'Authorization'::text OR name::text = 'submit'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'admin_update'::text AND entity_type::text = 'AuthorizationRequestChangelog'::text OR name::text = 'applicant_message'::text AND entity_type::text = 'Message'::text OR name::text = 'instructor_message'::text AND entity_type::text = 'Message'::text OR name::text = 'revoke'::text AND entity_type::text = 'RevocationOfAuthorization'::text OR name::text = 'transfer'::text AND entity_type::text = 'AuthorizationRequestTransfer'::text OR entity_type::text = 'AuthorizationRequest'::text", name: "entity_type_validation"
   end
 
   create_table "authorization_request_transfers", force: :cascade do |t|

--- a/spec/factories/authorization_request_events.rb
+++ b/spec/factories/authorization_request_events.rb
@@ -26,6 +26,18 @@ FactoryBot.define do
       name { 'update' }
     end
 
+    trait :transfer do
+      name { 'transfer' }
+
+      entity factory: :authorization_request_transfer
+
+      after(:build) do |authorization_request_event, evaluator|
+        next if evaluator.authorization_request.blank?
+
+        authorization_request_event.entity = build(:authorization_request_transfer, authorization_request: evaluator.authorization_request, from: evaluator.authorization_request.applicant)
+      end
+    end
+
     trait :submit do
       name { 'submit' }
 

--- a/spec/factories/authorization_request_transfers.rb
+++ b/spec/factories/authorization_request_transfers.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :authorization_request_transfer do
+    authorization_request
+
+    from { build(:user) }
+
+    after(:build) do |authorization_request_transfer|
+      authorization_request_transfer.to ||= create(:user, current_organization: authorization_request_transfer.from.current_organization)
+    end
+  end
+end

--- a/spec/models/authorization_request_transfer_spec.rb
+++ b/spec/models/authorization_request_transfer_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe AuthorizationRequestTransfer do
+  it 'has valid factories' do
+    expect(build(:authorization_request_transfer)).to be_valid
+  end
+
+  describe 'from and to users validation' do
+    subject { build(:authorization_request_transfer, from: from_user, to: to_user) }
+
+    let(:from_user) { create(:user) }
+
+    context 'when to_user is the same as from_user' do
+      let(:to_user) { from_user }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when to_user is different from from_user' do
+      context 'when to_user is not from the same organization as from_user' do
+        let(:to_user) { create(:user) }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when to_user is from the same organization as from_user' do
+        let(:to_user) { create(:user, current_organization: from_user.current_organization) }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end

--- a/spec/organizers/transfer_authorization_request_to_new_applicant_spec.rb
+++ b/spec/organizers/transfer_authorization_request_to_new_applicant_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe TransferAuthorizationRequestToNewApplicant, type: :organizer do
           entity: instance_of(AuthorizationRequestTransfer),
         )
       end
+
+      context 'when authorization request has webhooks activated' do
+        let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+
+        it 'delivers a webhook for transfer event' do
+          expect { subject }.to have_enqueued_job(DeliverAuthorizationRequestWebhookJob).with(
+            authorization_request.definition.id,
+            a_string_matching('"event":"transfer"'),
+            authorization_request.id,
+          )
+        end
+      end
     end
 
     context 'with invalid attributes' do

--- a/spec/organizers/transfer_authorization_request_to_new_applicant_spec.rb
+++ b/spec/organizers/transfer_authorization_request_to_new_applicant_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe TransferAuthorizationRequestToNewApplicant, type: :organizer do
+  describe '.call' do
+    subject { described_class.call(authorization_request:, new_applicant:, user:) }
+
+    let(:organization) { authorization_request.organization }
+    let(:authorization_request) { create(:authorization_request) }
+    let!(:old_applicant) { authorization_request.applicant }
+    let(:new_applicant) { create(:user, current_organization: organization) }
+    let(:user) { create(:user) }
+
+    context 'with valid attributes' do
+      it { is_expected.to be_success }
+
+      it 'transfers the authorization request to the new applicant' do
+        expect { subject }.to change { authorization_request.reload.applicant }.from(authorization_request.applicant).to(new_applicant)
+      end
+
+      it 'creates a new authorization request transfer with valid attributes' do
+        expect { subject }.to change(AuthorizationRequestTransfer, :count).by(1)
+
+        expect(AuthorizationRequestTransfer.last).to have_attributes(
+          authorization_request:,
+          from: old_applicant,
+          to: new_applicant,
+        )
+      end
+
+      it 'creates an event with valid attributes' do
+        expect { subject }.to change(AuthorizationRequestEvent, :count).by(1)
+
+        expect(AuthorizationRequestEvent.last).to have_attributes(
+          name: 'transfer',
+          user:,
+          entity: instance_of(AuthorizationRequestTransfer),
+        )
+      end
+    end
+
+    context 'with invalid attributes' do
+      let(:new_applicant) { create(:user) }
+
+      it { is_expected.to be_failure }
+
+      it 'does not transfer the authorization request to the new applicant' do
+        expect { subject }.not_to change { authorization_request.reload.applicant }
+      end
+
+      it 'does not create a new authorization request transfer' do
+        expect { subject }.not_to change(AuthorizationRequestTransfer, :count)
+      end
+
+      it 'does not create an event' do
+        expect { subject }.not_to change(AuthorizationRequestEvent, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Only a service to transfer an authorization request from one applicant to another applicant.

The new applicant must belong to an organization of the original applicant (and the authorization request as well).
There's a webhook delivered if there are activated (mostly to keep track of changes from the data provider side).

It'll be used at first mostly for support purpose