### PR TITLE
Introduce default reason for request changes instruction

### DIFF
--- a/app/controllers/instruction/request_changes_on_authorization_requests_controller.rb
+++ b/app/controllers/instruction/request_changes_on_authorization_requests_controller.rb
@@ -3,6 +3,8 @@ class Instruction::RequestChangesOnAuthorizationRequestsController < Instruction
 
   def new
     @instructor_modification_request = @authorization_request.modification_requests.build
+
+    AffectDefaultReasonToInstructionModificationRequest.call(instructor_modification_request: @instructor_modification_request)
   end
 
   def create

--- a/app/interactors/affect_default_reason_to_instruction_modification_request.rb
+++ b/app/interactors/affect_default_reason_to_instruction_modification_request.rb
@@ -1,0 +1,23 @@
+class AffectDefaultReasonToInstructionModificationRequest < ApplicationInteractor
+  def call
+    return unless authorization_definition_default_reason
+
+    context.instructor_modification_request.reason ||= authorization_definition_default_reason
+  end
+
+  private
+
+  def authorization_definition_default_reason
+    return unless File.exist?(authorization_definition_default_reason_file_path)
+
+    File.read(authorization_definition_default_reason_file_path)
+  end
+
+  def authorization_definition_default_reason_file_path
+    Rails.root.join('config', 'instruction_default_modification_request_texts', "#{authorization_request.kind}.text")
+  end
+
+  def authorization_request
+    context.instructor_modification_request.authorization_request
+  end
+end

--- a/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
+++ b/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
@@ -25,7 +25,7 @@
               <%= t(".#{namespace}.description.disclaimer").html_safe %>
             </p>
 
-            <%= f.dsfr_text_area :reason, required: true %>
+            <%= f.dsfr_text_area :reason, required: true, rows: 6 %>
           </div>
 
           <div class="fr-modal__footer">

--- a/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
+++ b/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
@@ -25,7 +25,7 @@
               <%= t(".#{namespace}.description.disclaimer").html_safe %>
             </p>
 
-            <%= f.dsfr_text_area :reason %>
+            <%= f.dsfr_text_area :reason, required: true %>
           </div>
 
           <div class="fr-modal__footer">

--- a/config/instruction_default_modification_request_texts/hubee_cert_dc.text
+++ b/config/instruction_default_modification_request_texts/hubee_cert_dc.text
@@ -1,0 +1,8 @@
+Vous avez indiqué le Maire comme étant l’ « Administrateur métier ».
+
+Sachez que l’administrateur métier est la personne qui bénéficiera des rôles de « Gestion des comptes utilisateurs » des agents instructeurs et de « Gestion des abonnements » aux démarches de votre commune.
+De ce fait, cette personne doit être impliquée dans l’utilisation fonctionnelle et quotidienne des demandes des usagers.
+
+M. le Maire n’étant pas la personne au plus près du traitement quotidien des demandes des usagers, il n'est donc pas nécessaire de l'indiquer en tant qu’Administrateur métier.
+
+Merci d’indiquer une personne faisant partie de votre service État Civil (vous-même si c’est le cas) et de soumettre à nouveau votre demande.

--- a/config/instruction_default_modification_request_texts/hubee_dila.text
+++ b/config/instruction_default_modification_request_texts/hubee_dila.text
@@ -1,0 +1,8 @@
+Vous avez indiqué le Maire comme étant l’ « Administrateur métier ».
+
+Sachez que l’administrateur métier est la personne qui bénéficiera des rôles de « Gestion des comptes utilisateurs » des agents instructeurs et de « Gestion des abonnements » aux démarches de votre commune.
+De ce fait, cette personne doit être impliquée dans l’utilisation fonctionnelle et quotidienne des demandes des usagers.
+
+M. le Maire n’étant pas la personne au plus près du traitement quotidien des demandes des usagers, il n'est donc pas nécessaire de l'indiquer en tant qu’Administrateur métier.
+
+Merci d’indiquer une personne faisant partie de votre service État Civil (vous-même si c’est le cas) et de soumettre à nouveau votre demande.

--- a/spec/interactors/affect_default_reason_to_instruction_modification_request_spec.rb
+++ b/spec/interactors/affect_default_reason_to_instruction_modification_request_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe AffectDefaultReasonToInstructionModificationRequest, type: :interactor do
+  subject(:instructor_modification_request_reason) { described_class.call(instructor_modification_request:).instructor_modification_request.reason }
+
+  let(:instructor_modification_request) { authorization_request.modification_requests.build }
+
+  describe 'with an authorization request kind with a custom default reason' do
+    let(:authorization_request) { create(:authorization_request, :hubee_cert_dc) }
+
+    it 'affects it' do
+      expect(instructor_modification_request_reason).to include('Maire')
+    end
+  end
+
+  describe 'without an authorization request kind with a custom default reason' do
+    let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+
+    it 'does not affect any default reason' do
+      expect(instructor_modification_request_reason).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
Displayed by default for instructors.
Quick win for HubEE (almost all reasons is the one mentionned in templates), we'll be replaced with future template system.