### PR TITLE
Enhance unauthenticated start page according to authorization definition type

### DIFF
--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -6,6 +6,7 @@ class AuthorizationDefinition < StaticApplicationRecord
     :link,
     :access_link,
     :cgu_link,
+    :kind,
     :scopes,
     :blocks,
     :unique
@@ -41,6 +42,7 @@ class AuthorizationDefinition < StaticApplicationRecord
         :cgu_link,
         :access_link,
         :public,
+        :kind,
         :startable_by_applicant,
         :unique,
       ).merge(

--- a/app/views/authorization_requests/shared/unauthenticated_pages/_timeline_steps.html.erb
+++ b/app/views/authorization_requests/shared/unauthenticated_pages/_timeline_steps.html.erb
@@ -4,28 +4,28 @@
       <div>
         <%= image_tag "pictograms/homepage/identification.svg", alt: "identification", class: %w(fr-responsive-img) %>
       </div>
-      <div><%= t('authorization_requests.unauthenticated_start.etape_1') %></div>
+      <div><%= t('authorization_requests.unauthenticated_start.timeline_steps.step_1') %></div>
     </div>
 
     <div>
       <div>
         <%= image_tag "pictograms/homepage/demande.svg", alt: "identification", class: %w(fr-responsive-img) %>
       </div>
-      <div><%= t('authorization_requests.unauthenticated_start.etape_2') %></div>
+      <div><%= t('authorization_requests.unauthenticated_start.timeline_steps.step_2') %></div>
     </div>
 
     <div>
       <div>
         <%= image_tag "pictograms/homepage/habilitation.svg", alt: "identification", class: %w(fr-responsive-img) %>
       </div>
-      <div><%= t('authorization_requests.unauthenticated_start.etape_3') %></div>
+      <div><%= t('authorization_requests.unauthenticated_start.timeline_steps.step_3') %></div>
     </div>
 
     <div>
       <div>
         <%= image_tag "pictograms/homepage/token.svg", alt: "identification", class: %w(fr-responsive-img) %>
       </div>
-      <div><%= t('authorization_requests.unauthenticated_start.etape_4') %></div>
+      <div><%= t("authorization_requests.unauthenticated_start.timeline_steps.step_4.#{@authorization_definition.kind}") %></div>
     </div>
   </div>
 

--- a/app/views/authorization_requests/unauthenticated_start.html.erb
+++ b/app/views/authorization_requests/unauthenticated_start.html.erb
@@ -9,7 +9,7 @@
         </h1>
 
         <p>
-          <%= simple_format(t '.sub_title', api_name: @authorization_definition.name) %>
+          <%= t(".sub_title.#{@authorization_definition.kind}", authorization_definition_name: @authorization_definition.name).html_safe %>
         </p>
 
         <%= render partial: 'authorization_requests/shared/unauthenticated_pages/timeline_steps' %>

--- a/config/authorization_definitions.yml
+++ b/config/authorization_definitions.yml
@@ -5,6 +5,7 @@ shared:
     description: "Formulaire d'abonnement à la démarche Certificats de Décès Électroniques Dématérialisés"
     cgu_link: "/cgus/20210212_dinum_hubee_cgu_v2_1_0_version_site.pdf"
     access_link: https://portail.hubee.numerique.gouv.fr
+    kind: 'service'
     provider: "hubee"
     public: true
     unique: true
@@ -17,6 +18,7 @@ shared:
     cgu_link: "/cgus/20210212_dinum_hubee_cgu_v2_1_0_version_site.pdf"
     access_link: https://portail.hubee.numerique.gouv.fr
     provider: "hubee"
+    kind: 'service'
     public: true
     unique: true
     blocks:
@@ -43,6 +45,7 @@ shared:
     name: "API Entreprise"
     description: "Entités administratives, simplifiez les démarches des entreprises et des associations en récupérant pour elles leurs informations administratives."
     provider: "dinum"
+    kind: 'api'
     link: "https://api.gouv.fr/les-api/api-entreprise"
     cgu_link: "https://entreprise.api.gouv.fr/cgu"
     access_link: https://entreprise.api.gouv.fr/compte/jetons/%{external_provider_id}
@@ -184,6 +187,7 @@ shared:
     provider: "dinum"
     link: "https://api.gouv.fr/les-api/api-particulier"
     access_link: https://particulier.api.gouv.fr/compte/jetons/%{external_provider_id}
+    kind: 'api'
     public: true
     blocks:
       - name: "basic_infos"
@@ -301,6 +305,7 @@ shared:
     name: "API Service National"
     description: "Vérifiez si un candidat est en règle vis-à-vis de ses obligations de Service National et peut s’inscrire au concours ou à l’examen dont vous êtes en charge."
     public: true
+    kind: 'api'
     cgu_link: "https://presaje.sga.defense.gouv.fr/cgu-dln1f"
     provider: "ministere_des_armees"
     blocks:
@@ -313,6 +318,7 @@ shared:
     name: "API CaptchEtat"
     description: "Générer un CAPTCHA pour sécuriser un service en ligne"
     public: true
+    kind: 'api'
     link: "https://api.gouv.fr/les-api/api-captchetat"
     cgu_link: "/cgus/cgu_api_captchetat_v_1_2.pdf"
     provider: "aife"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -93,6 +93,40 @@
       "note": ""
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "8cc63b2aec121ed7f45c7ec76737bedfa7dff8eee97c70cb7edce800ca1acd8b",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/authorization_requests/unauthenticated_start.html.erb",
+      "line": 12,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "t(\".sub_title.#{AuthorizationRequestForm.find(params[:form_uid]).decorate.authorization_definition.kind}\", :authorization_definition_name => AuthorizationRequestForm.find(params[:form_uid]).decorate.authorization_definition.name)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "AuthorizationRequestFormsController",
+          "method": "new",
+          "line": 19,
+          "file": "app/controllers/authorization_request_forms_controller.rb",
+          "rendered": {
+            "name": "authorization_requests/unauthenticated_start",
+            "file": "app/views/authorization_requests/unauthenticated_start.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "authorization_requests/unauthenticated_start"
+      },
+      "user_input": "AuthorizationRequestForm.find(params[:form_uid]).decorate",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Dangerous Send",
       "warning_code": 23,
       "fingerprint": "cd5690fd7ab199e5fa1e8ec5bebf78691dbc407680a2f4638f195c0c4396601b",
@@ -116,6 +150,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-08-12 14:07:23 +0000",
-  "brakeman_version": "6.1.2"
+  "updated": "2024-09-20 10:56:12 +0200",
+  "brakeman_version": "6.2.1"
 }

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -156,11 +156,24 @@ fr:
 
   authorization_requests:
     unauthenticated_start:
