### PR TITLE
Prevent message bubble superposition with the sticky bar

### DIFF
--- a/app/assets/stylesheets/components/messages-bubble.css
+++ b/app/assets/stylesheets/components/messages-bubble.css
@@ -1,7 +1,7 @@
 .message-bubble-cta {
   position: fixed;
-  bottom: 10px;
-  right: 50px;
+  bottom: 82px;
+  right: 1.5rem;
 
   padding: 20px;
   border: 1px solid var(--text-action-high-blue-france);
@@ -12,6 +12,12 @@
   z-index: 1000;
   border-radius: 50%;
   background-image: none;
+}
+@media (min-width: 1430px) {
+  .message-bubble-cta {
+    bottom: 39px;
+    right: 39px;
+  }
 }
 
 .message-bubble-cta:hover {

--- a/app/assets/stylesheets/components/messages-bubble.css
+++ b/app/assets/stylesheets/components/messages-bubble.css
@@ -11,7 +11,7 @@
   cursor: pointer;
   z-index: 1000;
   border-radius: 50%;
-  text-decoration: none;
+  background-image: none;
 }
 
 .message-bubble-cta:hover {


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/DAT-498/eviter-la-superposition-avec-la-bulle-de-messagerie

J'ai fait en sorte de garder le design de "bulle de chat" bien connu, en la positionnant à cheval pile à moitié sur la sticky bar pour les grandes fenêtres, et en la faisant remonter un peu au dessus de la barre dès qu'elle va se superposer avec le bouton.

Demo :

![Peek 2024-07-26 18-18](https://github.com/user-attachments/assets/85d81485-d06c-4fde-a962-f4422b35c228)

J'trouve ça pas trop moche comme ça. T'en dis quoi @evaspae ?