### PR TITLE
Harden notification settings boolean values

### DIFF
--- a/app/models/concerns/notifications_settings.rb
+++ b/app/models/concerns/notifications_settings.rb
@@ -9,9 +9,20 @@ module NotificationsSettings
 
           store_accessor :settings, method_name
 
-          define_method method_name do
-            settings[method_name].nil? ? true : settings[method_name]
-          end
+          create_boolean_setting_method(method_name)
+        end
+      end
+    end
+
+    def self.create_boolean_setting_method(method_name)
+      define_method method_name do
+        case settings[method_name]
+        when '1'
+          true
+        when '0'
+          false
+        else
+          settings[method_name].nil? ? true : settings[method_name]
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -177,6 +177,18 @@ RSpec.describe User do
       it { is_expected.to be_falsey }
     end
 
+    context 'when it sets to "0"' do
+      let(:user) { create(:user, instruction_submit_notifications_for_api_entreprise: '0') }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when it sets to "1"' do
+      let(:user) { create(:user, instruction_submit_notifications_for_api_entreprise: '1') }
+
+      it { is_expected.to be_truthy }
+    end
+
     context 'when it sets to true' do
       let(:user) { create(:user, instruction_submit_notifications_for_api_entreprise: true) }
 


### PR DESCRIPTION
In database when you manually change toggles from settings UI, we store '0' and '1', not boolean. We have to deal with these values too.

Thanks to this commit users who disabled notification from UI no longer receive emails.

For information there is users with boolean values on these settings, because of migration from v1 to v2.