### PR TITLE
Enhance bridges : async and revoke event

### DIFF
--- a/app/bridges/application_bridge.rb
+++ b/app/bridges/application_bridge.rb
@@ -1,6 +1,8 @@
 class ApplicationBridge < ApplicationJob
   attr_reader :authorization_request
 
+  retry_on(StandardError, wait: :polynomially_longer, attempts: :unlimited)
+
   def perform(authorization_request, event)
     @authorization_request = authorization_request
     send(:"on_#{event}")

--- a/app/bridges/application_bridge.rb
+++ b/app/bridges/application_bridge.rb
@@ -1,11 +1,7 @@
-class ApplicationBridge
+class ApplicationBridge < ApplicationJob
   attr_reader :authorization_request
 
-  def initialize(authorization_request)
-    @authorization_request = authorization_request
-  end
-
-  def perform
+  def perform(_authorization_request)
     fail ::NotImplementedError
   end
 end

--- a/app/bridges/application_bridge.rb
+++ b/app/bridges/application_bridge.rb
@@ -1,7 +1,14 @@
 class ApplicationBridge < ApplicationJob
   attr_reader :authorization_request
 
-  def perform(_authorization_request)
+  def perform(authorization_request, event)
+    @authorization_request = authorization_request
+    send(:"on_#{event}")
+  end
+
+  def on_approve
     fail ::NotImplementedError
   end
+
+  def on_revoke; end
 end

--- a/app/bridges/application_bridge.rb
+++ b/app/bridges/application_bridge.rb
@@ -1,4 +1,8 @@
 class ApplicationBridge < ApplicationJob
+  include KeepTrackOfJobAttempts
+
+  THRESHOLD_TO_TRACK_ERROR = 5
+
   attr_reader :authorization_request
 
   retry_on(StandardError, wait: :polynomially_longer, attempts: :unlimited)
@@ -6,6 +10,9 @@ class ApplicationBridge < ApplicationJob
   def perform(authorization_request, event)
     @authorization_request = authorization_request
     send(:"on_#{event}")
+  rescue StandardError => e
+    track_error(e) if attempts == THRESHOLD_TO_TRACK_ERROR
+    raise
   end
 
   def on_approve
@@ -13,4 +20,16 @@ class ApplicationBridge < ApplicationJob
   end
 
   def on_revoke; end
+
+  def track_error(exception)
+    Sentry.add_breadcrumb(
+      Sentry::Breadcrumb.new(
+        data: { authorization_request_id: authorization_request.id },
+        message: "Error on #{self.class.name} with authorization_request_id: #{authorization_request.id}",
+        category: 'error',
+      )
+    )
+
+    Sentry.capture_exception(exception)
+  end
 end

--- a/app/bridges/hubee_cert_dc_bridge.rb
+++ b/app/bridges/hubee_cert_dc_bridge.rb
@@ -1,7 +1,5 @@
 class HubEECertDCBridge < ApplicationBridge
-  def perform(authorization_request)
-    @authorization_request = authorization_request
-
+  def on_approve
     organization_hubee_payload = find_or_create_organization
 
     create_and_store_subscription(organization_hubee_payload)

--- a/app/bridges/hubee_cert_dc_bridge.rb
+++ b/app/bridges/hubee_cert_dc_bridge.rb
@@ -1,5 +1,7 @@
 class HubEECertDCBridge < ApplicationBridge
-  def perform
+  def perform(authorization_request)
+    @authorization_request = authorization_request
+
     organization_hubee_payload = find_or_create_organization
 
     create_and_store_subscription(organization_hubee_payload)

--- a/app/bridges/hubee_cert_dc_bridge.rb
+++ b/app/bridges/hubee_cert_dc_bridge.rb
@@ -1,25 +1,24 @@
 class HubEECertDCBridge < ApplicationBridge
   def perform
-    organization = find_or_create_organization(authorization_request)
+    organization_hubee_payload = find_or_create_organization
 
-    create_and_store_subscription(authorization_request, organization)
+    create_and_store_subscription(organization_hubee_payload)
   end
 
   private
 
