### PR TITLE
Harden EmailRecentlyVerifiedValidator on email verifier timeout

### DIFF
--- a/app/jobs/email_verifier_job.rb
+++ b/app/jobs/email_verifier_job.rb
@@ -1,7 +1,7 @@
 class EmailVerifierJob < ApplicationJob
   attr_reader :email
 
-  retry_on Emailable::TimeoutError, wait: :polynomially_longer, attempts: Float::INFINITY
+  retry_on EmailVerifierAPI::TimeoutError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   def perform(email)
     @email = email

--- a/app/services/email_verifier_api.rb
+++ b/app/services/email_verifier_api.rb
@@ -1,6 +1,8 @@
 class EmailVerifierAPI
   attr_reader :email
 
+  class TimeoutError < StandardError; end
+
   def initialize(email)
     @email = email
   end
@@ -9,6 +11,8 @@ class EmailVerifierAPI
     return ok_status unless enable_email_verification?
 
     Emailable.verify(email).state
+  rescue Emailable::TimeoutError
+    raise TimeoutError
   end
 
   private

--- a/app/validators/email_recently_verified_validator.rb
+++ b/app/validators/email_recently_verified_validator.rb
@@ -21,7 +21,10 @@ class EmailRecentlyVerifiedValidator < ActiveModel::EachValidator
 
   def create_or_refresh_verified_email!(email)
     EmailVerifierJob.new.perform(email)
+  # rubocop:disable Lint/SuppressedException
+  rescue EmailVerifierAPI::TimeoutError
   end
+  # rubocop:enable Lint/SuppressedException
 
   def track_errors_on_sentry(record, attribute, error_type)
     Sentry.capture_message(

--- a/spec/validators/email_recently_verified_validator_spec.rb
+++ b/spec/validators/email_recently_verified_validator_spec.rb
@@ -114,5 +114,19 @@ RSpec.describe EmailRecentlyVerifiedValidator do
         expect(subject.errors[:email].to_s).to include('pu être vérifiée')
       end
     end
+
+    context 'when EmailVerifierJob raises a timeout error' do
+      before do
+        allow(email_verifier_job).to receive(:perform).and_raise(EmailVerifierAPI::TimeoutError)
+      end
+
+      it { is_expected.not_to be_valid }
+
+      it 'adds email_unreachable error on attribute' do
+        subject.valid?
+
+        expect(subject.errors[:email].to_s).to include('pu être vérifiée')
+      end
+    end
   end
 end


### PR DESCRIPTION
Use a generic TimeoutError for EmailVerifierAPI in order to keep Emailable within this API.

Closes https://errors.data.gouv.fr/organizations/sentry/issues/142711/events/cb22af3a0bd14e47b94de545bdc69ca3/