### PR TITLE
add foreign key constraint to authorization_requests.applicant_id

### DIFF
--- a/db/migrate/20241113093824_add_foreign_key_to_authorization_requests_applicant_id.rb
+++ b/db/migrate/20241113093824_add_foreign_key_to_authorization_requests_applicant_id.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToAuthorizationRequestsApplicantId < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :authorization_requests, :users, column: :applicant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_02_115614) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_13_093824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
-  enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -344,6 +344,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_02_115614) do
   add_foreign_key "authorization_request_reopening_cancellations", "users"
   add_foreign_key "authorization_request_transfers", "authorization_requests"
   add_foreign_key "authorization_requests", "authorization_requests", column: "next_request_copied_id"
+  add_foreign_key "authorization_requests", "users", column: "applicant_id"
   add_foreign_key "authorizations", "authorization_requests", column: "request_id"
   add_foreign_key "authorizations", "users", column: "applicant_id"
   add_foreign_key "bulk_authorization_request_update_notification_reads", "bulk_authorization_request_updates"


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/DAT-683/ajouter-une-contrainte-de-db-sur-authorization-requestapplicant-id