### PR TITLE
Harden authorization creation for multiple steps form on invalid data

### DIFF
--- a/app/interactors/create_authorization_request_model.rb
+++ b/app/interactors/create_authorization_request_model.rb
@@ -1,6 +1,6 @@
 class CreateAuthorizationRequestModel < ApplicationInteractor
   def call
-    context.authorization_request = authorization_request_class.create(authorization_request_create_params)
+    context.authorization_request.assign_attributes(authorization_request_create_params)
   end
 
   private

--- a/app/organizers/create_authorization_request.rb
+++ b/app/organizers/create_authorization_request.rb
@@ -2,12 +2,13 @@ class CreateAuthorizationRequest < ApplicationOrganizer
   before do
     context.authorization_request_params ||= ActionController::Parameters.new
     context.event_name = 'create'
+    context.authorization_request = context.authorization_request_form.authorization_request_class.new
   end
 
-  organize CreateAuthorizationRequestModel,
-    AssignDefaultDataToAuthorizationRequest,
-    CreateAuthorizationRequestEventModel,
+  organize AssignDefaultDataToAuthorizationRequest,
+    CreateAuthorizationRequestModel,
     AssignParamsToAuthorizationRequest,
+    CreateAuthorizationRequestEventModel,
     DeliverAuthorizationRequestWebhook
 
   after do

--- a/spec/features/authorization_requests/create_spec.rb
+++ b/spec/features/authorization_requests/create_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe 'Starting a new authorization request' do
   it 'does not create a new authorization request (no longer persisted when starting)' do
     expect { subject }.not_to change(AuthorizationRequest, :count)
   end
+
+  describe 'tries to create an invalid authorization request (non-regression test)' do
+    let(:authorization_request_form) { AuthorizationRequestForm.find('api-entreprise') }
+
+    it 'does not create a new authorization request' do
+      subject
+
+      expect {
+        click_on 'Suivant'
+      }.not_to change(AuthorizationRequest, :count)
+    end
+  end
 end


### PR DESCRIPTION
Without this fix our model used to be persisted on the CreateAuthorizationRequest organizer, thanks to
CreateAuthorizationRequestModel interactor, but it fail later in the process.