### PR TITLE
don't display access callout on reopening request (too many callouts)

### DIFF
--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -44,8 +44,8 @@
       <% end %>
     <% end %>
 
-    <% if @authorization_request.access_link %>
-      <div class="fr-callout">
+    <% if @authorization_request.access_link && @authorization_request.validated? %>
+      <div class="fr-callout fr-my-16v">
         <h3 class="fr-callout__title">
           <%= t('authorization_requests.show.access_callout.title') %>
         </h3>

--- a/features/habilitations/portail_hubee_demarche_certdc.feature
+++ b/features/habilitations/portail_hubee_demarche_certdc.feature
@@ -63,3 +63,11 @@ Fonctionnalité: Soumission d'une demande d'habilitation Portail HubEE - Démarc
     Et que je clique sur "Consulter"
     Alors il y a un titre contenant "Portail HubEE - Démarche CertDC"
     Et la page ne contient aucun lien vers "portail.hubee.numerique.gouv.fr"
+
+  Scénario: Je ne vois aucun lien vers le portail HubEE quand je consulte une habilitation en réouverture avec token
+    Quand j'ai déjà une demande d'habilitation "Portail HubEE - Démarche CertDC" en réouverture avec token
+    Et que je vais sur la page du tableau de bord
+    Et que je clique sur le dernier "Consulter"
+    Alors il y a un titre contenant "Portail HubEE - Démarche CertDC"
+    Alors la page contient "Il s'agit d'une mise à jour d'une habilitation validée"
+    Et la page ne contient aucun lien vers "portail.hubee.numerique.gouv.fr"

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -16,6 +16,16 @@ Quand("j'ai déjà une demande d'habilitation {string} validée avec token") do 
   )
 end
 
+Quand("j'ai déjà une demande d'habilitation {string} en réouverture avec token") do |string|
+  FactoryBot.create(
+    :authorization_request,
+    find_factory_trait_from_name(string),
+    :reopened,
+    applicant: current_user,
+    linked_token_manager_id: 'some_token'
+  )
+end
+
 Quand('je veux remplir une demande pour {string} via le formulaire {string}') do |authorization_request_name, authorization_request_form_name|
   authorization_request_forms = AuthorizationRequestForm.where(
     name: authorization_request_form_name,


### PR DESCRIPTION
C'est très confusant de voir les deux callouts à la suite en cas de mise à jour :

![image](https://github.com/user-attachments/assets/354f92c9-8fa6-4853-bb6f-efaa6d877794)

Je pense qu'il faut n'afficher l'access url que sur la page d'une demande validée.

Ref : https://linear.app/pole-api/issue/DAT-516/hubee-ajouter-une-banniere-de-redirection-lorsque-lhabilitation-est