### PR TITLE
AuthorizationDefinition#editors: sort by name

### DIFF
--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -21,7 +21,7 @@ class AuthorizationDefinition < StaticApplicationRecord
   def editors
     available_forms.select { |form|
       form.editor.present?
-    }.map(&:editor).uniq(&:id)
+    }.map(&:editor).uniq(&:id).sort_by(&:name)
   end
 
   def self.indexable


### PR DESCRIPTION
Better display on decision tree: easier to find entry when it is in a natural order