### PR TITLE
Add a custom class to apply the align-items css rule to body

### DIFF
--- a/app/assets/stylesheets/components/prefilled_banner.css
+++ b/app/assets/stylesheets/components/prefilled_banner.css
@@ -1,8 +1,3 @@
-.prefilled-banner .fr-notice__body_align {
-    display: flex;
-    align-items: center;
-}
-
 .prefilled-banner .fr-notice__title {
     display: block;
     font-size: 1.375rem;

--- a/app/assets/stylesheets/components/prefilled_banner.css
+++ b/app/assets/stylesheets/components/prefilled_banner.css
@@ -1,12 +1,10 @@
-.prefilled-banner .fr-notice__title {
-    display: block;
-    color: var(--text-default-grey);
-    font-size: 1.375rem;
-    font-weight: 700;
-    line-height: 1.74rem;
+.prefilled-banner .fr-notice__body_align {
+    display: flex;
+    align-items: center;
 }
 
-
-.prefilled-banner .fr-notice__desc {
-    color: var(--text-default-grey);
+.prefilled-banner .fr-notice__title {
+    display: block;
+    font-size: 1.375rem;
+    line-height: 1.74rem;
 }

--- a/app/views/authorization_request_forms/shared/_prefilled_banner.html.erb
+++ b/app/views/authorization_request_forms/shared/_prefilled_banner.html.erb
@@ -1,10 +1,10 @@
 <div class="fr-notice fr-notice--info fr-notice--no-icon prefilled-banner fr-my-3w fr-p-0">
   <div class="fr-container fr-p-0">
-    <div class="fr-notice__body fr-grid-row fr-p-3w">
-      <div class="fr-notice__icone fr-p-1w fr-mr-3w">
+    <div class="fr-notice__body fr-grid-row fr-col-10 fr-p-3w">
+      <div class="fr-notice__icone fr-grid-row fr-grid-row--center fr-grid-row--middle  fr-mr-3w">
         <%= image_tag "authorization_requests/survey.svg", alt: "Prefilled document logo" %>
       </div>
-      <p class="fr-col">
+      <p class="fr-col fr-grid-row fr-grid-row-middle">
         <span class="fr-notice__title fr-text-title--grey"><%= t('authorization_request_forms.default.prefill_data_info.title') %></span>
         <span class="fr-notice__desc fr-text-default--grey"><%= t('authorization_request_forms.default.prefill_data_info.description', name: @authorization_request.form.name) %> </span>
       </p>

--- a/app/views/authorization_request_forms/shared/_prefilled_banner.html.erb
+++ b/app/views/authorization_request_forms/shared/_prefilled_banner.html.erb
@@ -1,10 +1,10 @@
 <div class="fr-notice fr-notice--info fr-notice--no-icon prefilled-banner fr-my-3w fr-p-0">
   <div class="fr-container fr-p-0">
-    <div class="fr-notice__body fr-notice__body_align fr-p-3w fr-col-md-10">
+    <div class="fr-notice__body fr-grid-row fr-p-3w">
       <div class="fr-notice__icone fr-p-1w fr-mr-3w">
         <%= image_tag "authorization_requests/survey.svg", alt: "Prefilled document logo" %>
       </div>
-      <p>
+      <p class="fr-col">
         <span class="fr-notice__title fr-text-title--grey"><%= t('authorization_request_forms.default.prefill_data_info.title') %></span>
         <span class="fr-notice__desc fr-text-default--grey"><%= t('authorization_request_forms.default.prefill_data_info.description', name: @authorization_request.form.name) %> </span>
       </p>

--- a/app/views/authorization_request_forms/shared/_prefilled_banner.html.erb
+++ b/app/views/authorization_request_forms/shared/_prefilled_banner.html.erb
@@ -1,12 +1,12 @@
 <div class="fr-notice fr-notice--info fr-notice--no-icon prefilled-banner fr-my-3w fr-p-0">
   <div class="fr-container fr-p-0">
-    <div class="fr-grid-row fr-p-3w fr-col-md-10">
-      <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-mr-5w">
+    <div class="fr-notice__body fr-notice__body_align fr-p-3w fr-col-md-10">
+      <div class="fr-notice__icone fr-p-1w fr-mr-3w">
         <%= image_tag "authorization_requests/survey.svg", alt: "Prefilled document logo" %>
       </div>
       <p>
-        <span class="fr-notice__title"><%= t('authorization_request_forms.default.prefill_data_info.title') %></span>
-        <span class="fr-notice__desc"><%= t('authorization_request_forms.default.prefill_data_info.description', name: @authorization_request.form.name) %> </span>
+        <span class="fr-notice__title fr-text-title--grey"><%= t('authorization_request_forms.default.prefill_data_info.title') %></span>
+        <span class="fr-notice__desc fr-text-default--grey"><%= t('authorization_request_forms.default.prefill_data_info.description', name: @authorization_request.form.name) %> </span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
  - the fr-grid-row classes did not apply on every page where the full custom notice disclaimer is used. On some page, it was ok and for some other the disclaimer was broken. `.prefilled_banner .fr-notice__body {}`  did not apply the `align-items:center` rules neither

  - Remove some css by replace it with dsfr class (color text)

Avant: 

![Capture d’écran 2024-08-22 à 17 07 51](https://github.com/user-attachments/assets/64d7b2e4-055c-4602-9493-be07fce35b84)


Après: 

![Capture d’écran 2024-08-22 à 17 08 45](https://github.com/user-attachments/assets/f4171d87-5b7b-4a96-a40d-edcc3404bd6b)
