### PR TITLE
Harden scopes changelog on changed prefilled form

### DIFF
--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -109,8 +109,10 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
 
   # rubocop:disable Metrics/AbcSize
   def build_scopes_change(values)
-    new_scopes = values[1] - values[0]
-    removed_scopes = values[0] - values[1]
+    initial_values = values[0].nil? && object.authorization_request.form.prefilled? ? object.authorization_request.form.data[:scopes] : values[0]
+
+    new_scopes = values[1] - initial_values
+    removed_scopes = initial_values - values[1]
 
     [
       new_scopes.map do |scope|


### PR DESCRIPTION
`values[0]` can be `nil`, this method is not evaluated if `name` is `submit_with_unchanged_prefilled_values`. However if form's scopes changed since the authorization request creation, we have a diff on scopes between initial form and authorization request, which leads to build the scopes change entry.

In order to mitigate 500 errors here, we are taking the form and build a diff with it : it is not 100% accurate, but better than error 500.

Ref https://linear.app/pole-api/issue/DAT-525/reouverture-dune-demande-dont-certains-scopes-voir-meme-champs-ont#comment-23bb258c