-      sub_title: "Vous souhaitez accédez à l’<strong>%{api_name}</strong> \n Votre demande d’habilitation va se dérouler en 4 étapes"
-      etape_1: S’identifier avec MonComptePro
-      etape_2: Remplir ma demande
-      etape_3: Être habilité
-      etape_4: Accéder au service
+      sub_title:
+        service: |
+          Vous souhaitez abonner votre structure au service <strong>%{authorization_definition_name}</strong>
+          <br/>
+          Votre demande d’habilitation va se dérouler en 4 étapes
+        api: |
+          Vous souhaitez accédez à l’<strong>%{authorization_definition_name}</strong>
+          <br/>
+          Votre demande d’habilitation va se dérouler en 4 étapes
+      timeline_steps:
+        step_1: S’identifier avec MonComptePro
+        step_2: Remplir ma demande
+        step_3: Être habilité
+        step_4:
+          api: Obtenir le jeton d’accès
+          service: Accéder au service
+
+
     new:
       default:
         title: &start_new_habilitation_title Demander une habilitation pour %{authorization_name}

--- a/docs/new_provider.md
+++ b/docs/new_provider.md
@@ -47,6 +47,10 @@ Pour la configuration de la [définition (1.)](../config/authorization_definitio
     link: https://mon-api.gouv.fr
     # Lien vers les CGU
     cgu_link: https://mon-api.gouv.fr/cgu.pdf
+    # Type de service. Valeurs possibles: api, service.
+    # Cette valeur sert principalement à personnaliser les textes, notamment sur la page de
+    # démarrage d'une demande.
+    kind: 'api'
     # Optionnel. Affiche ou non cette source de données dans l'index des formulaires. Par défaut à `true`
     public: true
     # Optionnel. Détermine si il ne peut y avoir qu'un seul formulaire par organisation. Par défaut à `false`

--- a/docs/new_provider.md
+++ b/docs/new_provider.md
@@ -47,7 +47,7 @@ Pour la configuration de la [définition (1.)](../config/authorization_definitio
     link: https://mon-api.gouv.fr
     # Lien vers les CGU
     cgu_link: https://mon-api.gouv.fr/cgu.pdf
-    # Affiche ou non cette source de données dans l'index des formulaires
+    # Optionnel. Affiche ou non cette source de données dans l'index des formulaires. Par défaut à `true`
     public: true
     # Optionnel. Détermine si il ne peut y avoir qu'un seul formulaire par organisation. Par défaut à `false`
     unique: false


### PR DESCRIPTION
J'étais pas parti pour faire cette PR, je voulais à l'origine corriger une typo relevé pendant de la Q&A de base pour la MeP d'HubEE:

![Screenshot 2024-09-20 at 10 44 52](https://github.com/user-attachments/assets/ff454152-73ab-4c5b-b25c-80f4dd8b1b1a)

Je suis allé voir comment c'était sur la v1, je me suis rendu compte qu'on faisait une disjonction en fonction du "type" d'habilitation 👇

![Screenshot 2024-09-20 at 09 49 36](https://github.com/user-attachments/assets/a39896b6-7d1d-43ac-b3ea-e7567f1f4398)
![Screenshot 2024-09-20 at 09 49 28](https://github.com/user-attachments/assets/7ab4ebb5-0a8b-429c-8b2b-8bf73410f65f)

Pour le contexte, les ajustements de wordings sont ici: https://github.com/betagouv/datapass/tree/master/frontend/src/components/templates/Login/NextSteps.tsx et https://github.com/betagouv/datapass/tree/master/frontend/src/components/templates/Login/index.tsx

J'ai failli ditch le fix, mais il s'avère que faire l'effort d'itérer sur ce type dans la définition allait grandement simplifier le travail d'Isabelle sur [cette PR](https://github.com/etalab/data_pass/pull/433), grace notamment à ce nouvel attribut `kind`.

J'ai donc itéré dans ce sens:

![Screenshot 2024-09-20 at 10 55 07](https://github.com/user-attachments/assets/a101b473-ea85-4001-a38b-3ae9a59e50a3)
![Screenshot 2024-09-20 at 10 49 17](https://github.com/user-attachments/assets/cba605a2-ac2d-4071-ac13-2c8d80d53532)

C'est pas exactement la même chose, faudrait peut-être revoir un peu (j'ai un doute sur le nom du type d'habilitation pour HubEEDila typiquement, c'est peu compréhensible et les commentaires de l'équipe sur l'autre PR vont dans le même sens).

Je suis pas super fan de `kind` mais j'ai pas trouvé mieux..