### PR TITLE
Ajoute un bouton pour annuler une réouverture côté utilisateur

### DIFF
--- a/app/controllers/cancel_authorization_reopenings_controller.rb
+++ b/app/controllers/cancel_authorization_reopenings_controller.rb
@@ -10,7 +10,7 @@ class CancelAuthorizationReopeningsController < AuthenticatedUserController
   end
 
   def create
-    organizer = CancelAuthorizationReopening.call(authorization_request_reopening_cancellation_params: {}, authorization_request: @authorization_request, user: current_user)
+    organizer = CancelAuthorizationReopening.call(authorization_request: @authorization_request, user: current_user)
 
     @authorization_request_reopening_cancellation = organizer.authorization_request_reopening_cancellation
 

--- a/app/controllers/cancel_authorization_reopenings_controller.rb
+++ b/app/controllers/cancel_authorization_reopenings_controller.rb
@@ -1,0 +1,36 @@
+class CancelAuthorizationReopeningsController < AuthenticatedUserController
+  helper AuthorizationRequestsHelpers
+  include AuthorizationRequestsFlashes
+
+  before_action :extract_authorization_request
+  before_action :authorize_authorization_request_reopening_cancellation
+
+  def new
+    @authorization_request_reopening_cancellation = @authorization_request.reopening_cancellations.build
+  end
+
+  def create
+    organizer = CancelAuthorizationReopening.call(authorization_request_reopening_cancellation_params: {}, authorization_request: @authorization_request, user: current_user)
+
+    @authorization_request_reopening_cancellation = organizer.authorization_request_reopening_cancellation
+
+    if organizer.success?
+      success_message_for_authorization_request(@authorization_request, key: 'cancel_authorization_reopenings.create')
+
+      redirect_to dashboard_path,
+        status: :see_other
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def authorize_authorization_request_reopening_cancellation
+    authorize @authorization_request, :cancel_reopening?
+  end
+
+  def extract_authorization_request
+    @authorization_request = AuthorizationRequest.find(params[:authorization_request_id])
+  end
+end

--- a/app/interactors/create_authorization_request_reopening_cancellation.rb
+++ b/app/interactors/create_authorization_request_reopening_cancellation.rb
@@ -1,4 +1,8 @@
 class CreateAuthorizationRequestReopeningCancellation < ApplicationInteractor
