### PR TITLE
Harden CreateAuthorizationRequestChangelog

### DIFF
--- a/app/interactors/create_authorization_request_changelog.rb
+++ b/app/interactors/create_authorization_request_changelog.rb
@@ -19,9 +19,9 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
     create_changelog(
       reified_data.each_with_object({}) do |(key, old_value), diff|
         next unless authorization_request.respond_to?(key)
-        next if authorization_request.public_send(key) == old_value
+        next if authorization_request_value_for_diff(key) == old_value
 
-        diff[key] = [old_value, authorization_request.public_send(key)]
+        diff[key] = [old_value, authorization_request_value_for_diff(key)]
       end
     )
   end
@@ -40,14 +40,10 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
     end
   end
 
-  def authorization_request_data
-    @authorization_request_data ||= authorization_request.data.to_h { |k, _| [k, authorization_request.public_send(k)] }
-  end
-
   def initial_diff_with_prefilled_form
-    authorization_request.data.to_h do |attribute, _|
+    authorization_request_data_keys.to_h do |attribute|
       default_value = authorization_request.form.data[attribute.to_sym]
-      actual_value = authorization_request.public_send(attribute)
+      actual_value = authorization_request_value_for_diff(attribute)
 
       if data_changed_between_prefilling_and_submit?(default_value, actual_value)
         [attribute, [default_value, actual_value]]
@@ -62,7 +58,15 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
   end
 
   def initial_diff_without_prefilled_form
-    authorization_request.data.to_h { |k, _| [k, [nil, authorization_request.public_send(k)]] }
+    authorization_request_data_keys.index_with { |k| [nil, authorization_request_value_for_diff(k)] }
+  end
+
+  def authorization_request_value_for_diff(key)
+    if authorization_request.class.documents.include?(key.to_sym)
+      authorization_request.public_send(key).filename
+    else
+      authorization_request.public_send(key)
+    end
   end
 
   def latest_changelog
@@ -71,8 +75,41 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
 
   def create_changelog(diff)
     context.changelog = authorization_request.changelogs.create!(
-      diff:
+      diff: diff.reject { |_, value| value[0].blank? && value[1].blank? }
     )
+  end
+
+  def authorization_request_data
+    @authorization_request_data ||= authorization_request_data_keys.index_with { |k| authorization_request_value_for_diff(k) }
+  end
+
+  def authorization_request_data_keys
+    authorization_request_data_extra_attributes_keys +
+      authorization_request_data_documents_keys +
+      authorization_request_data_contact_attributes_keys +
+      authorization_request_data_scopes_key
+  end
+
+  def authorization_request_data_extra_attributes_keys
+    authorization_request.class.extra_attributes.map(&:to_s)
+  end
+
+  def authorization_request_data_documents_keys
+    authorization_request.class.documents.map(&:to_s)
+  end
+
+  def authorization_request_data_contact_attributes_keys
+    authorization_request.class.contact_types.map { |contact_type|
+      authorization_request.class.contact_attributes.map { |attribute| "#{contact_type}_#{attribute}" }
+    }.flatten
+  end
+
+  def authorization_request_data_scopes_key
+    if authorization_request.class.scopes_enabled?
+      ['scopes']
+    else
+      []
+    end
   end
 
   def authorization_request

--- a/spec/organizers/submit_authorization_request_spec.rb
+++ b/spec/organizers/submit_authorization_request_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe SubmitAuthorizationRequest do
                 )
 
                 expect(changelog.diff.except('intitule', 'scopes')).to eq(
-                  authorization_request.data.except('intitule', 'scopes').to_h { |k, _| [k, [nil, authorization_request.public_send(k)]] }
+                  authorization_request.data.except('intitule', 'scopes', 'contact_metier_type', 'contact_technique_type').to_h { |k, _| [k, [nil, authorization_request.public_send(k)]] }
                 )
               end
             end
@@ -75,6 +75,22 @@ RSpec.describe SubmitAuthorizationRequest do
               expect(changelog.diff).to eq({
                 'intitule' => [old_intitule, 'new intitule']
               })
+            end
+          end
+
+          describe 'with document change' do
+            let(:authorization_request_params) do
+              ActionController::Parameters.new(
+                intitule: 'new intitule',
+                cadre_juridique_document: Rack::Test::UploadedFile.new('spec/fixtures/another_dummy.pdf')
+              )
+            end
+
+            it 'stores only the name of the document' do
+              submit_authorization_request
+              changelog = authorization_request.changelogs.last
+
+              expect(changelog.diff['cadre_juridique_document']).to eq([nil, 'another_dummy.pdf'])
             end
           end
 


### PR DESCRIPTION
Handles all attributes for a specific authorization request, thanks to `extra_attributes`, `documents`, `contact_types` and `scopes`.

Thanks to these methods we can exactly build data (keys and attributes) manipulated on this authorization request. Previous version did not handle documents.

Moreover, we don't want to store all the ActiveStorage model, so we can override the value thanks to `authorization_request_value_for_diff`