### PR TITLE
Feature/dat 411 etq d si la modalite dappel formulaire de collecte du

### DIFF
--- a/app/assets/stylesheets/components/authorization-requests-legal.css
+++ b/app/assets/stylesheets/components/authorization-requests-legal.css
@@ -1,0 +1,42 @@
+.legal-border-card {
+    border: 1px solid var(--border-default-grey);
+    padding: 2rem 2rem 2rem 2rem;
+    margin-bottom: 2rem;
+}
+
+.legal-subtitle {
+    color: var(--text-action-high-blue-france);
+}
+
+.legal-bloc-space {
+    padding-top: 1.5rem;
+}
+
+.legal-text__bold {
+    font-weight: bold;
+}
+
+.legal-bloc-separation {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 15vh;
+}
+
+.legal-line {
+    flex: 1;
+    height: 1px;
+    background-color: var(--border-default-grey);
+}
+
+.legal-centered__element {
+    padding: 0 1.25rem;
+}
+
+.legal-centered__element p {
+    margin: 0;
+}
+
+.legal-input__width {
+    max-width: 50%;
+}

--- a/app/views/authorization_request_forms/shared/_legal.html.erb
+++ b/app/views/authorization_request_forms/shared/_legal.html.erb
@@ -1,17 +1,59 @@
 <%= f.info_for(:legal) %>
 
-<fieldset class="fr-fieldset" aria-label="feedme" aria-describedby="name-1-fieldset-messages">
-  <div class="fr-fieldset__element">
-    <%= f.dsfr_text_area :cadre_juridique_nature, rows: 2 %>
+<div class="legal-border-card">
+  <% if f.wording_for('subtitle', 'legal') %>
+    <p class="fr-h5 legal-subtitle">
+      <%= f.wording_for('subtitle', 'legal') %>
+    </p>
+  <% end %>
+  <% if f.wording_for('description', 'legal') %>
+    <p>
+      <%= f.wording_for('description', 'legal') %>
+    </p>
+  <% end %>
+
+  <fieldset class="fr-fieldset" aria-label="feedme" aria-describedby="name-1-fieldset-messages">
+    <div class="fr-fieldset__element fr-my-3w">
+      <%= f.dsfr_text_area :cadre_juridique_nature, rows: 5 %>
+    </div>
+  </fieldset>
+
+  <div class="legal-bloc-space">
+    <hr>
+    <p class="fr-mt-3w">
+      <span class="fr-text--lg legal-text__bold"><%= f.wording_for('justificatif.title', 'legal') %></span>
+      <br>
+      <%= f.wording_for('justificatif.description', 'legal') %>
+    </p>
+
+    <% if @authorization_request_form.uid.include?('api-particulier') %>
+      <p>
+        <span class="legal-text__bold"><%= f.wording_for('cadre_juridique_document.title', 'legal') %></span>
+        <br>
+        <span class="fr-mt-1w"><%= f.wording_for('cadre_juridique_document.description', 'legal').html_safe %></span>
+      </p>
+    <% end %>
   </div>
 
-  <div class="fr-fieldset__element">
-    <%= f.dsfr_file_field :cadre_juridique_document %>
+  <fieldset class="fr-fieldset fr-mt-4w" aria-label="feedme" aria-describedby="name-1-fieldset-messages">
+    <div class="fr-fieldset__element">
+      <%= f.dsfr_file_field :cadre_juridique_document %>
+    </div>
+  </fieldset>
+
+  <div class="legal-bloc-separation">
+    <div class="legal-line"></div>
+    <div class="legal-centered__element">
+      <p class="fr-h5">OU</p>
+    </div>
+    <div class="legal-line"></div>
   </div>
 
-  <h4>OU</h4>
+  <p class="legal-text__bold"><%= f.wording_for('cadre_juridique_url', 'legal') %></p>
 
-  <div class="fr-fieldset__element">
-    <%= f.dsfr_url_field :cadre_juridique_url %>
-  </div>
-</fieldset>
+  <fieldset class="fr-fieldset" aria-label="feedme" aria-describedby="name-1-fieldset-messages">
+    <div class="fr-fieldset__element legal-input__width">
+      <%= f.dsfr_url_field :cadre_juridique_url %>
+    </div>
+  </fieldset>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -127,6 +127,8 @@ ignore_unused:
 - 'errors.messages.*'
 - 'validates_timeliness.error_value_formats.*'
 - 'authorization_request_forms.*.*.info.{title,content}'
+- 'authorization_request_forms.*.legal.justificatif.*'
+- 'authorization_request_forms.api_particulier.legal.cadre_juridique_document.*'
 - 'authorization_request_forms.*.modalities.values.*.label'
 - 'authorization_request_mailer.*.subject'
 - 'support.*'

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -9,6 +9,7 @@ fr:
         contacts: "Les personnes impliquées"
         modalities: "Les modalités d'accès"
         finish: "La synthèse"
+
       terms_of_service_accepted:
         label: J'ai pris connaissance des&nbsp;<a href="%{link}" target="_blank">conditions générales d'utilisation</a>&nbsp;et je les valide.
       intitule:
