### PR TITLE
Improve Hubee Mailer lisibility

### DIFF
--- a/app/mailers/hubee_mailer.rb
+++ b/app/mailers/hubee_mailer.rb
@@ -1,23 +1,22 @@
 class HubEEMailer < ApplicationMailer
-  def administrateur_metier_cert_dc
+  def administrateur_metier(kind)
     @authorization_request = params[:authorization_request]
 
     mail(
       to: @authorization_request.administrateur_metier_email,
-      subject: subject_for(__method__)
+      subject: subject_for(kind),
+      template_name: "administrateur_metier_#{kind}"
     )
   end
 
-  alias administrateur_metier_dila administrateur_metier_cert_dc
-
-  def subject_for(name)
-    case name
-    when :administrateur_metier_cert_dc
+  def subject_for(kind)
+    case kind
+    when :cert_dc
       'Vous avez été désigné administrateur local HubEE pour une démarche CertDC'
-    when :administrateur_metier_dila
+    when :dila
       'Vous avez été désigné administrateur local HubEE pour des démarches service-public.fr'
     else
-      raise "Unknown email name: #{name}"
+      raise "Unknown hubee email kind: #{kind}"
     end
   end
 end

--- a/app/notifiers/hubee_cert_dc_notifier.rb
+++ b/app/notifiers/hubee_cert_dc_notifier.rb
@@ -1,5 +1,5 @@
 class HubEECertDCNotifier < HubEENotifier
   def kind
-    'cert_dc'
+    :cert_dc
   end
 end

--- a/app/notifiers/hubee_dila_notifier.rb
+++ b/app/notifiers/hubee_dila_notifier.rb
@@ -1,5 +1,5 @@
 class HubEEDilaNotifier < HubEENotifier
   def kind
-    'dila'
+    :dila
   end
 end

--- a/app/notifiers/hubee_notifier.rb
+++ b/app/notifiers/hubee_notifier.rb
@@ -22,6 +22,6 @@ class HubEENotifier < BaseNotifier
   def notify_administrateur_metier
     HubEEMailer.with(
       authorization_request:,
-    ).public_send(:"administrateur_metier_#{kind}").deliver_later
+    ).administrateur_metier(kind).deliver_later
   end
 end

--- a/spec/mailers/hubee_mailer_spec.rb
+++ b/spec/mailers/hubee_mailer_spec.rb
@@ -1,31 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe HubEEMailer, type: :mailer do
-  describe '#administrateur_metier_cert_dc' do
-    let(:mail) { described_class.with(authorization_request:).administrateur_metier_cert_dc }
+  describe '#administrateur_metier' do
+    context 'with cert_dc' do
+      let(:mail) { described_class.with(authorization_request:).administrateur_metier(:cert_dc) }
 
-    let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }
+      let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }
 
-    it 'renders the headers' do
-      expect(mail.to).to eq([authorization_request.administrateur_metier_email])
+      it 'renders the headers' do
+        expect(mail.to).to eq([authorization_request.administrateur_metier_email])
+      end
+
+      it 'renders the body' do
+        expect(mail.body.encoded).to match('HubEE')
+      end
     end
 
-    it 'renders the body' do
-      expect(mail.body.encoded).to match('HubEE')
-    end
-  end
+    context 'with dila' do
+      let(:mail) { described_class.with(authorization_request:).administrateur_metier(:dila) }
 
-  describe '#administrateur_metier_dila' do
-    let(:mail) { described_class.with(authorization_request:).administrateur_metier_dila }
+      let(:authorization_request) { create(:authorization_request, :hubee_dila, :validated) }
 
-    let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }
+      it 'renders the headers' do
+        expect(mail.to).to eq([authorization_request.administrateur_metier_email])
+      end
 
-    it 'renders the headers' do
-      expect(mail.to).to eq([authorization_request.administrateur_metier_email])
-    end
-
-    it 'renders the body' do
-      expect(mail.body.encoded).to match('HubEE')
+      it 'renders the body' do
+        expect(mail.body.encoded).to match('HubEE')
+      end
     end
   end
 end

--- a/spec/mailers/previews/hubee_mailer_preview.rb
+++ b/spec/mailers/previews/hubee_mailer_preview.rb
@@ -1,10 +1,10 @@
 class HubEEMailerPreview < ActionMailer::Preview
   def administrateur_metier_cert_dc
-    HubEEMailer.with(authorization_request:).administrateur_metier_cert_dc
+    HubEEMailer.with(authorization_request:).administrateur_metier(:cert_dc)
   end
 
   def administrateur_metier_dila
-    HubEEMailer.with(authorization_request:).administrateur_metier_dila
+    HubEEMailer.with(authorization_request:).administrateur_metier(:dila)
   end
 
   private

--- a/spec/notifiers/hubee_notifier_spec.rb
+++ b/spec/notifiers/hubee_notifier_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe HubEENotifier, type: :notifier do
     before(:all) do
       class DummyHubEENotifier < HubEENotifier
         def kind
-          'cert_dc'
+          :cert_dc
         end
       end
     end


### PR DESCRIPTION
Proposition pour rendre plus lisible le mailer hubee, en remplaçant toute la metaprog par un petit paramètre `template_name`.