### PR TITLE
    Dynamically set host from mailer params

### DIFF
--- a/app/models/subdomain.rb
+++ b/app/models/subdomain.rb
@@ -24,6 +24,12 @@ class Subdomain < StaticApplicationRecord
     )
   end
 
+  def self.find_for_authorization_request(authorization_request)
+    all.find do |subdomain|
+      subdomain.authorization_definitions.map(&:id).include?(authorization_request.definition.id)
+    end
+  end
+
   def authorization_request_types
     authorization_definitions.map(&:authorization_request_class).flatten.uniq.map(&:to_s)
   end

--- a/spec/models/subdomain_spec.rb
+++ b/spec/models/subdomain_spec.rb
@@ -5,4 +5,24 @@ RSpec.describe Subdomain do
       expect(described_class.all.map(&:authorization_definitions)).to be_all(&:present?)
     end
   end
+
+  describe '.find_for_authorization_request' do
+    subject(:subdomain) { described_class.find_for_authorization_request(authorization_request) }
+
+    context 'when authorization request is linked to a subdomain' do
+      let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+
+      it 'returns the subdomain linked to the authorization request' do
+        expect(subdomain.id).to eq(described_class.find('api-entreprise').id)
+      end
+    end
+
+    context 'when authorization request is not linked to a subdomain' do
+      let(:authorization_request) { create(:authorization_request, :hubee_cert_dc) }
+
+      it 'returns nil' do
+        expect(subdomain).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because of the introduction of API Particulier with a subdomain we have to
set host dynamically. Thanks to subdomains config model we can fetch the
url with the link between authorization requests and subdomains.

This is a temporary solution, it won't work (well?) with authorization
requests linked to multiple subdomains.

Moreover when the migration from v1 will be over, perhaps we will set
the main domain ? (TBD)

Closes https://linear.app/pole-api/issue/DAT-438