### PR TITLE
Temporary fix for HubEE redirects from v1

### DIFF
--- a/app/controllers/authorization_requests_controller.rb
+++ b/app/controllers/authorization_requests_controller.rb
@@ -1,5 +1,6 @@
 class AuthorizationRequestsController < AuthenticatedUserController
   helper AuthorizationRequestsHelpers
+  include SubdomainsHelper
 
   allow_unauthenticated_access only: %i[new show]
 
@@ -30,6 +31,10 @@ class AuthorizationRequestsController < AuthenticatedUserController
     else
       show_as_guest_user
     end
+  rescue ActiveRecord::RecordNotFound
+    raise unless registered_subdomain? && registered_subdomain.id == 'hubee'
+
+    redirect_to dashboard_path
   end
 
   private


### PR DESCRIPTION
Because of the merge of several authorization requests, some of them from v1 no longer exists for HubEE on v2. In order to avoid dummy 404 on the redirection, we redirect them to the dashboard instead. It's not an ideal situation but it will be OK until the final migration.