@@ -183,6 +184,14 @@ fr:
     api_entreprise_atexo: *api_entreprise_contacts_editeur
 
     api_particulier:
+      steps:
+        basic_infos: "Mon projet"
+        personal_data: "Le traitement des données"
+        legal: "Justification du traitement des données personnelles"
+        scopes: "Les données"
+        contacts: "Les personnes impliquées"
+        finish: "La synthèse"
+
       modalities:
         intro: "Vous pourrez accéder au service API Particulier via les modalités ci-dessous :"
         values:
@@ -190,6 +199,7 @@ fr:
             label: Via un jeton d'accès, accompagné des paramètres usagers.
           formulaire_qf:
             label: Via l'utilisation du formulaire national QF (Quotient Familial). Plus d'infos <a href="https://quotient-familial.numerique.gouv.fr/" target="_blank">ici</a>.
+
       scopes:
         info:
           content: |

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -4,7 +4,7 @@ fr:
       steps:
         basic_infos: "Mon projet"
         personal_data: "Le traitement des données"
-        legal: "Le cadre juridique"
+        legal: "Justification du traitement des données personnelles"
         scopes: "Les données"
         contacts: "Les personnes impliquées"
         modalities: "Les modalités d'accès"
@@ -21,12 +21,12 @@ fr:
       duree_conservation_donnees_caractere_personnel:
         hint: <a href="https://www.cnil.fr/fr/les-durees-de-conservation-des-donnees" target="_blank">Plus d'infos</a>
       cadre_juridique_nature:
-        label: Précisez la nature et les références du texte vous autorisant à traiter les données
+        label: Précisez la nature et les références du texte vous autorisant à traiter les données *
         hint: loi, décret, arrêté, délibération, etc.
       cadre_juridique_url:
         label: URL du texte relatif au traitement
       cadre_juridique_document:
-        label: Joindre le document lui-même
+        label: Ajoutez votre document
         hint: 'Taille maximale: 10 Mo. Formats supportés: pdf'
 
       contact_technique:
@@ -81,6 +81,10 @@ fr:
       legal:
         info:
           title: Comment trouver le cadre juridique ?
+        justificatif:
+          title: Les justificatifs de votre cadre juridique *
+          description: Vous pouvez choisir d'indiquer une URL ou d'ajouter un fichier
+        cadre_juridique_url: Veuillez nous indiquer l'url du texte relatif au traitement des données personnelles
 
       scopes:
         info:
@@ -192,6 +196,11 @@ fr:
         contacts: "Les personnes impliquées"
         finish: "La synthèse"
 
+      cadre_juridique_nature:
+        label: Précisez la nature et les références du texte vous autorisant à traiter les données *
+      cadre_juridique_document:
+        label: Ajoutez votre délibération
+
       modalities:
         intro: "Vous pourrez accéder au service API Particulier via les modalités ci-dessous :"
         values:
@@ -204,7 +213,13 @@ fr:
         info:
           content: |
             L'API Particulier vous donne accès à <a href="https://particulier.api.gouv.fr/catalogue" target="_blank">plusieurs API</a>. Chaque API transmet <strong>différentes données, regroupées dans des périmètres distincts</strong>. En effet, afin de respecter les principes de collecte, traitement et conservation de données définit par <a href="https://www.cnil.fr/fr/la-loi-informatique-et-libertes#article4" target="_blank">l'article 4 de la loi informatique et libertés</a>, vous devez sélectionner uniquement les données strictement nécessaires à votre téléservice. Le non-respect du principe de proportionnalité vous expose vis-à-vis de la CNIL. <strong>Chaque périmètre est formalisé par une case à cocher dans ce formulaire</strong>.
+
       legal:
+        subtitle: Pour les données CNAF
+        description: Vous souhaitez accéder, traiter et conserver des données personnelles. Quel est le cadre juridique qui autorise votre organisation à accéder à ces données ?
+        cadre_juridique_document:
+          title: Veuillez joindre la délibération du conseil municipal explicitant l'usage des données demandées.
+          description: Pour en savoir plus, consultez <a href="https://api.gouv.fr/guides/deliberation-api-part" target="_blank">notre guide sur ce qu’est une bonne délibération.</a>
         info:
           content: |
             <p>


### PR DESCRIPTION
Work on view for Deliberation view : 

So far: 

![screencapture-localhost-3000-formulaires-api-particulier-arpege-concerto-demande-126-etapes-cadre-juridique-2024-06-26-17_01_20](https://github.com/etalab/data_pass/assets/43042737/59d34fc4-52a4-4d32-af80-ba1aa105692f)

- [ ] Encore besoin de revoir les wordings 
- [x] Gérer le bug d'affichage lorsque l'on est sur les autres formulaire d'api 
`undefined method html_safe' for nil`   `<%= f.wording_for('deliberation_link', 'legal').html_safe %>` 
- [x] Dans le formulaire, le champ "précisez la nature et les références …" sera affiché pré-rempli et désactivé => reporté dans le [ticket 437](https://linear.app/pole-api/issue/DAT-437/etq-d-si-je-souhaite-modifier-les-informations-du-cadre-juridique)
- [x]  Fixer les tests 
- [x] Clean les commits 
- [ ] Review 