### PR TITLE
Harden class name management for notifier

### DIFF
--- a/app/interactors/deliver_authorization_request_notification.rb
+++ b/app/interactors/deliver_authorization_request_notification.rb
@@ -18,7 +18,7 @@ class DeliverAuthorizationRequestNotification < ApplicationInteractor
   end
 
   def notifier_klass
-    "#{context.authorization_request.class.name.demodulize}Notifier".constantize
+    "#{context.authorization_request.class_name.demodulize}Notifier".constantize
   rescue NameError
     BaseNotifier
   end

--- a/app/interactors/execute_authorization_request_bridge.rb
+++ b/app/interactors/execute_authorization_request_bridge.rb
@@ -18,6 +18,6 @@ class ExecuteAuthorizationRequestBridge < ApplicationInteractor
   end
 
   def authorization_request_class
-    context.authorization_request.class.name.split('::').last
+    context.authorization_request.class_name.split('::').last
   end
 end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -115,6 +115,10 @@ class AuthorizationRequest < ApplicationRecord
     end
   end
 
+  def class_name
+    self.class.name
+  end
+
   def kind
     type.underscore.split('/').last
   end

--- a/features/habilitation_sur_une_page.feature
+++ b/features/habilitation_sur_une_page.feature
@@ -61,6 +61,16 @@ Fonctionnalité: Interactions sur une demande d'habilitation simple (sur une seu
     Alors il y a un message de succès contenant "soumise avec succès"
     Et je suis sur la page "Demandes et habilitations"
 
+  @FlushJobQueue
+  Scénario: Je soumets une demande d'habilitation valide émettant des webhooks
+    Quand je me rends sur une demande d'habilitation "Solution ASTRE GF" en brouillon et rempli
+    Et que je clique sur "Continuer vers le résumé"
+    Et que j'adhère aux conditions générales
+    Et que je clique sur "Soumettre la demande"
+    Alors il y a un message de succès contenant "soumise avec succès"
+    Et je suis sur la page "Demandes et habilitations"
+    Et un webhook avec l'évènement "submit" est envoyé
+
   Scénario: Je démarre une demande d'habilitation avec des données pré-remplies
     Quand je veux remplir une demande pour "API Entreprise" via le formulaire "Dématérialisation des marchés publics" de l'éditeur "SETEC"
     Et que je clique sur "Débuter ma demande"

--- a/features/instructeurs/modérer_une_habilitation.feature
+++ b/features/instructeurs/modérer_une_habilitation.feature
@@ -25,6 +25,14 @@ Fonctionnalité: Instruction: modération
     Et un email est envoyé contenant "vous a désigné(e) comme Délégué à la protection des données"
     Et il y a un message de succès contenant "a été validé"
 
+  @FlushJobQueue
+  Scénario: Je valide une demande d'habilitation qui déclenche un webhook
+    Sachant que je suis un instructeur "API Entreprise"
+    Quand je me rends sur une demande d'habilitation "API Entreprise" à modérer
+    Et je clique sur "Valider"
+    Et je clique sur "Valider la demande d'habilitation"
+    Alors un webhook avec l'évènement "approve" est envoyé
+
   @AvecCourriels
   Scénario: Je refuse une demande d'habilitation avec un message valide
     Quand je me rends sur une demande d'habilitation "API Service National" à modérer
@@ -35,6 +43,15 @@ Fonctionnalité: Instruction: modération
     Et je vois 1 demande d'habilitation "API Service National" refusée
     Et un email est envoyé contenant "Vous êtes une entreprise privée"
     Et il y a un message de succès contenant "a été refusé"
+
+  @FlushJobQueue
+  Scénario: Je refuse une demande d'habilitation qui déclenche un webhook
+    Sachant que je suis un instructeur "API Entreprise"
+    Quand je me rends sur une demande d'habilitation "API Entreprise" à modérer
+    Et je clique sur "Refuser"
+    Et que je remplis "Raison du refus" avec "Vous êtes une entreprise privée"
+    Et que je clique sur "Refuser la demande d'habilitation"
+    Alors un webhook avec l'évènement "refuse" est envoyé
 
   Scénario: Je refuse une demande d'habilitation avec un message invalide
     Quand je me rends sur une demande d'habilitation "API Service National" à modérer
@@ -53,7 +70,16 @@ Fonctionnalité: Instruction: modération
     Et un email est envoyé contenant "Précisez votre cas d'usage"
     Et il y a un message de succès contenant "demande de modifications"
 
-  Scénario: Je demande des modifications sur une demande d'habilitation avec un message valide
+  @FlushJobQueue
+  Scénario: Je demande des modifications sur une demande d'habilitation qui déclenche un webhook
+    Sachant que je suis un instructeur "API Entreprise"
+    Quand je me rends sur une demande d'habilitation "API Entreprise" à modérer
+    Et je clique sur "Demander des modifications"
+    Et que je remplis "Raison de la demande de modification" avec "Précisez votre cas d'usage"
+    Et que je clique sur "Envoyer la demande de modification"
+    Alors un webhook avec l'évènement "request_changes" est envoyé
+
+  Scénario: Je demande des modifications sur une demande d'habilitation avec un message invalide
     Quand je me rends sur une demande d'habilitation "API Service National" à modérer
     Et je clique sur "Demander des modifications"
     Et que je clique sur "Envoyer la demande de modification"
@@ -65,3 +91,11 @@ Fonctionnalité: Instruction: modération
     Et je clique sur "Supprimer la demande"
     Alors je suis sur la page "Liste des demandes en cours"
     Et il y a un message de succès contenant "a été supprimée"
+
+  @FlushJobQueue
+  Scénario: Je supprime une demande d'habilitation qui déclenche un webhook
+    Sachant que je suis un instructeur "API Entreprise"
+    Quand je me rends sur une demande d'habilitation "API Entreprise" en brouillon
+    Et je clique sur "Supprimer"
+    Et je clique sur "Supprimer la demande"
+    Alors un webhook avec l'évènement "archive" est envoyé

--- a/features/support/authorization_request_helpers.rb
+++ b/features/support/authorization_request_helpers.rb
@@ -33,6 +33,8 @@ def extract_state_from_french_status(status)
     'submitted'
   when 'brouillon', 'brouillons'
     'draft'
+  when 'brouillon et rempli', 'brouillons et remplis'
+    'draft_and_filled'
   when 'refusée', 'refusées'
     'refused'
   when 'validée', 'validées'

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -82,6 +82,11 @@ FactoryBot.define do
       state { 'draft' }
     end
 
+    trait :draft_and_filled do
+      state { 'draft' }
+      fill_all_attributes { true }
+    end
+
     trait :archived do
       state { 'archived' }
     end


### PR DESCRIPTION
Decorators from Draper does not handle STI well :
`AuthorizationRequest::Whatever` instance `#decorate` method always return
`AuthorizationRequestDecorator`.

Because of this behaviour we have to implement a new method in order to
fetch the correct class name to fetch the correct notifier.

This bug was introduced by 00fe726261ce957d7099e5e1670d3d2bd6cd1708