### PR TITLE
Changelog: always displays changelog entries on admin update

### DIFF
--- a/app/services/authorization_request_changelog_presenter.rb
+++ b/app/services/authorization_request_changelog_presenter.rb
@@ -5,8 +5,9 @@ class AuthorizationRequestChangelogPresenter
 
   delegate :t, to: I18n
 
-  def initialize(changelog)
+  def initialize(changelog, from_admin: true)
     @changelog = changelog
+    @from_admin = from_admin
   end
 
   def event_name
@@ -28,6 +29,8 @@ class AuthorizationRequestChangelogPresenter
   end
 
   def consolidated_changelog_entries
+    return changelog_builder(changelog_diff) if from_admin?
+
     case event_name
     when 'initial_submit_with_changes_on_prefilled_data'
       changelog_builder(changelog_diff_without_unchanged_prefilled_values_and_new_values)
@@ -167,5 +170,9 @@ class AuthorizationRequestChangelogPresenter
 
   def authorization_request
     changelog.authorization_request
+  end
+
+  def from_admin?
+    @from_admin
   end
 end

--- a/spec/services/authorization_request_changelog_presenter_spec.rb
+++ b/spec/services/authorization_request_changelog_presenter_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe AuthorizationRequestChangelogPresenter do
-  let(:instance) { described_class.new(changelog) }
+  let(:instance) { described_class.new(changelog, from_admin:) }
   let(:changelog) { AuthorizationRequestChangelog.create!(diff:, authorization_request:) }
   let(:authorization_request) { create(:authorization_request) }
+  let(:from_admin) { false }
 
   let(:initial_no_prefilled_data_diff) do
     {
@@ -96,6 +97,23 @@ RSpec.describe AuthorizationRequestChangelogPresenter do
 
   describe '#consolidated_changelog_entries' do
     subject(:changelog_entries) { instance.consolidated_changelog_entries }
+
+    context 'when is from admin' do
+      let(:diff) do
+        {
+          'attr1' => %w[old_value1 new_value1],
+          'attr2' => %w[value2 value2],
+          'attr3' => [nil, 'value3'],
+        }
+      end
+      let(:from_admin) { true }
+
+      it 'displays only keys with changed data' do
+        expect(changelog_entries.count).to eq(2)
+        expect(changelog_entries[0]).to match(/Attr1.*a changé.*old_value1.*new_value1/)
+        expect(changelog_entries[1]).to match(/Attr3.*initialisé.*value3/)
+      end
+    end
 
     context 'when it is the first changelog' do
       context 'when all first values are nil (no prefilled data)' do


### PR DESCRIPTION
No need to filter keys when it is an admin update: displays changelog no matter what.