### PR TITLE
API Particulier CCAS : add cadre juridique url for some cases

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -283,6 +283,7 @@ api-particulier-ccas-arche-mc2:
     description: Logiciel utilisé par des agents habilités de CCAS/CIAS dans le cadre de l'instruction de dossier de demandes d'aides sociales
     cadre_juridique_nature: &api_particulier_cadre_juridique_nature_ccas |
       Article L. 312-1 et Article R123-5 du code de l'action sociale et des familles. Article L114-8 et Article R. 114-9-3 du code des relations entre le public et l'administration.
+    cadre_juridique_url: &api_particulier_cadre_juridique_url_ccas_cnaf_scopes_only 'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038833680/'
     scopes:
       - cnaf_quotient_familial
       - cnaf_allocataires
@@ -314,6 +315,7 @@ api-particulier-ccas-arpege:
       et les services à la personne du CCAS
     description: Logiciel utilisé par des agents habilités de CCAS/CIAS dans le cadre de l'instruction de dossier de demandes d'aides sociales
     cadre_juridique_nature: *api_particulier_cadre_juridique_nature_ccas
+    cadre_juridique_url: *api_particulier_cadre_juridique_url_ccas_cnaf_scopes_only
     scopes:
       - cnaf_quotient_familial
       - cnaf_allocataires

--- a/features/habilitations/api_particulier/soumission.feature
+++ b/features/habilitations/api_particulier/soumission.feature
@@ -206,13 +206,12 @@ Fonctionnalité: Soumission d'une demande d'habilitation API Particulier
       | Loyfeey                   | Ecorestauration   |
       | Kosmos Education          | Kosmos            |
 
-  Plan du scénario: Je soumets une demande d'habilitation, en plusieurs étapes, d'un éditeur avec le contact technique non renseigné et des scopes non modifiables pour un cas d'usage lié au CCAS
+  Plan du scénario: Je soumets une demande d'habilitation, en plusieurs étapes, d'un éditeur avec le contact technique non renseigné et des scopes non modifiables pour un cas d'usage lié au CCAS, où le cadre juridique est déjà renseigné
     Quand je veux remplir une demande pour "API Particulier" via le formulaire "<Nom du formulaire>" de l'éditeur "<Nom de l'éditeur>"
     Et que je clique sur "Débuter ma demande"
 
     * je clique sur "Suivant"
 
-    * je renseigne le cadre légal
     * je clique sur "Suivant"
 
     * je renseigne les infos concernant les données personnelles


### PR DESCRIPTION
Cases with only CNAF scopes no need deliberations, but we have to have at least an url or a document.

This is not ideal, but it is a good tradeoff instead of adding complexe validations within the model.