### PR TITLE
Harden reopening action

### DIFF
--- a/app/controllers/reopen_authorizations_controller.rb
+++ b/app/controllers/reopen_authorizations_controller.rb
@@ -33,7 +33,8 @@ class ReopenAuthorizationsController < AuthenticatedUserController
   end
 
   def extract_authorization
-    @authorization = Authorization.friendly.find(params[:authorization_id])
+    authorization_request = AuthorizationRequest.find(params[:authorization_request_id])
+    @authorization = authorization_request.authorizations.friendly.find(params[:authorization_id])
   end
 
   def authorize_authorization_reopening

--- a/app/views/authorization_request_forms/build/_header.html.erb
+++ b/app/views/authorization_request_forms/build/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="authorization-request-form-header">
   <div class="fr-container">
     <div class="fr-grid-row">
-      
+
       <div class="fr-col-12 fr-col-md-8">
         <%= render partial: "authorization_requests/shared/title" %>
 
@@ -15,7 +15,7 @@
           <% end %>
 
           <% if policy(@authorization.try(:request) || @authorization_request).reopen? %>
-            <%= dsfr_main_modal_button t('authorization_request_forms.form.reopen'), new_authorization_reopen_path(@authorization_request.latest_authorization), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
+            <%= dsfr_main_modal_button t('authorization_request_forms.form.reopen'), new_authorization_request_authorization_reopening_path(authorization_request_id: @authorization_request.id, authorization_id: @authorization_request.latest_authorization.id), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
           <% end %>
 
           <% if policy(@authorization_request).archive? %>

--- a/app/views/authorization_request_forms/build/_header.html.erb
+++ b/app/views/authorization_request_forms/build/_header.html.erb
@@ -15,7 +15,7 @@
           <% end %>
 
           <% if policy(@authorization.try(:request) || @authorization_request).reopen? %>
-            <%= dsfr_main_modal_button t('authorization_request_forms.form.reopen'), new_authorization_request_authorization_reopening_path(authorization_request_id: @authorization_request.id, authorization_id: @authorization_request.latest_authorization.id), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
+            <%= dsfr_main_modal_button t('authorization_request_forms.form.reopen'), url_for(controller: 'reopen_authorizations', action: 'new', authorization_request_id: @authorization_request.id, authorization_id: @authorization_request.latest_authorization.id), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
           <% end %>
 
           <% if policy(@authorization_request).archive? %>

--- a/app/views/dashboard/card/_authorization_request_card.html.erb
+++ b/app/views/dashboard/card/_authorization_request_card.html.erb
@@ -35,7 +35,7 @@
 
       <div class="card__actions_btn">
         <% if policy(authorization_request).reopen? %>
-          <%= dsfr_main_modal_button t('.reopen_cta'), new_authorization_reopen_path(authorization_request.latest_authorization), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
+          <%= dsfr_main_modal_button t('.reopen_cta'), new_authorization_request_authorization_reopening_path(authorization_request_id: authorization_request.id, authorization_id: authorization_request.latest_authorization.id), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
         <% end %>
 
         <% if authorization_request.already_been_validated? %>

--- a/app/views/dashboard/card/_authorization_request_card.html.erb
+++ b/app/views/dashboard/card/_authorization_request_card.html.erb
@@ -35,7 +35,7 @@
 
       <div class="card__actions_btn">
         <% if policy(authorization_request).reopen? %>
-          <%= dsfr_main_modal_button t('.reopen_cta'), new_authorization_request_authorization_reopening_path(authorization_request_id: authorization_request.id, authorization_id: authorization_request.latest_authorization.id), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
+          <%= dsfr_main_modal_button t('.reopen_cta'), url_for(controller: 'reopen_authorizations', action: 'new', authorization_request_id: authorization_request.id, authorization_id: authorization_request.latest_authorization.id), class: %w(fr-btn fr-btn--secondary fr-btn--sm) %>
         <% end %>
 
         <% if authorization_request.already_been_validated? %>

--- a/app/views/reopen_authorizations/new.html.erb
+++ b/app/views/reopen_authorizations/new.html.erb
@@ -15,7 +15,7 @@
         <div class="fr-modal__footer">
           <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
             <%= link_to t('.cancel'), '#', class: %w(fr-btn fr-btn--secondary), aria: { controls: 'main-modal' } %>
-            <%= button_to t('.reopen'), authorization_reopen_index_path(@authorization), class: %w(fr-btn fr-btn--primary fr-icon-success-line fr-btn--icon-left) %>
+            <%= button_to t('.reopen'), authorization_request_authorization_reopening_index_path(authorization_request_id: @authorization.request_id, authorization_id: @authorization.id), class: %w(fr-btn fr-btn--primary fr-icon-success-line fr-btn--icon-left) %>
           </div>
         </div>
       </turbo-frame>

