### PR TITLE
Harden changelog displays for authorization requests with changed prefilled data

### DIFF
--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -101,11 +101,17 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
       if authorization_request.form.data[h.to_sym].blank?
         v[0].blank?
       else
-        authorization_request.public_send(h) == authorization_request.form.data[h.to_sym]
+        initial_diff_on_scopes_without_changed_values?(h, v) ||
+          authorization_request.public_send(h) == authorization_request.form.data[h.to_sym]
       end
     end
   end
   # rubocop:enable Metrics/AbcSize
+
+  def initial_diff_on_scopes_without_changed_values?(key, values)
+    key.to_s == 'scopes' &&
+      values[0].blank?
+  end
 
   # rubocop:disable Metrics/AbcSize
   def build_scopes_change(values)


### PR DESCRIPTION
Read commit message plz

Closes https://errors.data.gouv.fr/organizations/sentry/issues/143777/
Ref https://github.com/etalab/data_pass/pull/352 (other solution, but a bad one)
Ref https://linear.app/pole-api/issue/DAT-525/reouverture-dune-demande-dont-certains-scopes-voir-meme-champs-ont#comment-23bb258c