### PR TITLE
CreateAuthorizationRequestChangelog no longer tries to build diff with old attributes

### DIFF
--- a/app/interactors/create_authorization_request_changelog.rb
+++ b/app/interactors/create_authorization_request_changelog.rb
@@ -18,6 +18,7 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
   def create_changelog_with_diff
     create_changelog(
       reified_data.each_with_object({}) do |(key, old_value), diff|
+        next unless authorization_request.respond_to?(key)
         next if authorization_request.public_send(key) == old_value
 
         diff[key] = [old_value, authorization_request.public_send(key)]

--- a/spec/organizers/submit_authorization_request_spec.rb
+++ b/spec/organizers/submit_authorization_request_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe SubmitAuthorizationRequest do
             end
 
             describe 'when it is not the first submit and there is a changelog' do
-              before do
+              let!(:previous_authorization_request_changelog) do
                 create(:authorization_request_changelog, authorization_request:)
               end
 
@@ -115,6 +115,16 @@ RSpec.describe SubmitAuthorizationRequest do
                   initial_scopes,
                   initial_scopes + %w[scope1 scope2]
                 ])
+              end
+
+              context 'when changelog has attributes no longer present on the model' do
+                let!(:previous_authorization_request_changelog) do
+                  create(:authorization_request_changelog, authorization_request:, diff: { 'old_attribute' => [nil, 'whatever'] })
+                end
+
+                it 'does not raise an error by ignoring attribute within diff building' do
+                  expect { submit_authorization_request }.not_to raise_error
+                end
               end
             end
           end


### PR DESCRIPTION
Some old authorization requests can have old attributes no longer available versions. In that case some changelogs can have these attributes, which leads to a NoMethodError withint this class.

No need to build a diff with a deprecated value, it can be ignored.

Closes https://errors.data.gouv.fr/organizations/sentry/issues/143791/