--- a/app/views/reopen_authorizations/new.html.erb
+++ b/app/views/reopen_authorizations/new.html.erb
@@ -15,7 +15,7 @@
         <div class="fr-modal__footer">
           <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
             <%= link_to t('.cancel'), '#', class: %w(fr-btn fr-btn--secondary), aria: { controls: 'main-modal' } %>
-            <%= button_to t('.reopen'), authorization_request_authorization_reopening_index_path(authorization_request_id: @authorization.request_id, authorization_id: @authorization.id), class: %w(fr-btn fr-btn--primary fr-icon-success-line fr-btn--icon-left) %>
+            <%= button_to t('.reopen'), url_for(controller: 'reopen_authorizations', action: 'create', authorization_request_id: @authorization.request_id, authorization_id: @authorization.id), class: %w(fr-btn fr-btn--primary fr-icon-success-line fr-btn--icon-left) %>
           </div>
         </div>
       </turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,9 +57,9 @@ Rails.application.routes.draw do
 
     get 'demandes/:id/reopen-from-external', to: 'external_reopen_authorization_requests#create'
 
-    resources :authorization_requests, only: [], path: 'demandes' do
-      resources :authorizations, only: [], path: 'habilitations' do
-        resources :reopen_authorizations, only: %w[new create], path: 'réouvrir', as: :reopening
+    resources :authorization_requests, only: [] do
+      resources :authorizations, only: [] do
+        resources :reopen_authorizations, only: %w[new create]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,8 +57,10 @@ Rails.application.routes.draw do
 
     get 'demandes/:id/reopen-from-external', to: 'external_reopen_authorization_requests#create'
 
-    resources :authorizations, only: [], path: 'habilitations' do
-      resources :reopen_authorizations, only: %w[new create], path: 'réouvrir', as: :reopen
+    resources :authorization_requests, only: [], path: 'demandes' do
+      resources :authorizations, only: [], path: 'habilitations' do
+        resources :reopen_authorizations, only: %w[new create], path: 'réouvrir', as: :reopening
+      end
     end
   end
 

--- a/spec/controllers/external_reopen_authorization_requests_controller_spec.rb
+++ b/spec/controllers/external_reopen_authorization_requests_controller_spec.rb
@@ -5,10 +5,7 @@ RSpec.describe ExternalReopenAuthorizationRequestsController do
     let(:user) { create(:user) }
 
     before do
-      session[:user_id] = {
-        'value' => user.id,
-        'expires_at' => 1.hour.from_now,
-      }
+      sign_in(user)
     end
 
     context 'when the authorization request is not validated' do

--- a/spec/controllers/reopen_authorizations_controller_spec.rb
+++ b/spec/controllers/reopen_authorizations_controller_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe ReopenAuthorizationsController, type: :controller do
+  subject(:get_new_reopening) { get :new, params: { authorization_id: authorization.id, authorization_request_id: authorization.request_id } }
+
+  let!(:valid_authorization) { create(:authorization, applicant: user, slug: friendly_id) }
+  let!(:invalid_authorization) { create(:authorization, slug: friendly_id) }
+  let(:friendly_id) { '2024-01-01' }
+
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+  end
+
+  context 'when we try to reopen an authorization belonging to the current user' do
+    let(:authorization) { valid_authorization }
+
+    it 'is ok' do
+      expect(get_new_reopening).to have_http_status(:ok)
+    end
+  end
+
+  context 'when we try to reopen an authorization not belonging to the current user' do
+    let(:authorization) { invalid_authorization }
+
+    it 'redirects to dashboard path' do
+      expect(get_new_reopening).to have_http_status(302)
+      expect(response).to redirect_to(dashboard_path)
+    end
+  end
+end

--- a/spec/factories/authorizations.rb
+++ b/spec/factories/authorizations.rb
@@ -10,7 +10,12 @@ FactoryBot.define do
         evaluator.authorization_request_trait,
         :validated
       )
-      authorization.applicant = authorization.request.applicant
+      if authorization.applicant.nil?
+        authorization.applicant = authorization.request.applicant
+      else
+        authorization.request.applicant = authorization.applicant
+        authorization.request.organization = authorization.applicant.current_organization
+      end
       authorization.data = authorization.request.data.dup
 
       authorization.data['what'] = 'ever' if authorization.data.blank?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
   config.include SessionsHelpers, type: :feature
   config.include FeaturesHelpers, type: :feature
   config.include FixturesHelpers
+  config.include ControllersHelpers, type: :controller
   config.include INSEESireneAPIMocks
   config.include HubEEAPIClientMocks
 

--- a/spec/support/controllers_helpers.rb
+++ b/spec/support/controllers_helpers.rb
@@ -1,0 +1,8 @@
+module ControllersHelpers
+  def sign_in(user)
+    session[:user_id] = {
+      'value' => user.id,
+      'expires_at' => 1.hour.from_now,
+    }
+  end
+end


### PR DESCRIPTION
Previously the `extract_authorization` used to find first authorization
with valid slug, which is a simple date. However our model should use a
couple (request_id, slug) to find the valid authorization.

This bug used to cause forbidden access to some users (check controller
test)