### PR TITLE
Changelog: always displays entities

### DIFF
--- a/app/decorators/authorization_request_event_decorator.rb
+++ b/app/decorators/authorization_request_event_decorator.rb
@@ -18,15 +18,17 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
     end
   end
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def text
     case name
     when 'refuse', 'request_changes', 'revoke', 'cancel_reopening_from_instructor'
       h.simple_format(entity.reason)
     when 'applicant_message', 'instructor_message'
       h.simple_format(entity.body)
-    when 'initial_submit_with_changes_on_prefilled_data', 'submit_with_changes', 'admin_update'
+    when 'initial_submit_with_changes_on_prefilled_data', 'submit_with_changes'
       humanized_changelog
+    when 'admin_update'
+      humanized_changelog(isolated: true)
     when 'transfer'
       if entity.from_type == 'User'
         "#{entity.to.full_name} (#{entity.to.email})"
@@ -35,7 +37,7 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def copied_from_authorization_request_id
     return unless name == 'copy'
@@ -45,9 +47,11 @@ class AuthorizationRequestEventDecorator < ApplicationDecorator
 
   private
 
-  def humanized_changelog
+  def humanized_changelog(isolated: false)
+    changelog_entries = isolated ? changelog_presenter.entries_builder(entity.diff) : changelog_presenter.consolidated_changelog_entries
+
     h.content_tag(:ul) do
-      changelog_presenter.consolidated_changelog_entries.map { |entry|
+      changelog_entries.map { |entry|
         h.content_tag(:li, entry)
       }.join.html_safe
     end

--- a/app/services/authorization_request_changelog_presenter.rb
+++ b/app/services/authorization_request_changelog_presenter.rb
@@ -30,17 +30,15 @@ class AuthorizationRequestChangelogPresenter
   def consolidated_changelog_entries
     case event_name
     when 'initial_submit_with_changes_on_prefilled_data'
-      changelog_builder(changelog_diff_without_unchanged_prefilled_values_and_new_values)
+      entries_builder(changelog_diff_without_unchanged_prefilled_values_and_new_values)
     when 'submit_with_changes'
-      changelog_builder(changelog_diff)
+      entries_builder(changelog_diff)
     else
       []
     end
   end
 
-  private
-
-  def changelog_builder(diffs)
+  def entries_builder(diffs)
     diffs.map { |attribute, values|
       values = sanitize_values(attribute, values)
 
@@ -53,6 +51,8 @@ class AuthorizationRequestChangelogPresenter
       end
     }.flatten
   end
+
+  private
 
   def sanitize_values(attribute, values)
     case attribute


### PR DESCRIPTION
AuthorizationRequestChangelogPresenter is based on event and legacy boolean to filter diffs keys. There's no need to make this filter for admin update.

Closes https://linear.app/pole-api/issue/DAT-554