### PR TITLE
Bugfix unfocus on instruction search

### DIFF
--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -1,6 +1,6 @@
 <p class="fr-h2 fr-mt-5w"><%= t('.table.caption') %></p>
 
-<%= search_form_for(@search_engine, url: instruction_authorization_requests_path, html: { method: :get, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 300, 'auto-submit-form-event-mode-value' => 'input' }, class: %w[search-box] }) do |f| %>
+<%= search_form_for(@search_engine, url: instruction_authorization_requests_path, html: { method: :get, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 300, 'auto-submit-form-event-mode-value' => 'input', turbo_frame: 'authorization_requests_table' }, class: %w[search-box] }) do |f| %>
   <div class="search-inputs">
     <div class="fr-input-group main-input input">
       <%= f.label :within_data_or_organization_raison_sociale_or_organization_siret_or_applicant_email_or_applicant_family_name_cont, t('.search.main_input.label'), class: %w[fr-label] %>


### PR DESCRIPTION
Target a specific turbo-frame to reload, not the whole page, which leads to not lost the focus on the input.

Closes https://linear.app/pole-api/issue/DAT-658