### PR TITLE
replace shadows by borders for .summary-block and .scopes-group

### DIFF
--- a/app/assets/stylesheets/components/authorization-requests-scopes.css
+++ b/app/assets/stylesheets/components/authorization-requests-scopes.css
@@ -1,6 +1,6 @@
 .scopes-group {
   padding: 20px 20px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  border: 1px solid #00000033;
   border-radius: 5px;
   margin-bottom: 20px;
 }

--- a/app/assets/stylesheets/components/summary_block.css
+++ b/app/assets/stylesheets/components/summary_block.css
@@ -7,7 +7,7 @@
   position: relative;
   background-color: #fff;
   border-radius: 0px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  border: 1px solid #00000033;
   padding: var(--summary-block--padding-y) var(--summary-block--padding-x);
 
   margin-bottom: 50px;


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/DAT-366/habilitation-validee-refusee-retirer-les-ombres-sous-les-blocs