### PR TITLE
Introduce proper reopen from external controller

### DIFF
--- a/app/controllers/external_reopen_authorization_requests_controller.rb
+++ b/app/controllers/external_reopen_authorization_requests_controller.rb
@@ -1,0 +1,37 @@
+class ExternalReopenAuthorizationRequestsController < AuthenticatedUserController
+  before_action :extract_authorization
+  before_action :authorize_authorization_reopening
+
+  def create
+    success_message(title: t('reopen_authorizations.create.success.title', name: @authorization.authorization_request.name)) if reopen_authorization.success?
+
+    redirect_to summary_path
+  end
+
+  private
+
+  def reopen_authorization
+    ReopenAuthorization.call(
+      authorization: @authorization,
+      user: current_user,
+    )
+  end
+
+  def summary_path
+    summary_authorization_request_form_path(
+      form_uid: @authorization_request.form.uid,
+      id: @authorization_request.id,
+    )
+  end
+
+  def extract_authorization
+    @authorization_request = AuthorizationRequest.find(params[:id])
+    @authorization = @authorization_request.latest_authorization
+  end
+
+  def authorize_authorization_reopening
+    authorize @authorization, :reopen?
+  rescue Pundit::NotAuthorizedError, Pundit::NotDefinedError
+    redirect_to summary_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,9 +42,10 @@ Rails.application.routes.draw do
       resources :authorization_request_from_templates, only: %i[index create], path: 'templates'
     end
 
+    get 'demandes/:id/reopen-from-external', to: 'external_reopen_authorization_requests#create'
+
     resources :authorizations, only: %i[show], path: 'habilitations' do
       resources :reopen_authorizations, only: %w[new create], path: 'réouvrir', as: :reopen
-      get 'reopen-from-external', to: 'reopen_authorizations#create', as: :reopen_from_external
     end
   end
 

--- a/spec/controllers/external_reopen_authorization_requests_controller_spec.rb
+++ b/spec/controllers/external_reopen_authorization_requests_controller_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe ExternalReopenAuthorizationRequestsController do
+  describe 'GET #create' do
+    subject(:reopen_from_external) { get :create, params: { id: authorization_request.id } }
+
+    let(:user) { create(:user) }
+
+    before do
+      session[:user_id] = {
+        'value' => user.id,
+        'expires_at' => 1.hour.from_now,
+      }
+    end
+
+    context 'when the authorization request is not validated' do
+      let(:authorization_request) { create(:authorization_request, applicant: user) }
+
+      it 'does not reopen the authorization request' do
+        expect { reopen_from_external }.not_to change { authorization_request.reload.state }
+      end
+
+      it 'redirects to the authorization summary request page' do
+        reopen_from_external
+
+        expect(response).to redirect_to(summary_authorization_request_form_path(id: authorization_request.id, form_uid: authorization_request.form.uid))
+      end
+    end
+
+    context 'when the authorization request is validated' do
+      let(:authorization_request) { create(:authorization_request, :validated, applicant: user) }
+
+      it 'reopens the authorization request' do
+        expect { reopen_from_external }.to change { authorization_request.reload.state }.from('validated').to('draft')
+      end
+
+      it 'redirects to the authorization summary request page' do
+        reopen_from_external
+
+        expect(response).to redirect_to(summary_authorization_request_form_path(id: authorization_request.id, form_uid: authorization_request.form.uid))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previous version did not work because we don't have authorizations' ids Moreover, make it more flex by redirecting to authorization if exists, even if it's already reopened