### PR TITLE
Harden HubEECertDCBridge

### DIFF
--- a/app/bridges/hubee_cert_dc_bridge.rb
+++ b/app/bridges/hubee_cert_dc_bridge.rb
@@ -10,5 +10,11 @@ class HubEECertDCBridge < HubEEBaseBridge
   def create_and_store_subscription(organization_hubee_payload, process_code)
     subscription_hubee_payload = hubee_api_client.create_subscription(subscription_body(organization_hubee_payload, process_code))
     authorization_request.update!(external_provider_id: subscription_hubee_payload['id'])
+  rescue HubEEAPIClient::AlreadyExistsError
+    raise unless authorization_request.external_provider_id.present? || authorization_request_reopening?
+  end
+
+  def authorization_request_reopening?
+    authorization_request.last_validated_at.present?
   end
 end

--- a/spec/bridges/hubee_cert_dc_bridge_spec.rb
+++ b/spec/bridges/hubee_cert_dc_bridge_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe HubEECertDCBridge do
   describe '#perform on approve' do
-    subject(:hubee_cert_dc_bridge) { described_class.perform_now(authorization_request, 'approve') }
+    subject(:hubee_cert_dc_bridge) { described_class.new.perform(authorization_request, 'approve') }
 
     let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated, organization:) }
     let(:organization) { create(:organization, siret: '21920023500014') }
@@ -10,25 +10,40 @@ RSpec.describe HubEECertDCBridge do
     let(:hubee_subscription_id) { '1234567890' }
 
     include_examples 'with mocked hubee API client'
-
     include_examples 'organization creation in hubee on approve'
 
     describe 'subscription creation' do
-      it 'does create a subscription on HubEE linked to DataPass ID and CERTDC process code' do
-        expect(hubee_api_client).to receive(:create_subscription).with(
-          hash_including(
-            datapassId: authorization_request.id,
-            processCode: 'CERTDC'
+      context 'when client works' do
+        it 'does create a subscription on HubEE linked to DataPass ID and CERTDC process code' do
+          expect(hubee_api_client).to receive(:create_subscription).with(
+            hash_including(
+              datapassId: authorization_request.id,
+              processCode: 'CERTDC'
+            )
           )
-        )
 
-        hubee_cert_dc_bridge
+          hubee_cert_dc_bridge
+        end
+
+        it 'updates external_provider_id to HubEE subscription ID' do
+          hubee_cert_dc_bridge
+
+          expect(authorization_request.reload.external_provider_id).to eq(hubee_subscription_id)
+        end
       end
 
-      it 'updates external_provider_id to HubEE subscription ID' do
-        hubee_cert_dc_bridge
+      context 'when client raises an HubEEAPIClient::AlreadyExistsError' do
+        before do
+          allow(hubee_api_client).to receive(:create_subscription).and_raise(HubEEAPIClient::AlreadyExistsError)
+        end
 
-        expect(authorization_request.reload.external_provider_id).to eq(hubee_subscription_id)
+        context 'when it is a reopening' do
+          let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened, organization:) }
+
+          it 'does not raise an error' do
+            expect { hubee_cert_dc_bridge }.not_to raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Mitigate https://errors.data.gouv.fr/organizations/sentry/issues/146403/ : every single event from this issue is a reopening on a previously validated HubEE access.