-  def find_or_create_organization(authorization_request)
+  def find_or_create_organization
     hubee_api_client.get_organization(organization.siret, organization.code_commune)
   rescue Faraday::ResourceNotFound
-    organization_payload = organization_body(organization, authorization_request)
-    hubee_api_client.create_organization(organization_payload)
+    hubee_api_client.create_organization(organization_create_payload)
   end
 
-  def create_and_store_subscription(authorization_request, organization)
-    subscription_payload = hubee_api_client.create_subscription(subscription_body(authorization_request, organization, process_code))
-    authorization_request.update!(linked_token_manager_id: subscription_payload['id'])
+  def create_and_store_subscription(organization_hubee_payload)
+    subscription_hubee_payload = hubee_api_client.create_subscription(subscription_body(organization_hubee_payload, process_code))
+    authorization_request.update!(linked_token_manager_id: subscription_hubee_payload['id'])
   end
 
-  def organization_body(organization, authorization_request)
+  def organization_create_payload
     {
       type: 'SI',
       companyRegister: organization.siret,
@@ -35,14 +34,14 @@ class HubEECertDCBridge < ApplicationBridge
     }
   end
 
-  def subscription_body(authorization_request, organization, process_code)
+  def subscription_body(organization_hubee_payload, process_code)
     {
       datapassId: authorization_request.id,
       processCode: process_code,
       subscriber: {
-        type: organization[:type],
-        companyRegister: organization[:companyRegister],
-        branchCode: organization[:branchCode],
+        type: organization_hubee_payload[:type],
+        companyRegister: organization_hubee_payload[:companyRegister],
+        branchCode: organization_hubee_payload[:branchCode],
       },
       notificationFrequency: 'unitaire',
       validateDateTime: authorization_request.last_validated_at.iso8601,

--- a/app/interactors/execute_authorization_request_bridge.rb
+++ b/app/interactors/execute_authorization_request_bridge.rb
@@ -2,7 +2,7 @@ class ExecuteAuthorizationRequestBridge < ApplicationInteractor
   def call
     return unless bridge_exists?
 
-    bridge.new(context.authorization_request).perform
+    bridge.perform_later(context.authorization_request)
   end
 
   private

--- a/app/interactors/execute_authorization_request_bridge.rb
+++ b/app/interactors/execute_authorization_request_bridge.rb
@@ -2,7 +2,7 @@ class ExecuteAuthorizationRequestBridge < ApplicationInteractor
   def call
     return unless bridge_exists?
 
-    bridge.perform_later(context.authorization_request)
+    bridge.perform_later(context.authorization_request, context.state_machine_event)
   end
 
   private

--- a/app/jobs/concerns/keep_track_of_job_attempts.rb
+++ b/app/jobs/concerns/keep_track_of_job_attempts.rb
@@ -1,0 +1,16 @@
+module KeepTrackOfJobAttempts
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :attempts
+  end
+
+  def serialize
+    super.merge('tries_count' => (@attempts || 1) + 1)
+  end
+
+  def deserialize(job_data)
+    super
+    @attempts = job_data['tries_count']
+  end
+end

--- a/app/mailers/authorization_request_mailer.rb
+++ b/app/mailers/authorization_request_mailer.rb
@@ -1,6 +1,8 @@
 class AuthorizationRequestMailer < ApplicationMailer
   %i[approve refuse request_changes revoke].each do |event|
     [event, "reopening_#{event}"].each do |mth|
+      next if mth == 'reopening_revoke'
+
       define_method(mth) do
         @authorization_request = params[:authorization_request]
 

--- a/app/organizers/revoke_authorization_request.rb
+++ b/app/organizers/revoke_authorization_request.rb
@@ -5,5 +5,6 @@ class RevokeAuthorizationRequest < ApplicationOrganizer
   end
 
   organize CreateRevocationOfAuthorizationModel,
-    ExecuteAuthorizationRequestTransitionWithCallbacks
+    ExecuteAuthorizationRequestTransitionWithCallbacks,
+    ExecuteAuthorizationRequestBridge
 end

--- a/spec/bridges/application_bridge_spec.rb
+++ b/spec/bridges/application_bridge_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe ApplicationBridge, type: :job do
+  subject(:dummy_bridge) { job_instance.perform_now }
+
+  before(:all) do
+    class DummyBridge < ApplicationBridge
+      def on_approve; end
+    end
+  end
+
+  let(:job_instance) { DummyBridge.new(authorization_request, 'approve') }
+  let(:authorization_request) { create(:authorization_request) }
+
+  describe 'error tracking' do
+    before do
+      allow(job_instance).to receive(:on_approve).and_raise(StandardError)
+      allow(job_instance).to receive(:attempts).and_return(attempts)
+    end
+
+    describe 'when the attempt count has not reached the threshold yet' do
+      let(:attempts) { ApplicationBridge::THRESHOLD_TO_TRACK_ERROR - 1 }
+
+      it 'does not track the error' do
+        expect(Sentry).not_to receive(:capture_exception)
+
+        dummy_bridge
+      end
+    end
+
+    describe 'when the attempt count has reached the threshold' do
+      let(:attempts) { ApplicationBridge::THRESHOLD_TO_TRACK_ERROR }
+
+      it 'tracks the error' do
+        expect(Sentry).to receive(:capture_exception)
+
+        dummy_bridge
+      end
+    end
+  end
+end

--- a/spec/bridges/hubee_cert_dc_bridge_spec.rb
+++ b/spec/bridges/hubee_cert_dc_bridge_spec.rb
@@ -1,63 +1,39 @@
 RSpec.describe HubEECertDCBridge do
-  subject(:hubee_cert_dc_bridge) { described_class.new(authorization_request).perform }
-
-  let(:hubee_api_client) { instance_double(HubEEAPIClient) }
-
-  let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated, organization:) }
-  let(:organization) { create(:organization, siret: '21920023500014') }
-
-  let(:organization_payload) { build(:hubee_organization_payload, organization:, authorization_request:) }
-  let(:subscription_response) { build(:hubee_subscription_response_payload, :cert_dc) }
-
-  before do
-    allow(HubEEAPIClient).to receive(:new).and_return(hubee_api_client)
-    allow(hubee_api_client).to receive_messages(
-      get_organization: organization_payload.with_indifferent_access,
-      create_organization: organization_payload.with_indifferent_access,
-      create_subscription: subscription_response.with_indifferent_access
-    )
-  end
-
   describe '#perform' do
