### PR TITLE
Harden CreateAuthorizationRequestChangelog by using attr reader instead of raw data key

### DIFF
--- a/app/interactors/create_authorization_request_changelog.rb
+++ b/app/interactors/create_authorization_request_changelog.rb
@@ -34,9 +34,13 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
   end
 
   def reified_data
-    @reified_data ||= latest_changelog.diff.each_with_object(authorization_request.data.dup) do |(key, value), latest_data|
+    @reified_data ||= latest_changelog.diff.each_with_object(authorization_request_data) do |(key, value), latest_data|
       latest_data[key] = value[1]
     end
+  end
+
+  def authorization_request_data
+    @authorization_request_data ||= authorization_request.data.to_h { |k, _| [k, authorization_request.public_send(k)] }
   end
 
   def initial_diff_with_prefilled_form


### PR DESCRIPTION
Closes https://errors.data.gouv.fr/organizations/sentry/issues/140124/

Before this version, we used to compare, for a key `k`, `authorization_request.send(k)` and `authorization_request.data[k]`.

Because of some override, for example `scopes`, we used to create diff which are not relevant, and because of the difference on `scopes` between the reader (which renders an array) and the `data` (which is a string), our changelog builder raised the issue reported at the beginning of this commit. We used to store the following within `diff`:

```
{
  "scope": ["['scope1', 'scope2']", ['scope1', 'scope2']]
}
```

This commit introduces a normalisation, and build a proper changelog to display.