### PR TITLE
Feat/dat 390 remove scope shadow bloc

### DIFF
--- a/app/assets/stylesheets/components/authorization-requests-scopes.css
+++ b/app/assets/stylesheets/components/authorization-requests-scopes.css
@@ -13,12 +13,13 @@
 
 .scopes-group__grid {
   font-size: 1em;
+  padding: 1rem 0.5rem;
   display: grid;
 
-  --column-gap: 1.5em;
-  --row-gap: 2.0em;
+  --column-gap: 9rem;
+  --row-gap: 2rem;
 
-  grid-template-columns: repeat(3,1fr);
+  grid-template-columns: repeat(2, 1fr);
 
   grid-column-gap: var(--column-gap);
   -webkit-column-gap: var(--column-gap);

--- a/app/assets/stylesheets/components/authorization-requests-scopes.css
+++ b/app/assets/stylesheets/components/authorization-requests-scopes.css
@@ -1,7 +1,6 @@
 .scopes-group {
-  padding: 20px 20px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-  border-radius: 5px;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border-default-grey);
   margin-bottom: 20px;
 }
 

--- a/app/assets/stylesheets/components/authorization-requests-scopes.css
+++ b/app/assets/stylesheets/components/authorization-requests-scopes.css
@@ -6,7 +6,9 @@
 
 .scopes-group__title {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding-bottom: 8px;
+  padding: 0.75rem 0;
+  color: var(--text-action-high-blue-france);
+  font-weight: bold;
 }
 
 .scopes-group__grid {

--- a/app/assets/stylesheets/components/summary_block.css
+++ b/app/assets/stylesheets/components/summary_block.css
@@ -7,7 +7,7 @@
   position: relative;
   background-color: #fff;
   border-radius: 0px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--border-default-grey);
   padding: var(--summary-block--padding-y) var(--summary-block--padding-x);
 
   margin-bottom: 50px;

--- a/app/views/authorization_request_forms/shared/_scopes.html.erb
+++ b/app/views/authorization_request_forms/shared/_scopes.html.erb
@@ -14,9 +14,9 @@
       </div>
     <% end %>
 
-    <h5 class="scopes-group__title">
+    <p class="scopes-group__title fr-text--lg">
       <%= group_name %>
-    </h5>
+    </p>
 
     <div class="scopes-group__grid">
       <% scopes.each do |scope| %>


### PR DESCRIPTION
![screencapture-localhost-3000-habilitations-19-2024-07-15-14_59_14](https://github.com/user-attachments/assets/5437b1c8-33fb-4b07-bebb-ca23c47a9a07)

Closes https://linear.app/pole-api/issue/DAT-366/habilitation-validee-refusee-retirer-les-ombres-sous-les-blocs
Closes https://linear.app/pole-api/issue/DAT-449/revoir-le-formalisme-du-bloc-donnee