-    let(:bridge) { described_class.new(authorization_request) }
+    subject(:hubee_cert_dc_bridge) { described_class.new(authorization_request).perform }
+
+    let(:hubee_api_client) { instance_double(HubEEAPIClient) }
+
+    let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated, organization:) }
+    let(:organization) { create(:organization, siret: '21920023500014') }
+
+    let(:organization_payload) { build(:hubee_organization_payload, organization:, authorization_request:) }
+    let(:subscription_response) { build(:hubee_subscription_response_payload, :cert_dc, id: hubee_subscription_id) }
+    let(:hubee_subscription_id) { '1234567890' }
 
     before do
-      allow(bridge).to receive(:find_or_create_organization).and_call_original
+      allow(HubEEAPIClient).to receive(:new).and_return(hubee_api_client)
+      allow(hubee_api_client).to receive_messages(
+        create_organization: organization_payload.with_indifferent_access,
+        create_subscription: subscription_response.with_indifferent_access
+      )
     end
 
-    it 'does not render en error' do
-      expect { hubee_cert_dc_bridge }.not_to raise_error
-    end
+    context 'when organization exists on HubEE' do
+      before do
+        allow(hubee_api_client).to receive(:get_organization).and_return(organization_payload.with_indifferent_access)
+      end
 
-    it 'Finds or creates organization' do
-      expect(bridge).to receive(:find_or_create_organization)
-
-      bridge.perform
-    end
-
-    it 'Creates and store subscription id' do
-      expect(bridge).to receive(:create_and_store_subscription).with(organization_payload.with_indifferent_access)
-
-      bridge.perform
-    end
-  end
-
-  describe '#find_or_create_organization' do
-    context 'when organization exists' do
-      it 'gets the organization and return an organization payload' do
-        siret = authorization_request.organization.siret
-        code_commune = authorization_request.organization.code_commune
-
-        expect(hubee_api_client).to receive(:get_organization).with(siret, code_commune)
-
+      it 'does not create a new organization on HubEE' do
         hubee_cert_dc_bridge
