### PR TITLE
Removing unicity clause on UUID for MalwareScan model

### DIFF
--- a/app/jobs/malware_scan_job.rb
+++ b/app/jobs/malware_scan_job.rb
@@ -15,9 +15,9 @@ class MalwareScanJob < ApplicationJob
   private
 
   def create_and_start_scan
-    MalwareScan.create!(uuid:, attachment: @attachment)
+    malware_scan = MalwareScan.create!(uuid:, attachment: @attachment)
 
-    MalwareScanRetrieveStateJob.perform_later(uuid)
+    MalwareScanRetrieveStateJob.perform_later(malware_scan.id)
   end
 
   def uuid

--- a/app/jobs/malware_scan_retrieve_state_job.rb
+++ b/app/jobs/malware_scan_retrieve_state_job.rb
@@ -10,35 +10,31 @@ class MalwareScanRetrieveStateJob < ApplicationJob
   retry_on Faraday::ServerError, wait: RETRY_WAIT_TIME, attempts: RETRIES
   retry_on Faraday::ConnectionFailed, wait: RETRY_WAIT_TIME, attempts: RETRIES
 
-  def perform(uuid)
-    @uuid = uuid
+  def perform(malware_scan_id)
+    malware_scan = MalwareScan.find(malware_scan_id)
 
-    @result_analyze = api_client.result(@uuid)
+    uuid = malware_scan.uuid
+
+    result_analyze = api_client.result(uuid)
+
+    safety_state = extract_safety_state(result_analyze)
 
     raise MalwareScanRetrieveStateJobError if safety_state.blank?
 
-    malware_scan.update!(safety_state:, analyzed_at:)
+    malware_scan.update!(safety_state:, analyzed_at: Time.zone.at(result_analyze[:analyzed_at]))
   rescue MalwareScanRetrieveStateJobError, Faraday::ServerError, Faraday::ConnectionFailed
     malware_scan.update!(safety_state: :unknown, analyzed_at: Time.zone.now.to_i) if attempts == RETRIES
   end
 
   private
 
-  def malware_scan
-    @malware_scan ||= MalwareScan.find_by(uuid: @uuid)
-  end
-
-  def safety_state
-    case @result_analyze[:is_malware]
+  def extract_safety_state(result_analyze)
+    case result_analyze[:is_malware]
     when true
       :unsafe
     when false
       :safe
     end
-  end
-
-  def analyzed_at
-    Time.zone.at(@result_analyze[:analyzed_at])
   end
 
   def api_client

--- a/app/models/malware_scan.rb
+++ b/app/models/malware_scan.rb
@@ -3,6 +3,6 @@ class MalwareScan < ApplicationRecord
 
   enum :safety_state, { pending: 0, safe: 1, unsafe: 2, unknown: 3 }
 
-  validates :uuid, presence: true, uniqueness: true
+  validates :uuid, presence: true
   validates :safety_state, presence: true
 end

--- a/db/migrate/20241029104935_remove_uuid_unicity_from_malware_scans.rb
+++ b/db/migrate/20241029104935_remove_uuid_unicity_from_malware_scans.rb
@@ -1,0 +1,6 @@
+class RemoveUuidUnicityFromMalwareScans < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :malware_scans, :uuid, unique: true
+    add_index :malware_scans, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_03_093735) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_29_104935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -263,7 +263,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_03_093735) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["attachment_id"], name: "index_malware_scans_on_attachment_id"
-    t.index ["uuid"], name: "index_malware_scans_on_uuid", unique: true
+    t.index ["uuid"], name: "index_malware_scans_on_uuid"
   end
 
   create_table "messages", force: :cascade do |t|

--- a/spec/jobs/malware_scan_job_spec.rb
+++ b/spec/jobs/malware_scan_job_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe MalwareScanJob do
     expect(MalwareScan.last.attachment).to eq(attachment)
   end
 
-  it 'calls MalwareScanRetrieveStateJob with the analysis uuid' do
-    expect(MalwareScanRetrieveStateJob).to receive(:perform_later).with(uuid)
-
+  it 'calls MalwareScanRetrieveStateJob with the new MalwareScan id' do
     subject
+
+    expect(MalwareScanRetrieveStateJob).to have_been_enqueued.with(MalwareScan.last.id)
   end
 end

--- a/spec/jobs/malware_scan_retrieve_state_job_spec.rb
+++ b/spec/jobs/malware_scan_retrieve_state_job_spec.rb
@@ -1,14 +1,16 @@
 RSpec.describe MalwareScanRetrieveStateJob do
   subject { job_instance.perform_now }
 
-  let(:job_instance) { described_class.new(uuid) }
-  let(:uuid) { SecureRandom.uuid }
+  let(:job_instance) { described_class.new(malware_scan_id) }
   let(:api_client_double) { instance_double(JeCliqueOuPasAPIClient) }
-  let(:malware_scan) { MalwareScan.find_by(uuid:) }
-  let!(:attachment) { create(:active_storage_attachment) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:attachment) { create(:active_storage_attachment) }
+  let(:malware_scan) { MalwareScan.find(malware_scan_id) }
+  let(:malware_scan_id) { rand(666..6666) }
 
   before do
-    create(:malware_scan, uuid:, attachment:)
+    create(:malware_scan, uuid:, attachment:, id: malware_scan_id)
     allow(JeCliqueOuPasAPIClient).to receive(:new).and_return(api_client_double)
   end
 


### PR DESCRIPTION
If 2 people upload the same attachment, we get the same response from JCOP, with the same UUID.

Because of unicity clause, the second MalwareScan will fail be created.

Removing the unicity clause means we need to adapt MalwareScanRetrieveStateJob. Previously we find_by uuid, this might apply the job to the wrong MalwareScan.

We now pass MalwareScan id to MalwareScanRetrieveStateJob instead of UUID.