### PR TITLE
Can whitelist emails for VerifiedEmail

### DIFF
--- a/app/jobs/email_verifier_job.rb
+++ b/app/jobs/email_verifier_job.rb
@@ -11,6 +11,8 @@ class EmailVerifierJob < ApplicationJob
     return if verified_email.invalid?
 
     mark_email_as_safe!(verified_email) if user_exists_with_email?
+
+    return if verified_email.whitelisted?
     return if verified_email.recent? && verified_email.determined?
     return if email_verifier_status == 'unknown'
 

--- a/app/models/verified_email.rb
+++ b/app/models/verified_email.rb
@@ -1,9 +1,9 @@
 class VerifiedEmail < ApplicationRecord
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :status, presence: true, inclusion: { in: %w[unknown deliverable undeliverable risky] }
+  validates :status, presence: true, inclusion: { in: %w[unknown deliverable undeliverable risky whitelisted] }
 
   def reacheable?
-    %w[deliverable risky].include?(status)
+    %w[deliverable risky whitelisted].include?(status)
   end
 
   def unreachable?
@@ -12,6 +12,10 @@ class VerifiedEmail < ApplicationRecord
 
   def unknown?
     status == 'unknown'
+  end
+
+  def whitelisted?
+    status == 'whitelisted'
   end
 
   def determined?

--- a/spec/jobs/email_verifier_job_spec.rb
+++ b/spec/jobs/email_verifier_job_spec.rb
@@ -44,6 +44,20 @@ RSpec.describe EmailVerifierJob do
         expect { verify_email }.not_to change(VerifiedEmail, :count)
       end
 
+      context 'when the email is whitelisted and verified more than 30 days ago' do
+        let!(:verified_email) { create(:verified_email, email:, status: 'whitelisted', verified_at: 31.days.ago) }
+
+        it 'does not call the email verifier API' do
+          verify_email
+
+          expect(EmailVerifierAPI).not_to have_received(:new)
+        end
+
+        it 'does not update model' do
+          expect { verified_email }.not_to change(verified_email, :updated_at)
+        end
+      end
+
       context 'when the email is already verified and deliverable' do
         let!(:verified_email) { create(:verified_email, email:, status: 'deliverable', verified_at:) }
 

--- a/spec/validators/email_recently_verified_validator_spec.rb
+++ b/spec/validators/email_recently_verified_validator_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe EmailRecentlyVerifiedValidator do
         expect(email_verifier_job).to have_received(:perform)
       end
     end
+
+    context 'when the email is whitelisted and was verified more than 1 month ago' do
+      let(:status) { :whitelisted }
+      let(:verified_at) { 3.months.ago }
+
+      it { is_expected.to be_valid }
+
+      it 'calls EmailVerifierJob' do
+        subject.valid?
+
+        expect(email_verifier_job).to have_received(:perform)
+      end
+    end
   end
 
   context 'when there is no verified email' do


### PR DESCRIPTION
When there is an unknown status, users sent email to support -> we should be able to whiteliste and not mark as validated, which expires after 30 days.

Ref https://app-eu1.hubspot.com/live-messages/143503609/inbox/4370534633