+
+        expect(hubee_api_client).not_to have_received(:create_organization)
       end
     end
 
     context 'when organization does not exists' do
       before do
         allow(hubee_api_client).to receive(:get_organization).and_raise(Faraday::ResourceNotFound)
-        allow(hubee_api_client).to receive(:create_organization).with(organization_payload).and_return(organization_payload)
       end
 
       it 'calls create_organization' do
@@ -66,21 +42,28 @@ RSpec.describe HubEECertDCBridge do
         hubee_cert_dc_bridge
       end
     end
-  end
 
-  describe '#create_and_store_subscription' do
-    let(:subscription_payload) { build(:hubee_subscription_payload, :cert_dc, authorization_request:, organization:) }
+    describe 'subscription creation' do
+      before do
+        allow(hubee_api_client).to receive(:get_organization).and_return(organization_payload.with_indifferent_access)
+      end
 
-    it 'Creates a subscription to hubee and return a subscription_id' do
-      expect(hubee_api_client).to receive(:create_subscription).with(subscription_payload.deep_symbolize_keys)
+      it 'does create a subscription on HubEE linked to DataPass ID and CERTDC process code' do
+        expect(hubee_api_client).to receive(:create_subscription).with(
+          hash_including(
+            datapassId: authorization_request.id,
+            processCode: 'CERTDC'
+          )
+        )
 
-      hubee_cert_dc_bridge
-    end
+        hubee_cert_dc_bridge
+      end
 
-    it 'Updates the authorization request with the linked token manager id from subscription payload' do
-      hubee_cert_dc_bridge
+      it 'updates linked_token_manager_id to HubEE subscription ID' do
+        hubee_cert_dc_bridge
 
-      expect(authorization_request.reload.linked_token_manager_id).to eq('22')
+        expect(authorization_request.reload.linked_token_manager_id).to eq(hubee_subscription_id)
+      end
     end
   end
 end

--- a/spec/bridges/hubee_cert_dc_bridge_spec.rb
+++ b/spec/bridges/hubee_cert_dc_bridge_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe HubEECertDCBridge do
   describe '#perform' do
-    subject(:hubee_cert_dc_bridge) { described_class.new(authorization_request).perform }
+    subject(:hubee_cert_dc_bridge) { described_class.perform_now(authorization_request) }
 
     let(:hubee_api_client) { instance_double(HubEEAPIClient) }
 

--- a/spec/bridges/hubee_cert_dc_bridge_spec.rb
+++ b/spec/bridges/hubee_cert_dc_bridge_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe HubEECertDCBridge do
-  describe '#perform' do
-    subject(:hubee_cert_dc_bridge) { described_class.perform_now(authorization_request) }
+  describe '#perform on approve' do
+    subject(:hubee_cert_dc_bridge) { described_class.perform_now(authorization_request, 'approve') }
 
     let(:hubee_api_client) { instance_double(HubEEAPIClient) }
 

--- a/spec/bridges/hubee_cert_dc_bridge_spec.rb
+++ b/spec/bridges/hubee_cert_dc_bridge_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe HubEECertDCBridge do
     end
 
     it 'Finds or creates organization' do
-      expect(bridge).to receive(:find_or_create_organization).with(authorization_request)
+      expect(bridge).to receive(:find_or_create_organization)
 
       bridge.perform
     end
 
     it 'Creates and store subscription id' do
-      expect(bridge).to receive(:create_and_store_subscription).with(authorization_request, organization_payload.with_indifferent_access)
+      expect(bridge).to receive(:create_and_store_subscription).with(organization_payload.with_indifferent_access)
 
       bridge.perform
     end

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -126,7 +126,7 @@ FactoryBot.define do
       fill_all_attributes { true }
 
       after(:build) do |authorization_request|
-        authorization_request.denials << build(:denial_of_authorization, authorization_request:)
+        authorization_request.revocations << build(:revocation_of_authorization, authorization_request:)
       end
     end
 

