### PR TITLE
DAT-435 / Supprimer les sections informations Pré-remplies de la synthèse

### DIFF
--- a/app/assets/stylesheets/components/basic_card.css
+++ b/app/assets/stylesheets/components/basic_card.css
@@ -1,8 +1,7 @@
 .fr-basic-card {
-  border-radius: 5px;
-  border: 1px solid #00000033;
-  padding: 1.5em;
-  background-color: #fff;
+  border: 1px solid var(--border-default-grey);
+  padding: 1.5rem;
+  background-color: var(--grey-1000-50);
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/app/assets/stylesheets/components/summary_block.css
+++ b/app/assets/stylesheets/components/summary_block.css
@@ -5,16 +5,13 @@
 
 .summary-block {
   position: relative;
-  background-color: #fff;
-  border-radius: 0px;
+  background-color: var(--background-default-grey);
   border: 1px solid var(--border-default-grey);
   padding: var(--summary-block--padding-y) var(--summary-block--padding-x);
-
-  margin-bottom: 50px;
 }
 
 .summary-block.summary-block--fixed {
-  background-color: rgba(0, 0, 0, 0.03);
+  background-color: var(--background-default-grey-hover);
 }
 
 .summary-block__ctas {
@@ -25,6 +22,5 @@
 
 .summary-block__title {
   display: inline-block;
-  border-bottom: 5px solid var(--border-active-blue-france);
-  padding-bottom: 5px;
+  border-bottom: 4px solid var(--border-active-blue-france);
 }

--- a/app/assets/stylesheets/components/summary_block.css
+++ b/app/assets/stylesheets/components/summary_block.css
@@ -14,6 +14,17 @@
   background-color: var(--background-default-grey-hover);
 }
 
+.summary-block__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.summary-block__icon {
+  margin-right: 0.5rem;
+  color: var(--text-action-high-blue-france);
+}
+
 .summary-block__ctas {
   position: absolute;
   top: var(--summary-block--padding-y);

--- a/app/decorators/authorization_request_decorator.rb
+++ b/app/decorators/authorization_request_decorator.rb
@@ -14,27 +14,22 @@ class AuthorizationRequestDecorator < ApplicationDecorator
     end
   end
 
-  def editable_blocks
-    blocks.select do |block|
-      object.form.static_blocks.pluck(:name).exclude?(block[:name])
+  def blocks
+    @blocks ||= begin
+      static_block_names = object.form.static_blocks.pluck(:name)
+
+      object.definition.blocks.map do |block|
+        block.merge(editable: static_block_names.exclude?(block[:name]))
+      end
     end
+  end
+
+  def editable_blocks
+    blocks.select { |block| block[:editable] }
   end
 
   def static_blocks
     blocks - editable_blocks
-  end
-
-  def ordered_blocks
-    blocks.map do |block|
-      {
-        name: block[:name],
-        editable: object.form.static_blocks.pluck(:name).exclude?(block[:name])
-      }
-    end
-  end
-
-  def blocks
-    object.definition.blocks
   end
 
   def contact_full_name(contact_type)

--- a/app/decorators/authorization_request_decorator.rb
+++ b/app/decorators/authorization_request_decorator.rb
@@ -24,6 +24,15 @@ class AuthorizationRequestDecorator < ApplicationDecorator
     blocks - editable_blocks
   end
 
+  def ordered_blocks
+    blocks.map do |block|
+      {
+        name: block[:name],
+        editable: object.form.static_blocks.pluck(:name).exclude?(block[:name])
+      }
+    end
+  end
+
   def blocks
     object.definition.blocks
   end

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -70,14 +70,10 @@
     <% end %>
 
     <% if @authorization_request.filling? %>
-      <% @authorization_request.editable_blocks.each do |block| %>
-        <%= render partial: "authorization_requests/shared/blocks/#{block[:name]}", locals: { f: f, editable: true } %>
-      <% end %>
-
       <%= render partial: 'authorization_requests/shared/organization_and_applicant' %>
 
-      <% @authorization_request.static_blocks.each do |block| %>
-        <%= render partial: "authorization_requests/shared/blocks/#{block[:name]}", locals: { f: f, editable: false } %>
+      <% @authorization_request.ordered_blocks.each do |block| %>
+        <%= render partial: "authorization_requests/shared/blocks/#{block[:name]}", locals: { f: f, editable: block[:editable] } %>
       <% end %>
     <% else %>
       <%= render partial: 'authorization_requests/shared/organization_and_applicant' %>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -60,18 +60,11 @@
         <%= render partial: 'authorization_requests/shared/reopening_callout', locals: { klass: 'fr-mt-6w' } %>
       <% else %>
         <h2>
-          Récapitulatif de votre demande
+          <%= t('authorization_request_forms.summary.title') %>
         </h2>
 
         <p>
-          Vous avez complété toutes les étapes de votre demande.
-          <br />
-          Merci de vérifier que les informations ci-dessous sont correctes et d'accepter les conditions générales d'utilisation.
-
-          <% if @authorization_request.static_blocks.any? %>
-            <br />
-            Une partie des informations ci-dessous ont été pré-remplies en accord avec le type de formulaire que vous avez sélectionné et ne sont pas modifiables.
-          <% end %>
+          <%= t('authorization_request_forms.summary.description').html_safe %>
         </p>
       <% end %>
     <% end %>
@@ -80,13 +73,6 @@
       <% @authorization_request.editable_blocks.each do |block| %>
         <%= render partial: "authorization_requests/shared/blocks/#{block[:name]}", locals: { f: f, editable: true } %>
       <% end %>
-
-      <h3>
-        Les informations pré-remplies
-      </h3>
-      <p>
-        Les informations suivantes ont été pré-remplies et ne sont pas modifiables.
-      </p>
 
       <%= render partial: 'authorization_requests/shared/organization_and_applicant' %>
 

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -28,18 +28,16 @@
       <% if @authorization.latest? && @authorization.request.reopening? %>
         <div class="fr-alert fr-alert--info fr-mb-4v">
           <h3 class="fr-alert__title">
-            Une mise à jour de cette demande est en cours.
+            <%= t('authorization_request_forms.summary.reopening_alerts.update_in_progress.title') %>
           </h3>
-
-          Vous avez initié une mise à jour de cette habilitation. Vous pouvez y accéder en cliquant ici : <%= link_to "Demande de mise à jour n°#{@authorization.request.id}", authorization_request_path(@authorization.request) %>
+          <%= t('authorization_request_forms.summary.reopening_alerts.update_in_progress.message', link: link_to("Demande de mise à jour n°#{@authorization.request.id}", authorization_request_path(@authorization.request))).html_safe %>
         </div>
       <% elsif !@authorization.latest? %>
         <div class="fr-alert fr-alert--warning fr-mb-4v">
           <h3 class="fr-alert__title">
-            Attention, vous consultez une version ancienne de cette habilitation
+            <%= t('authorization_request_forms.summary.reopening_alerts.old_version.title') %>
           </h3>
-
-          Il existe une version plus récente de cette habilitation que vous pouvez consulter en cliquant ici : <%= link_to "Habilitation n°#{@authorization_request.latest_authorization.id}", @authorization_request.latest_authorization %>
+          <%= t('authorization_request_forms.summary.reopening_alerts.old_version.message', link: link_to("Habilitation n°#{@authorization_request.latest_authorization.id}", @authorization_request.latest_authorization)).html_safe %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -72,7 +72,7 @@
     <% if @authorization_request.filling? %>
       <%= render partial: 'authorization_requests/shared/organization_and_applicant' %>
 
-      <% @authorization_request.ordered_blocks.each do |block| %>
+      <% @authorization_request.blocks.each do |block| %>
         <%= render partial: "authorization_requests/shared/blocks/#{block[:name]}", locals: { f: f, editable: block[:editable] } %>
       <% end %>
     <% else %>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -59,7 +59,7 @@
       <% if @authorization_request.reopening? && @authorization_request.applicant == current_user %>
         <%= render partial: 'authorization_requests/shared/reopening_callout', locals: { klass: 'fr-mt-6w' } %>
       <% else %>
-        <h2>
+        <h2 class="fr-h3">
           <%= t('authorization_request_forms.summary.title') %>
         </h2>
 

--- a/app/views/authorization_requests/shared/blocks/_summary_block.html.erb
+++ b/app/views/authorization_requests/shared/blocks/_summary_block.html.erb
@@ -7,7 +7,7 @@
     <div class="summary-block__info fr-text--sm font-weight-700">
       <% if policy(@authorization_request).update? && !editable %>
         <span class="fr-icon-info-fill summary-block__icon"></span>
-        Ces informations ne sont pas modifiables
+        <%= t('authorization_request_forms.summary.summary_block.message') %>
       <% end %>
     </div>
   </div>

--- a/app/views/authorization_requests/shared/blocks/_summary_block.html.erb
+++ b/app/views/authorization_requests/shared/blocks/_summary_block.html.erb
@@ -1,5 +1,5 @@
-<div class="summary-block <%= !editable ? 'summary-block--fixed' : '' %>" id="<%= dom_id(@authorization_request, block_id) %>">
-  <h3 class="summary-block__title">
+<div class="summary-block <%= !editable ? 'summary-block--fixed' : '' %> fr-mb-6w" id="<%= dom_id(@authorization_request, block_id) %>">
+  <h3 class="summary-block__title fr-h4 fr-pb-1-5v">
     <%= title %>
   </h3>
 

--- a/app/views/authorization_requests/shared/blocks/_summary_block.html.erb
+++ b/app/views/authorization_requests/shared/blocks/_summary_block.html.erb
@@ -1,7 +1,16 @@
 <div class="summary-block <%= !editable ? 'summary-block--fixed' : '' %> fr-mb-6w" id="<%= dom_id(@authorization_request, block_id) %>">
-  <h3 class="summary-block__title fr-h4 fr-pb-1-5v">
-    <%= title %>
-  </h3>
+  <div class="summary-block__header">
+    <h3 class="summary-block__title fr-h4 fr-pb-1-5v">
+      <%= title %>
+    </h3>
+
+    <div class="summary-block__info fr-text--sm font-weight-700">
+      <% if policy(@authorization_request).update? && !editable %>
+        <span class="fr-icon-info-fill summary-block__icon"></span>
+        Ces informations ne sont pas modifiables
+      <% end %>
+    </div>
+  </div>
 
   <div class="summary-block__ctas">
     <% if policy(@authorization_request).update? && editable %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -272,6 +272,9 @@ fr:
           title: Attention, vous consultez une version ancienne de cette habilitation
           message: "Il existe une version plus récente de cette habilitation que vous pouvez consulter en cliquant ici: %{link}"
 
+      summary_block:
+        message: Ces informations ne sont pas modifiables
+
     form:
       back: Retour à la synthèse
       message_datapass: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -258,6 +258,12 @@ fr:
         description: *common_authorization_requests_error_description
 
     summary:
+      title: Récapitulatif de votre demande
+      description: |
+        Vous avez complété toutes les étapes de votre demande !
+        <br />
+        Vous pouvez à présent la soumettre à l'équipe d’instruction après avoir lu nos conditions générales d’utilisation.
+
       reopening_alerts:
         update_in_progress:
           title: Une mise à jour de cette demande est en cours.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -12,8 +12,10 @@ fr:
     legal: 'cadre-juridique'
     scopes: 'donnees'
     contacts: 'contacts'
+
   authorization:
     badge: habilitation du %{date}
+
   authorization_request:
     badge: demande n°%{id}
     status:
@@ -192,6 +194,7 @@ fr:
 
   start_authorization_request_form:
     cta: Débuter ma demande
+
   authorization_request_forms:
     new:
       title: *start_new_habilitation_title
@@ -208,6 +211,7 @@ fr:
       single_form:
         title: "Les étapes de votre formulaire"
         description: "Cliquez sur le bouton ci-dessous pour démarrer le formulaire. Celui-ci se complètera en une seule page. Vous pourrez le sauvegarder et le reprendre plus tard."
+
     unicity_callout:
       title: Vous ne pouvez pas créer de nouvelle habilitation
       habilitation:
@@ -240,6 +244,7 @@ fr:
       reopening_error: &authorization_requests_update_reopening_error
         title: Une erreur est survenue lors de la sauvegarde de la mise à jour de la demande d'habilitation
         description: *common_authorization_requests_error_description
+
     submit:
       success:
         title: La demande d'habilitation %{name} a été soumise avec succès
@@ -251,6 +256,16 @@ fr:
       reopening_error:
         title: Une erreur est survenue lors de la soumission de la demande de mise à jour de l'habilitation
         description: *common_authorization_requests_error_description
+
+    summary:
+      reopening_alerts:
+        update_in_progress:
+          title: Une mise à jour de cette demande est en cours.
+          message: "Vous avez initié une mise à jour de cette habilitation. Vous pouvez y accéder en cliquant ici : %{link}"
+        old_version:
+          title: Attention, vous consultez une version ancienne de cette habilitation
+          message: "Il existe une version plus récente de cette habilitation que vous pouvez consulter en cliquant ici: %{link}"
+
     form:
       back: Retour à la synthèse
       message_datapass: 


### PR DESCRIPTION
Je souhaiterais m'attaquer à la refactorisation des alerts (il y en a 3 rien que dans ce fichier) mais je préfère le traiter dans une autre PR.

--- 
![screencapture-localhost-3000-formulaires-api-particulier-arpege-concerto-demande-50-resume-2024-08-29-16_46_37](https://github.com/user-attachments/assets/f64b935f-a9e6-4b2d-aedc-70d326a854ef)

----

En cours d'instruction 

![screencapture-localhost-3000-formulaires-hubee-dila-demande-47-resume-2024-08-29-16_47_31](https://github.com/user-attachments/assets/5e1b88c0-2292-4386-9dde-71706695d0d2)


Closes [DAT-436/distinction-des-blocs-non-modifiables](https://linear.app/pole-api/issue/DAT-436/distinction-des-blocs-non-modifiables)
