### PR TITLE
Introduce proper "as applicant" steps with named session

### DIFF
--- a/features/habilitation_changelogs.feature
+++ b/features/habilitation_changelogs.feature
@@ -5,19 +5,13 @@ Fonctionnalité: Création de changelog sur les habilitations soumises
   comprendre ce qui a été changé ou non.
 
   Contexte:
-    Sachant que je suis un demandeur
+    Sachant que je suis un rapporteur "Portail HubEE - Démarche CertDC"
     Et que je me connecte
 
   @DisableBullet
   Scénario: Je soumets une demande d'habilitation après avoir modifié un champ à la suite d'une demande de modification
-    Quand je me rends sur une demande d'habilitation "Portail HubEE - Démarche CertDC" à modifier
-    Et que je clique sur "Modifier"
-    Et que je remplis les informations du contact "Administrateur métier" avec :
-      | Nom    |
-      | Durand |
-    Et que je clique sur "Enregistrer les modifications"
-    Et que je clique sur "Soumettre"
-    Et que je suis un rapporteur "Portail HubEE - Démarche CertDC"
+    Quand il y a 1 demande d'habilitation "Portail HubEE - Démarche CertDC" en attente de modification
+    Et que le demandeur modifie le champ "Nom" avec la valeur "Durand" et soumet la demande
     Et que je me rends sur la dernière demande à instruire
     Et que je clique sur "Historique"
     Alors la page contient "Le champ Nom de famille de l'administrateur système a changé de \"Dupont Administrateur metier\" en \"Durand\""

--- a/features/habilitation_changelogs.feature
+++ b/features/habilitation_changelogs.feature
@@ -11,7 +11,8 @@ Fonctionnalité: Création de changelog sur les habilitations soumises
   @DisableBullet
   Scénario: Je soumets une demande d'habilitation après avoir modifié un champ à la suite d'une demande de modification
     Quand il y a 1 demande d'habilitation "Portail HubEE - Démarche CertDC" en attente de modification
-    Et que le demandeur modifie le champ "Nom" avec la valeur "Durand" et soumet la demande
+    Et que le demandeur modifie le champ "Nom" avec la valeur "Durand"
+    Et que le demandeur soumet la demande
     Et que je me rends sur la dernière demande à instruire
     Et que je clique sur "Historique"
     Alors la page contient "Le champ Nom de famille de l'administrateur système a changé de \"Dupont Administrateur metier\" en \"Durand\""

--- a/features/step_definitions/applicant_authorization_requests_steps.rb
+++ b/features/step_definitions/applicant_authorization_requests_steps.rb
@@ -1,0 +1,15 @@
+Quand('le demandeur modifie le champ {string} avec la valeur {string}') do |field, value|
+  Capybara.using_session(applicant_session(AuthorizationRequest.last)) do
+    step "je me rends sur cette demande d'habilitation"
+    step 'je clique sur "Modifier"'
+    step "je remplis \"#{field}\" avec \"#{value}\""
+    step 'je clique sur "Enregistrer"'
+  end
+end
+
+Quand('le demandeur soumet la demande') do
+  Capybara.using_session(applicant_session(AuthorizationRequest.last)) do
+    step "je me rends sur cette demande d'habilitation"
+    step 'je clique sur "Soumettre"'
+  end
+end

--- a/features/step_definitions/applicant_authorization_requests_steps.rb
+++ b/features/step_definitions/applicant_authorization_requests_steps.rb
@@ -1,5 +1,5 @@
 Quand('le demandeur modifie le champ {string} avec la valeur {string}') do |field, value|
-  Capybara.using_session(applicant_session(AuthorizationRequest.last)) do
+  using_last_applicant_session do
     step "je me rends sur cette demande d'habilitation"
     step 'je clique sur "Modifier"'
     step "je remplis \"#{field}\" avec \"#{value}\""
@@ -8,7 +8,7 @@ Quand('le demandeur modifie le champ {string} avec la valeur {string}') do |fiel
 end
 
 Quand('le demandeur soumet la demande') do
-  Capybara.using_session(applicant_session(AuthorizationRequest.last)) do
+  using_last_applicant_session do
     step "je me rends sur cette demande d'habilitation"
     step 'je clique sur "Soumettre"'
   end

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -291,18 +291,3 @@ Alors(/je vois (\d+) habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, 
     expect(page).to have_css('.authorization-request-state', text: I18n.t("authorization_request.status.#{state}"), count:)
   end
 end
-
-Quand('le demandeur modifie le champ {string} avec la valeur {string} et soumet la demande') do |field, value|
-  latest_authorization = AuthorizationRequest.last
-
-  Capybara.using_session("applicant #{latest_authorization.applicant.id}") do
-    mock_mon_compte_pro(latest_authorization.applicant)
-
-    step 'je me connecte'
-    step "je me rends sur cette demande d'habilitation"
-    step 'je clique sur "Modifier"'
-    step "je remplis \"#{field}\" avec \"#{value}\""
-    step 'je clique sur "Enregistrer"'
-    step 'je clique sur "Soumettre"'
-  end
-end

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -291,3 +291,18 @@ Alors(/je vois (\d+) habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, 
     expect(page).to have_css('.authorization-request-state', text: I18n.t("authorization_request.status.#{state}"), count:)
   end
 end
+
+Quand('le demandeur modifie le champ {string} avec la valeur {string} et soumet la demande') do |field, value|
+  latest_authorization = AuthorizationRequest.last
+
+  Capybara.using_session("applicant #{latest_authorization.applicant.id}") do
+    mock_mon_compte_pro(latest_authorization.applicant)
+
+    step 'je me connecte'
+    step "je me rends sur cette demande d'habilitation"
+    step 'je clique sur "Modifier"'
+    step "je remplis \"#{field}\" avec \"#{value}\""
+    step 'je clique sur "Enregistrer"'
+    step 'je clique sur "Soumettre"'
+  end
+end

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -291,7 +291,3 @@ Alors(/je vois (\d+) habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, 
     expect(page).to have_css('.authorization-request-state', text: I18n.t("authorization_request.status.#{state}"), count:)
   end
 end
-
-Et('je peux voir le bouton {string} grisé et désactivé') do |string|
-  expect(page).to have_css('button[disabled]', text: string)
-end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -218,3 +218,7 @@ end
 Alors('un champ contient {string}') do |text|
   expect(all('input').any? { |input| input.value == text }).to be_truthy, "Expected to find a field with value '#{text}'"
 end
+
+Et('je peux voir le bouton {string} grisé et désactivé') do |string|
+  expect(page).to have_css('button[disabled]', text: string)
+end

--- a/features/support/applicant_authorization_request_helpers.rb
+++ b/features/support/applicant_authorization_request_helpers.rb
@@ -1,0 +1,12 @@
+def applicant_session(authorization_request)
+  return @applicant_session if @applicant_session.present?
+
+  @applicant_session = Capybara::Session.new(Capybara.default_driver, Rails.application)
+
+  Capybara.using_session(@applicant_session) do
+    mock_mon_compte_pro(authorization_request.applicant)
+    step 'je me connecte'
+  end
+
+  @applicant_session
+end

--- a/features/support/applicant_authorization_request_helpers.rb
+++ b/features/support/applicant_authorization_request_helpers.rb
@@ -10,3 +10,7 @@ def applicant_session(authorization_request)
 
   @applicant_session
 end
+
+def using_last_applicant_session(&)
+  Capybara.using_session(applicant_session(AuthorizationRequest.last), &)
+end


### PR DESCRIPTION
Refactor in a nicer way to deal with applicant modification when we are connected as a reporter/instructor. 
It will be useful in next iterations