--- a/spec/jobs/deliver_authorization_request_webhook_job_spec.rb
+++ b/spec/jobs/deliver_authorization_request_webhook_job_spec.rb
@@ -3,13 +3,7 @@ require 'rails_helper'
 RSpec.describe DeliverAuthorizationRequestWebhookJob do
   subject(:deliver_authorization_request_webhook) { job_instance.perform_now }
 
-  before do
-    ActiveJob::Base.queue_adapter = :inline
-  end
-
   after do
-    ActiveJob::Base.queue_adapter = :test
-
     Rails.application.credentials.webhooks.api_entreprise.url = nil
     Rails.application.credentials.webhooks.api_entreprise.token = nil
   end
@@ -125,14 +119,12 @@ RSpec.describe DeliverAuthorizationRequestWebhookJob do
           deliver_authorization_request_webhook
         end
 
-        context 'when last retry_on attempt fails' do
-          let(:tries_count) { described_class::TOTAL_ATTEMPTS }
+        context 'when we reach the threshold to notify data provider' do
+          let(:tries_count) { described_class::THRESHOLD_TO_NOTIFY_DATA_PROVIDER }
           let(:response) { instance_double(Faraday::Response, status:, body: 'body') }
 
           before do
-            allow(job_instance).to receive_messages(request: response, attempts: described_class::TOTAL_ATTEMPTS)
-
-            ActiveJob::Base.queue_adapter = :test
+            allow(job_instance).to receive_messages(request: response, attempts: described_class::THRESHOLD_TO_NOTIFY_DATA_PROVIDER)
           end
 
           it 'sends an email through WebhookMailer to instructors' do

--- a/spec/mailers/authorization_request_mailer_spec.rb
+++ b/spec/mailers/authorization_request_mailer_spec.rb
@@ -38,7 +38,25 @@ RSpec.describe AuthorizationRequestMailer do
     end
   end
 
