### PR TITLE
Instruction: save search params on authorization request index

### DIFF
--- a/app/controllers/instruction/authorization_requests_controller.rb
+++ b/app/controllers/instruction/authorization_requests_controller.rb
@@ -1,5 +1,7 @@
 class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthorizationRequestsController
   before_action :redirect_to_searched_authorization_request, only: [:index]
+  before_action :save_or_load_search_params, only: [:index]
+
   skip_before_action :extract_authorization_request, only: :index
 
   def index
@@ -51,5 +53,14 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
 
   def extract_authorization_request
     @authorization_request = AuthorizationRequest.find(params[:id]).decorate
+  end
+
+  def save_or_load_search_params
+    session[search_key] = params[:q] if params[:q].present?
+    params[:q] = session[search_key] if params[:q].blank?
+  end
+
+  def search_key
+    :"#{controller_name}_#{action_name}_search"
   end
 end

--- a/app/controllers/instruction/authorization_requests_controller.rb
+++ b/app/controllers/instruction/authorization_requests_controller.rb
@@ -9,7 +9,7 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
 
     base_relation = base_relation.none if search_terms_is_a_possible_id?
 
-    @search_engine = base_relation.ransack(params[:q])
+    @search_engine = base_relation.ransack(params[:search_query])
     @search_engine.sorts = 'last_submitted_at desc' if @search_engine.sorts.empty?
 
     @authorization_requests = build_search_engine_results_with_order_which_puts_null_as_last.page(params[:page])
@@ -26,7 +26,7 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   def redirect_to_searched_authorization_request
     return unless search_terms_is_a_possible_id?
 
-    potential_authorization_request = AuthorizationRequest.find_by(id: params[:q][:within_data_or_organization_siret_or_applicant_email_or_applicant_family_name_cont].to_i)
+    potential_authorization_request = AuthorizationRequest.find_by(id: params[:search_query][:within_data_or_organization_siret_or_applicant_email_or_applicant_family_name_cont].to_i)
 
     return unless potential_authorization_request
 
@@ -38,9 +38,9 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   end
 
   def search_terms_is_a_possible_id?
-    return false if params[:q].blank?
+    return false if params[:search_query].blank?
 
-    main_search_input = params[:q][:within_data_or_organization_siret_or_applicant_email_or_applicant_family_name_cont]
+    main_search_input = params[:search_query][:within_data_or_organization_siret_or_applicant_email_or_applicant_family_name_cont]
 
     return false if main_search_input.blank?
 
@@ -56,8 +56,8 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   end
 
   def save_or_load_search_params
-    session[search_key] = params[:q] if params[:q].present?
-    params[:q] = session[search_key] if params[:q].blank?
+    session[search_key] = params[:search_query] if params[:search_query].present?
+    params[:search_query] = session[search_key] if params[:search_query].blank?
   end
 
   def search_key

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,3 @@
+Ransack.configure do |c|
+  c.search_key = :search_query
+end

--- a/spec/features/instruction/search_spec.rb
+++ b/spec/features/instruction/search_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe 'Instruction: habilitation search' do
     visit instruction_authorization_requests_path
 
     within('#authorization_request_search') do
-      fill_in 'q_within_data_or_organization_siret_or_applicant_email_or_applicant_family_name_cont', with: search_text if use_search_text
-      select state, from: 'q_state_eq' if state
-      select type, from: 'q_type_eq' if type
+      fill_in 'search_query_within_data_or_organization_siret_or_applicant_email_or_applicant_family_name_cont', with: search_text if use_search_text
+      select state, from: 'search_query_state_eq' if state
+      select type, from: 'search_query_type_eq' if type
 
       click_link_or_button
     end


### PR DESCRIPTION
Allow instructors to save some clics on redirect after instruction.

Closes https://linear.app/pole-api/issue/DAT-563