### PR TITLE
    Introduce scopes config on forms

### DIFF
--- a/app/form_builders/authorization_request_form_builder.rb
+++ b/app/form_builders/authorization_request_form_builder.rb
@@ -101,6 +101,8 @@ class AuthorizationRequestFormBuilder < DSFRFormBuilder
   def dsfr_scope(scope, opts = {})
     disabled = opts.delete(:disabled)
 
+    disabled = @object.disabled_scopes.include?(scope) if disabled.blank?
+
     @template.content_tag(:div, class: 'fr-checkbox-group') do
       @template.safe_join(
         [

--- a/app/models/authorization_request_form.rb
+++ b/app/models/authorization_request_form.rb
@@ -13,6 +13,7 @@ class AuthorizationRequestForm < StaticApplicationRecord
   attr_writer :description,
     :startable_by_applicant,
     :data,
+    :scopes_config,
     :public
 
   def self.all
@@ -31,7 +32,8 @@ class AuthorizationRequestForm < StaticApplicationRecord
         :use_case,
         :data,
         :single_page_view,
-        :startable_by_applicant
+        :startable_by_applicant,
+        :scopes_config,
       ).merge(
         uid: uid.to_s,
         editor: hash[:editor_id].present? ? Editor.find(hash[:editor_id]) : nil,
@@ -102,6 +104,10 @@ class AuthorizationRequestForm < StaticApplicationRecord
     end
 
     data
+  end
+
+  def scopes_config
+    @scopes_config || {}
   end
 
   def self.indexable

--- a/app/models/concerns/authorization_core/scopes.rb
+++ b/app/models/concerns/authorization_core/scopes.rb
@@ -36,14 +36,34 @@ module AuthorizationCore::Scopes
   end
 
   def available_scopes
-    @available_scopes ||= definition.scopes
+    @available_scopes ||= if displayed_scope_values
+                            definition.scopes.select { |scope| displayed_scope_values.include?(scope.value) }
+                          else
+                            definition.scopes
+                          end
   end
 
   def included_scopes
     @included_scopes ||= definition.scopes.select(&:included?)
   end
 
+  def disabled_scopes
+    @disabled_scopes ||= definition.scopes.select { |scope| disabled_scope_values.include?(scope.value) }
+  end
+
   def legacy_scope_values
     scopes - available_scopes.map(&:value)
+  end
+
+  private
+
+  def disabled_scope_values
+    form.scopes_config[:disabled].presence || []
+  end
+
+  def displayed_scope_values
+    return if form.scopes_config[:displayed].blank?
+
+    form.scopes_config[:displayed]
   end
 end

--- a/app/views/authorization_request_forms/api_particulier_through_editor.html.erb
+++ b/app/views/authorization_request_forms/api_particulier_through_editor.html.erb
@@ -22,6 +22,16 @@
 
   <div class="fr-mt-2w">
     <h3>
+      Les données
+    </h3>
+  </div>
+
+  <div class="fr-container-fluid">
+    <%= render partial: 'authorization_request_forms/shared/scopes', locals: { f: } %>
+  </div>
+
+  <div class="fr-mt-2w">
+    <h3>
       Contacts légaux
     </h3>
 

--- a/app/views/authorization_request_forms/api_particulier_through_editor_without_contact_technique.html.erb
+++ b/app/views/authorization_request_forms/api_particulier_through_editor_without_contact_technique.html.erb
@@ -22,6 +22,16 @@
 
   <div class="fr-mt-2w">
     <h3>
+      Les données
+    </h3>
+  </div>
+
+  <div class="fr-container-fluid">
+    <%= render partial: 'authorization_request_forms/shared/scopes', locals: { f: } %>
+  </div>
+
+  <div class="fr-mt-2w">
+    <h3>
       Contacts
     </h3>
 

--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -56,6 +56,14 @@ api-particulier-abelium:
   - name: personal_data
   - name: legal
   - name: scopes
+  scopes_config:
+    disabled:
+      - cnaf_quotient_familial
+    displayed:
+      - cnaf_quotient_familial
+      - cnaf_allocataires
+      - cnaf_enfants
+      - cnaf_adresse
   data:
     intitule: Service Périscolaire, Restauration Scolaire, Extrascolaire, Accueil
       des loisirs
@@ -79,9 +87,6 @@ api-particulier-abelium:
     duree_conservation_donnees_caractere_personnel: 36
     scopes:
       - cnaf_quotient_familial
-      - cnaf_allocataires
-      - cnaf_enfants
-      - cnaf_adresse
 
 api-particulier-agora-plus:
   name: Agora Famille Premium, Tarification services municipaux / Portail Famille

--- a/docs/new_provider.md
+++ b/docs/new_provider.md
@@ -91,6 +91,19 @@ Pour [le formulaire](../config/authorization_request_forms.yml):
     public: true
     # Optionnel. Prend celui de l'habilitation par défaut
     startable_by_applicant: true
+    # Optionnel. Permet de définir des options sur les scopes de la définition
+    # au sein du formulaire.
+    scopes_config:
+      # Optionnel. Scopes (par valeur) qui auront leur checkbox désactivés. A
+      # noter que le scope peut-être présent (grace à la clé `data`) ci-dessous.
+      disabled:
+        - scope1
+        - scope2
+      # Optionnel. Scopes (par valeur) qui seront affichés. Si cette clé est
+      # omise l'ensemble des scopes de la définition sont affichés.
+      displayed:
+        - scope3
+        - scope4
     # Optionnel. Données pré-rempli au démarrage du formulaire.
     data:
       intitule: "Mon intitulé"

--- a/features/habilitations/portail_hubee_demarches_dila.feature
+++ b/features/habilitations/portail_hubee_demarches_dila.feature
@@ -51,7 +51,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation Portail HubEE - Démarc
     Et il y a au moins une erreur sur un champ
     Et je suis sur la page "Portail HubEE - Démarches DILA"
 
-  Scénario: Je soumets une demande d'habilitation valide
+  Scénario: Je ne peux pas cocher un scope si celui-ci existe déjà dans une demande envoyée
     Quand je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
     * je coche "AEC - Acte d’Etat Civil"
     * je clique sur "Suivant"
@@ -64,5 +64,5 @@ Fonctionnalité: Soumission d'une demande d'habilitation Portail HubEE - Démarc
     * j'adhère aux conditions générales
     * je clique sur "Soumettre la demande d'habilitation"
 
-    * je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
+    Et que je démarre une nouvelle demande d'habilitation "Portail HubEE - Démarches DILA"
     Alors je ne peux pas cocher "AEC - Acte d’Etat Civil"

--- a/features/habilitations_avec_des_options_sur_les_scopes.feature
+++ b/features/habilitations_avec_des_options_sur_les_scopes.feature
@@ -1,0 +1,42 @@
+# language: fr
+
+Fonctionnalité: Demandes d'habilitation ayant des configurations sur les scopes
+  Ces scénarios traduisent les diverses propriétés existantes sur les scopes des demandes
+  d'habilitation, tel que le caractère désactivé des cases à cochées, ou encore de l'affichage
+  de ces scopes. Le tout est déterminé au niveau du formulaire (ou du contexte de la demande)
+  et non au niveau de la définition.
+
+  Contexte:
+    Sachant que je suis un demandeur
+    Et que je me connecte
+
+  Scénario: Je consulte la page des scopes d'une demande d'habilitation où il n'y a pas d'options sur les scopes, où tous les scopes sont affichés
+    Quand je veux remplir une demande pour "API Particulier" via le formulaire "Demande libre"
+    Et que je clique sur "Débuter mon habilitation"
+
+    * je renseigne les infos de bases du projet
+    * je remplis "Date de mise en production" avec "25/12/2042"
+    * je clique sur "Suivant"
+
+    * je renseigne les infos concernant les données personnelles
+    * je clique sur "Suivant"
+
+    * je remplis "Précisez la nature et les références du texte vous autorisant à traiter les données" avec "Article 42"
+    * je remplis "URL du texte relatif au traitement" avec "https://legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006430983&cidTexte=LEGITEXT000006070721"
+    * je clique sur "Suivant"
+
+    Alors la page contient "Les données"
+    Et la page contient "API Quotient familial"
+    Et la page contient "API Statut étudiant boursier"
+    Et la page contient "API Prime d'Activité"
+
+  Scénario: Je consulte la page des scopes d'une demande d'habilitation où il y a des options de désactivation et d'affichage
+
+    Quand je veux remplir une demande pour "API Particulier" via le formulaire "Domino web 2.0, Tarification services municipaux / Portail Famille"
+    Et que je clique sur "Débuter mon habilitation"
+
+    Alors la page contient "Les données"
+    Et la page contient "API Quotient familial"
+    Et la page ne contient pas "API Statut étudiant boursier"
+    Et je ne peux pas cocher "Quotient familial CAF & MSA"
+    Et je peux cocher "Identités allocataire et conjoint"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -186,5 +186,11 @@ end
 Alors('je ne peux pas cocher {string}') do |checkbox_label|
   checkbox_id = "##{find('label', text: checkbox_label)[:for]}"
 
-  expect(page.find(checkbox_id, visible: :all)[:disabled]).to be_truthy
+  expect(page.find(checkbox_id, visible: :all)[:disabled]).to be_truthy, "Expected checkbox '#{checkbox_label}' to be disabled"
+end
+
+Alors('je peux cocher {string}') do |checkbox_label|
+  checkbox_id = "##{find('label', text: checkbox_label)[:for]}"
+
+  expect(page.find(checkbox_id, visible: :all)[:disabled]).to be_in([nil, false]), "Expected checkbox '#{checkbox_label}' to be enabled"
 end

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -202,4 +202,38 @@ RSpec.describe AuthorizationRequest do
       it { is_expected.to eq(%w[old_scope1 old_scope2]) }
     end
   end
+
+  describe 'scopes config behaviour' do
+    describe '#available_scopes' do
+      subject(:available_scopes) { authorization_request.available_scopes }
+
+      context 'without config' do
+        let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+
+        it { expect(available_scopes.map(&:value)).to match_array(authorization_request.definition.scopes.map(&:value)) }
+      end
+
+      context 'with displayed config on form' do
+        let(:authorization_request) { create(:authorization_request, :api_particulier_abelium) }
+
+        it { expect(available_scopes.map(&:value)).to match_array(%w[cnaf_quotient_familial cnaf_allocataires cnaf_enfants cnaf_adresse]) }
+      end
+    end
+
+    describe '#disabled_scopes' do
+      subject(:disabled_scopes) { authorization_request.disabled_scopes }
+
+      context 'without config' do
+        let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'with disabled scopes config on form' do
+        let(:authorization_request) { create(:authorization_request, :api_particulier_abelium) }
+
+        it { expect(disabled_scopes.map(&:value)).to contain_exactly('cnaf_quotient_familial') }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Introduce 2 new behaviours on forms:

1. Ability to hide within form some scopes: for specific use case no
   need to displays all of them
2. Ability to disabled checkbox: this value is set by the form data
   default, and applicant can't change it

   This is different from included scopes from definition, it depends
   on the form here