-  describe '#request_changes' do
+  describe '#revoke' do
+    subject(:mail) do
+      described_class.with(
+        authorization_request:
+      ).revoke
+    end
+
+    let(:authorization_request) { create(:authorization_request, :api_entreprise, :revoked) }
+
+    it 'sends the email to the applicant' do
+      expect(mail.to).to eq([authorization_request.applicant.email])
+    end
+
+    it 'renders valid template' do
+      expect(mail.body.encoded).to match('a été révoquée')
+    end
+  end
+
+  describe '#changes_requested' do
     subject(:mail) do
       described_class.with(
         authorization_request:

--- a/spec/organizers/approve_authorization_request_spec.rb
+++ b/spec/organizers/approve_authorization_request_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe ApproveAuthorizationRequest do
         expect { approve_authorization_request }.to have_enqueued_mail(GDPRContactMailer, :responsable_traitement)
       end
 
+      context 'when there is a bridge' do
+        let(:authorization_request_kind) { :hubee_cert_dc }
+        let(:hubee_cert_dc_bridge) { instance_double(HubEECertDCBridge, perform: true) }
+
+        before do
+          allow(HubEECertDCBridge).to receive(:new).and_return(hubee_cert_dc_bridge)
+        end
+
+        it 'executes the bridge' do
+          approve_authorization_request
+
+          expect(hubee_cert_dc_bridge).to have_received(:perform)
+        end
+      end
+
       context 'when it is a reopening' do
         let!(:authorization_request) { create(:authorization_request, :api_service_national, :reopened) }
 

--- a/spec/organizers/approve_authorization_request_spec.rb
+++ b/spec/organizers/approve_authorization_request_spec.rb
@@ -28,16 +28,15 @@ RSpec.describe ApproveAuthorizationRequest do
 
       context 'when there is a bridge' do
         let(:authorization_request_kind) { :hubee_cert_dc }
-        let(:hubee_cert_dc_bridge) { instance_double(HubEECertDCBridge, enqueue: true) }
 
         before do
-          allow(HubEECertDCBridge).to receive(:new).and_return(hubee_cert_dc_bridge)
+          allow(HubEECertDCBridge).to receive(:perform_later)
         end
 
-        it 'executes the bridge asynchronously' do
+        it 'executes the bridge asynchronously with approve event' do
           approve_authorization_request
 
-          expect(hubee_cert_dc_bridge).to have_received(:enqueue)
+          expect(HubEECertDCBridge).to have_received(:perform_later).with(authorization_request, :approve)
         end
       end
 

--- a/spec/organizers/approve_authorization_request_spec.rb
+++ b/spec/organizers/approve_authorization_request_spec.rb
@@ -28,16 +28,16 @@ RSpec.describe ApproveAuthorizationRequest do
 
       context 'when there is a bridge' do
         let(:authorization_request_kind) { :hubee_cert_dc }
-        let(:hubee_cert_dc_bridge) { instance_double(HubEECertDCBridge, perform: true) }
+        let(:hubee_cert_dc_bridge) { instance_double(HubEECertDCBridge, enqueue: true) }
 
         before do
           allow(HubEECertDCBridge).to receive(:new).and_return(hubee_cert_dc_bridge)
         end
 
-        it 'executes the bridge' do
+        it 'executes the bridge asynchronously' do
           approve_authorization_request
 
-          expect(hubee_cert_dc_bridge).to have_received(:perform)
+          expect(hubee_cert_dc_bridge).to have_received(:enqueue)
         end
       end
 

--- a/spec/organizers/revoke_authorization_request_spec.rb
+++ b/spec/organizers/revoke_authorization_request_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe RevokeAuthorizationRequest, type: :organizer do
         it 'delivers an email' do
           expect { revoke_authorization_request }.to have_enqueued_mail(AuthorizationRequestMailer, :revoke)
         end
+
+        context 'when there is a bridge' do
+          let(:authorization_request_kind) { :hubee_cert_dc }
+
+          before do
+            allow(HubEECertDCBridge).to receive(:perform_later)
+          end
+
+          it 'executes the bridge asynchronously with revoke event' do
+            revoke_authorization_request
+
+            expect(HubEECertDCBridge).to have_received(:perform_later).with(authorization_request, :revoke)
+          end
+        end
       end
 
       context 'with authorization request in draft state' do

--- a/spec/organizers/revoke_authorization_request_spec.rb
+++ b/spec/organizers/revoke_authorization_request_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe RevokeAuthorizationRequest, type: :organizer do
+  describe '.call' do
+    subject(:revoke_authorization_request) { described_class.call(authorization_request:, revocation_of_authorization_params:, user:) }
+
+    let(:user) { create(:user, :instructor, authorization_request_types: %w[hubee_cert_dc]) }
+
+    context 'with valid params' do
+      let(:revocation_of_authorization_params) { attributes_for(:revocation_of_authorization) }
+
+      context 'with authorization request in validated state' do
+        let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }
+
+        it { is_expected.to be_success }
+
+        it 'creates a revocation of authorization' do
+          expect { revoke_authorization_request }.to change(RevocationOfAuthorization, :count).by(1)
+        end
+
+        it 'changes state to revoked' do
+          expect { revoke_authorization_request }.to change { authorization_request.reload.state }.from('validated').to('revoked')
+        end
+
+        it 'delivers an email' do
+          expect { revoke_authorization_request }.to have_enqueued_mail(AuthorizationRequestMailer, :revoke)
+        end
+      end
+
+      context 'with authorization request in draft state' do
+        let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :draft) }
+
+        it { is_expected.to be_failure }
+
+        it 'does not change state' do
+          expect { revoke_authorization_request }.not_to change { authorization_request.reload.state }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ça se lit commit / commit.

Les 3 premiers commits sont des ajouts/fixs de tests sur la révocation.
Le 4e commit c'est histoire d'être sûr que le bridge s'execute.
Les commits 5 et 6 clarifie/simplifie le bridge HubEE (le premier c'est vraiment de la clarification, le 2e c'est pour avoir des tests propres qui permettent de switch du mode sync -> async sans avoir à tout réécrire là dedans)

Le code effectif de cette PR tient dans les 2 derniers (petits) commits.

A noter que ça ne close pas 479 car le code effectif pour HubEE n'est pas encore spécifié (TBD plus tard, il suffira d'implémenter la méthode).

Closes https://linear.app/pole-api/issue/DAT-494
Ref https://linear.app/pole-api/issue/DAT-479