+  before do
+    context.authorization_request_reopening_cancellation_params ||= {}
+  end
+
   def call
     context.authorization_request_reopening_cancellation = context.authorization_request.reopening_cancellations.build(
       authorization_request_reopening_cancellation_params,

--- a/app/policies/authorization_request_policy.rb
+++ b/app/policies/authorization_request_policy.rb
@@ -47,7 +47,7 @@ class AuthorizationRequestPolicy < ApplicationPolicy
 
   def cancel_reopening?
     same_user_and_organization? &&
-      record.can_cancel_reopening?
+      record.can_cancel_reopening? && !record.submitted?
   end
 
   def messages?

--- a/app/policies/authorization_request_policy.rb
+++ b/app/policies/authorization_request_policy.rb
@@ -45,6 +45,11 @@ class AuthorizationRequestPolicy < ApplicationPolicy
       record.can_reopen?
   end
 
+  def cancel_reopening?
+    same_user_and_organization? &&
+      record.can_cancel_reopening?
+  end
+
   def messages?
     record.persisted? &&
       record.applicant == user

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -88,21 +88,29 @@
     <% end %>
   </div>
   
-  <% if policy(@authorization_request).submit? || policy(@authorization_request).cancel_reopening? %>
+  <% if policy(@authorization_request).cancel_reopening? %>
     <% content_for :sticky_bar do %>
       <div class="fr-container fr-grid-row">
         <div class="fr-col-12">
           <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--between">
-            <% if policy(@authorization_request).cancel_reopening? %>
-              <li>
-                <%= dsfr_main_modal_button(t('authorization_request_forms.form.cancel_reopening'), new_authorization_request_cancel_reopening_path(@authorization_request), class: %w(fr-btn fr-btn--secondary fr-icon-arrow-left-s-line-double fr-btn--icon-left)) %>
-              </li>
-            <% end %>
-            <% if policy(@authorization_request).submit? %>
-              <li class="fr-ml-auto">
-                <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
-              </li>
-            <% end %>
+            <li>
+              <%= dsfr_main_modal_button(t('authorization_request_forms.form.cancel_reopening'), new_authorization_request_cancel_reopening_path(@authorization_request), class: %w(fr-btn fr-btn--secondary fr-icon-arrow-left-s-line-double fr-btn--icon-left)) %>
+            </li>
+            <li class="fr-ml-auto">
+              <%= f.button t('authorization_request_forms.form.submit_reopening'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+  <% elsif policy(@authorization_request).submit? %>
+    <% content_for :sticky_bar do %>
+      <div class="fr-container fr-grid-row">
+        <div class="fr-col-12">
+          <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--between">
+            <li class="fr-ml-auto">
+              <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
+            </li>
           </ul>
         </div>
       </div>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -99,7 +99,7 @@
               </li>
             <% end %>
             <% if policy(@authorization_request).submit? %>
-              <li>
+              <li class="fr-ml-auto">
                 <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
               </li>
             <% end %>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -87,12 +87,21 @@
       <%= render partial: 'authorization_request_forms/shared/tos_checkboxes', locals: { f: f } %>
     <% end %>
   </div>
-
-   <% if policy(@authorization_request).submit? %>
+  
+  <% if policy(@authorization_request).submit? || policy(@authorization_request).cancel_reopening? %>
     <% content_for :sticky_bar do %>
-        <div class="fr-container fr-grid-row fr-grid-row--right">
-          <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
+      <div class="fr-container fr-grid-row">
+        <div class="fr-col-12">
+          <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--between">
+            <li>
+              <%= dsfr_main_modal_button(t('authorization_request_forms.form.cancel_reopening'), new_authorization_request_cancel_reopening_path(@authorization_request), class: %w(fr-btn fr-btn--secondary fr-icon-arrow-left-s-line-double fr-btn--icon-left)) %>
+            </li>
+            <li>
+              <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
+            </li>
+          </ul>
         </div>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -93,12 +93,16 @@
       <div class="fr-container fr-grid-row">
         <div class="fr-col-12">
           <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--between">
-            <li>
-              <%= dsfr_main_modal_button(t('authorization_request_forms.form.cancel_reopening'), new_authorization_request_cancel_reopening_path(@authorization_request), class: %w(fr-btn fr-btn--secondary fr-icon-arrow-left-s-line-double fr-btn--icon-left)) %>
-            </li>
-            <li>
-              <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
-            </li>
+            <% if policy(@authorization_request).cancel_reopening? %>
+              <li>
+                <%= dsfr_main_modal_button(t('authorization_request_forms.form.cancel_reopening'), new_authorization_request_cancel_reopening_path(@authorization_request), class: %w(fr-btn fr-btn--secondary fr-icon-arrow-left-s-line-double fr-btn--icon-left)) %>
+              </li>
+            <% end %>
+            <% if policy(@authorization_request).submit? %>
+              <li>
+                <%= f.button t('authorization_request_forms.form.submit'), type: :submit, name: :submit, id: :submit_authorization_request, class: %w(fr-btn fr-icon-checkbox-line fr-btn--icon-left) %>
+              </li>
+            <% end %>
           </ul>
         </div>
       </div>

--- a/app/views/cancel_authorization_reopenings/new.html.erb
+++ b/app/views/cancel_authorization_reopenings/new.html.erb
@@ -1,0 +1,39 @@
+
+<div class="simple-page-action-wrapper fr-pt-5w">
+  <div class="fr-grid-row fr-grid-row--center">
+    <div class="fr-col-md-offset-1 fr-col-md-10">
+      <turbo-frame id="main-modal-content">
+        <%= form_with(model: @authorization_request_reopening_cancellation, url: authorization_request_cancel_reopening_index_path(@authorization_request), data: { turbo_frame: 'main-modal-content' }) do |f| %>
+          <div class="fr-modal__content">
+            <h1 class="fr-modal__title">
+              <%= t(".initial.title", authorization_request_name: @authorization_request.name) %>
+            </h1>
+
+            <p>
+              <%=
+                t(
+                  ".initial.description.organization",
+                  authorization_request_name: sanitize(@authorization_request.name),
+                  organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                  organization_siret: @authorization_request.organization.siret,
+                )
+              %>
+            </p>
+
+            <p>
+              <%= t(".initial.description.disclaimer").html_safe %>
+            </p>
+
+          </div>
+
+          <div class="fr-modal__footer">
+            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+              <%= link_to t(".initial.cancel"), '#', class: %w(fr-btn fr-btn--secondary), aria: { controls: 'main-modal' } %>
+              <%= f.button t(".initial.cancel_reopening"), type: :submit, class: %w(fr-btn fr-btn--primary fr-icon-error-line fr-btn--icon-left) %>
+            </div>
+          </div>
+        <% end %>
+      </turbo-frame>
+    </div>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -133,6 +133,7 @@ ignore_unused:
   - "transfer_authorization_requests.create.to_another.error.*"
   - "instruction.{approve,refuse,request_changes_on,revoke}_authorization_requests.create.{reopening_,}success.title"
   - "instruction.cancel_authorization_reopenings.create.success.title"
+  - "cancel_authorization_reopenings.create.success.title"
   - "gdpr_contact_mailer.delegue_protection_donnees.subject"
   - "gdpr_contact_mailer.responsable_traitement.subject"
   - "instruction.authorization_requests.index.status.*"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -319,7 +319,8 @@ fr:
       save: Enregistrer les modifications
       start: Démarrer
       submit: Soumettre la demande d'habilitation
-      cancel_reopening: Annuler la demande de réouverture
+      submit_reopening: Envoyer ma demande de modification
+      cancel_reopening: Annuler ma demande de modification
       review: Continuer vers le résumé
       previous: Précédent
       next: Suivant
@@ -708,15 +709,14 @@ fr:
   cancel_authorization_reopenings:
     new:
       initial:
-        title: Annulation de la réouverture de l'habilitation
+        title: Annulation de vos modifications
         description:
           organization: |
-            Vous êtes sur le point d'annuler la réouverture de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+            Vous êtes sur le point d'annuler vos modifications, l'ensemble des changements que vous avez pu effectuer seront perdus. Votre habilitation quant à elle sera toujours valide.
           disclaimer: |
             <strong>Cette action est irréversible</strong>.
         cancel: Annuler
-        cancel_reopening: Annuler la réouverture de cette demande
-
+        cancel_reopening: Annuler ma demande de modification
     create:
       success:
         title: La réouverture de l'habilitation %{name} a été annulée.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -319,6 +319,7 @@ fr:
       save: Enregistrer les modifications
       start: Démarrer
       submit: Soumettre la demande d'habilitation
+      cancel_reopening: Annuler la demande de réouverture
       review: Continuer vers le résumé
       previous: Précédent
       next: Suivant
@@ -703,3 +704,19 @@ fr:
 
         system_import:
           text: La demande d'habilitation a été importé depuis une autre source
+
+  cancel_authorization_reopenings:
+    new:
+      initial:
+        title: Annulation de la réouverture de l'habilitation
+        description:
+          organization: |
+            Vous êtes sur le point d'annuler la réouverture de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+          disclaimer: |
+            <strong>Cette action est irréversible</strong>.
+        cancel: Annuler
+        cancel_reopening: Annuler la réouverture de cette demande
+
+    create:
+      success:
+        title: La réouverture de l'habilitation %{name} a été annulée.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       resources :archive_authorization_requests, only: %w[new create], path: 'archiver', as: :archive
       resources :transfer_authorization_requests, only: %w[new create], path: 'transferer', as: :transfer
       resources :blocks, only: %w[edit update], path: 'blocs', controller: 'authorization_requests/blocks'
+      resources :cancel_authorization_reopenings, only: %w[new create], path: 'annuler_reouverture', as: :cancel_reopening
 
       resources :authorizations, only: :show, path: 'habilitations'
     end

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -78,10 +78,13 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte
     Et que je vais sur la page tableau de bord
     Et que je clique sur le dernier "Consulter"
+    Alors il y a un bouton "Annuler la demande de réouverture"
     Et que je clique sur "Soumettre"
     Alors il y a un message de succès contenant "soumise avec succès"
     Et il y a un badge "Validée"
     Et il y a un badge "En cours"
+    Et que je clique sur le dernier "Consulter"
+    Alors il n'y a pas de bouton "Annuler la demande de réouverture"
 
   @DisableBullet
   @FlushJobQueue

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -68,23 +68,24 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte
     Et que je vais sur la page tableau de bord
     Et que je clique sur le dernier "Consulter"
-    Alors il y a un bouton "Annuler la demande de réouverture"
-    Et que je clique sur "Annuler la demande de réouverture"
-    Alors il y a un bouton "Annuler la réouverture de cette demande"
-    Et que je clique sur "Annuler la réouverture de cette demande"
+    Alors il y a un bouton "Annuler ma demande de modification"
+    Et que je clique sur "Annuler ma demande de modification"
+    Alors il y a un titre contenant "Annulation de vos modifications"
+    Alors il y a un bouton "Annuler ma demande de modification"
+    Et que je clique sur "Annuler ma demande de modification"
     Alors il y a un message de succès contenant "a été annulée"
 
   Scénario: Soumission d'une habilitation fraîchement réouverte
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte
     Et que je vais sur la page tableau de bord
     Et que je clique sur le dernier "Consulter"
-    Alors il y a un bouton "Annuler la demande de réouverture"
-    Et que je clique sur "Soumettre"
+    Alors il y a un bouton "Annuler ma demande de modification"
+    Et que je clique sur "Envoyer ma demande de modification"
     Alors il y a un message de succès contenant "soumise avec succès"
     Et il y a un badge "Validée"
     Et il y a un badge "En cours"
     Et que je clique sur le dernier "Consulter"
-    Alors il n'y a pas de bouton "Annuler la demande de réouverture"
+    Alors il n'y a pas de bouton "Annuler ma demande de modification"
 
   @DisableBullet
   @FlushJobQueue

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -2,7 +2,8 @@
 
 Fonctionnalité: Réouverture d'une habilitation validée
   Une habilitation validée peut être réouverte par un demandeur. Celle-ci peut
-  être resoumisse, revalidée ou refusée (ce qui annule les changements).
+  être ressoumise, revalidée ou refusée (ce qui annule les changements) et la 
+  réouverture peut être annulée
 
   Contexte:
     Sachant que je suis un demandeur
@@ -62,6 +63,16 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et il y a un badge "Mise à jour"
     Et il y a un badge "Brouillon"
     Et il n'y a pas de bouton "Enregistrer"
+
+  Scénario: Annulation d'une demande de réouverture
+    Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte
+    Et que je vais sur la page tableau de bord
+    Et que je clique sur le dernier "Consulter"
+    Alors il y a un bouton "Annuler la demande de réouverture"
+    Et que je clique sur "Annuler la demande de réouverture"
+    Alors il y a un bouton "Annuler la réouverture de cette demande"
+    Et que je clique sur "Annuler la réouverture de cette demande"
+    Alors il y a un message de succès contenant "a été annulée"
 
   Scénario: Soumission d'une habilitation fraîchement réouverte
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte

--- a/spec/organizers/cancel_authorization_reopening_spec.rb
+++ b/spec/organizers/cancel_authorization_reopening_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe CancelAuthorizationReopening, type: :organizer do
   describe '.call' do
-    subject(:cancel_authorization_reopening) { described_class.call(authorization_request:, user:, authorization_request_reopening_cancellation_params:) }
+    subject(:cancel_authorization_reopening) { described_class.call(**params) }
 
     let!(:authorization_request) { create(:authorization_request, authorization_request_kind, :reopened) }
     let(:authorization_request_kind) { :hubee_cert_dc }
     let(:authorization_request_reopening_cancellation_params) { { reason: } }
+    let(:params) { { authorization_request:, user:, authorization_request_reopening_cancellation_params: } }
     let(:reason) { 'Too old mate' }
 
     context 'when user is an instructor' do
@@ -56,9 +57,56 @@ RSpec.describe CancelAuthorizationReopening, type: :organizer do
         end
       end
     end
-  end
 
-  context 'when it is the applicant' do
-    xit 'works'
+    context 'when it is the applicant' do
+      let(:authorization_request_reopening_cancellation_params) { nil }
+      let(:user) { authorization_request.applicant }
+
+      context 'with valid attributes' do
+        it { is_expected.to be_success }
+
+        it 'create an authorization request reopening cancellation' do
+          expect { cancel_authorization_reopening }.to change(AuthorizationRequestReopeningCancellation, :count).by(1)
+        end
+
+        it 'changes authorization request state to validated' do
+          expect { cancel_authorization_reopening }.to change { authorization_request.reload.state }.from('draft').to('validated')
+        end
+
+        context 'when there was changes on the authorization request' do
+          let!(:authorization_request) { create(:authorization_request, authorization_request_kind, :reopened, administrateur_metier_email: 'old@gouv.fr') }
+
+          before do
+            authorization_request.administrateur_metier_email = 'new@gouv.fr'
+            authorization_request.save!
+          end
+
+          it 'reverts attributes to latest authorization data' do
+            expect { cancel_authorization_reopening }.to change { authorization_request.reload.administrateur_metier_email }.from('new@gouv.fr').to('old@gouv.fr')
+          end
+        end
+
+        include_examples 'creates an event', event_name: :cancel_reopening, entity_type: :authorization_request_reopening_cancellation
+        include_examples 'delivers a webhook', event_name: :cancel_reopening
+      end
+
+      context 'with invalid attributes' do
+        let(:user) { nil }
+
+        it { is_expected.to be_failure }
+
+        it 'does not create an authorization request reopening cancellation' do
+          expect { cancel_authorization_reopening }.not_to change(AuthorizationRequestReopeningCancellation, :count)
+        end
+
+        it 'does not change authorization request state' do
+          expect { cancel_authorization_reopening }.not_to change { authorization_request.reload.state }
+        end
+
+        it 'does not create an event' do
+          expect { cancel_authorization_reopening }.not_to change(AuthorizationRequestEvent, :count)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Cette PR permet aux demandeurs d'annuler une demande de réouverture.
![Capture d'écran 2024-09-25 112412](https://github.com/user-attachments/assets/fbd702eb-9d9a-41fa-b9c0-7c8305edeacc)


![Capture d'écran 2024-09-25 112431](https://github.com/user-attachments/assets/5b3fb975-669a-4a95-9aca-f8bd81f04fb1)
