### PR TITLE
Formulaire qf

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -1519,3 +1519,37 @@ api-particulier-gestion-rh-secteur-public:
       - mesri_inscription_etudiant
       - mesri_inscription_autre
       - mesri_etablissements
+
+api-particulier-formulaire-de-collecte-du-quotient-familial:
+  name: Tarification sociale des services municipaux à l'enfance (via formulaire QF)
+  description: EXCLUSIVEMENT pour les petites communes sans éditeur - Accéder au quotient familial CAF & MSA pour simplifier la tarification sociale municipale à l'enfance par le biais du "formulaire de collecte du quotient familial" et du portail agent HubEE.
+  authorization_request: APIParticulier
+  use_case: formulaire_de_collecte_du_quotient_familial
+  introduction: |
+    Vous allez demander un accès à la solution clé en main du "Formulaire de collecte du quotient familial".
+
+    Dans le cadre de leur démarche de demande d'accès aux services municipaux à l'enfance, les usagers pourront vous transmettre leur quotient familial par le formulaire en s'identifiant via FranceConnect et vous pourrez ensuite récupérer les données sur HubEE pour calculer la tarification de l'usager.
+  steps:
+    - name: legal
+    - name: personal_data
+    - name: contacts
+  static_blocks:
+    - name: basic_infos
+    - name: modalities
+    - name: scopes
+  data:
+    intitule: Formulaire de collecte du quotient familial pour la tarification sociale des services municipaux à l’enfance
+    description: '-'
+    cadre_juridique_nature: |+
+      - Cadre légal général : L'article L114-8 du Code des relations entre le public et l’administration qui fixe le cadre général qui oblige l’administration à échanger des données lors d’une démarche d’un usager.
+    contact_technique_email: api-particulier@api.gouv.fr
+    contact_technique_phone_number: Non nécessaire
+    contact_technique_type: organization
+    destinataire_donnees_caractere_personnel: Agents de la municipalité
+    scopes:
+      - cnaf_quotient_familial
+      - cnaf_allocataires
+      - cnaf_enfants
+      - cnaf_adresse
+    modalities:
+      - formulaire_qf

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -584,6 +584,25 @@ fr:
         label: Description du cadre juridique autorisant à traiter les données*
         hint: Le cadre général est déjà spécifié. Vous pouvez ajouter un cadre spécifique à votre situation.
 
+    api_particulier_formulaire_de_collecte_du_quotient_familial:
+      contact_technique:
+        info: |
+          Il s'agit de l'équipe qui s'occupe de gérer le site Formulaire QF, vous n'avez pas besoin de modifier ces informations.
+
+      legal: &api_particulier_use_cases_forms_legal_tarification
+        justificatif:
+          title: Délibération avec les conditions tarifaires*
+          description: Ce document doit permettre de justifier les données demandées. <a href="https://particulier.api.gouv.fr/faq#qu-est-ce-qu-une-bonne-deliberation-pour-acceder-a-api-particulier" target="_blank">En savoir plus sur la délibération attendue par API Particulier</a>
+      cadre_juridique_nature:
+        &api_particulier_use_cases_forms_cadre_juridique_nature
+        label: Description du cadre juridique autorisant à traiter les données*
+        hint: Le cadre général est déjà spécifié. Vous pouvez ajouter un cadre spécifique à votre situation. Veuillez citer le texte de la délibération qui spécifie les conditions tarifaires et mentionner la page.
+      cadre_juridique_document:
+        &api_particulier_use_cases_forms_cadre_juridique_document
+        label: Ajoutez le fichier de la délibération
+      cadre_juridique_url: &api_particulier_use_cases_forms_cadre_juridique_url
+        label: Indiquez une URL vers la délibération
+
     api_infinoe_production:
       sandbox_authorization_request:
         title: L'habilitation de bac à sable

--- a/features/habilitations/api_particulier/soumission.feature
+++ b/features/habilitations/api_particulier/soumission.feature
@@ -349,7 +349,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation API Particulier
     Alors il y a un message de succès contenant "soumise avec succès"
     Et je suis sur la page "Demandes et habilitations"
 
-Plan du scénario: Je soumets une demande d'habilitation, en plusieurs étapes, d'un éditeur dont le contact technique n'est pas renseigné et des scopes non modifiables pour un cas d'usage lié à la tarification des transports
+  Plan du scénario: Je soumets une demande d'habilitation, en plusieurs étapes, d'un éditeur dont le contact technique n'est pas renseigné et des scopes non modifiables pour un cas d'usage lié à la tarification des transports
     Quand je veux remplir une demande pour "API Particulier" via le formulaire "<Nom du formulaire>" de l'éditeur "<Nom de l'éditeur>"
     Et que je clique sur "Débuter ma demande"
 
@@ -378,6 +378,28 @@ Plan du scénario: Je soumets une demande d'habilitation, en plusieurs étapes, 
       | Nom du formulaire   | Nom de l'éditeur          |
       | MaaSify             | Monkey Factory            |
       | Airweb             | Airweb          |
+
+  Scénario: Je soumets une demande d'habilitation pour le formulaire QF uniquement
+    Quand je veux remplir une demande pour "API Particulier" via le formulaire "Tarification sociale des services municipaux à l'enfance (via formulaire QF)"
+    Et que je clique sur "Débuter ma demande"
+
+    * je remplis "Indiquez une URL vers la délibération" avec "https://legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006430983&cidTexte=LEGITEXT000006070721"
+    * je clique sur "Suivant"
+
+    * je renseigne les infos concernant les données personnelles
+    * je clique sur "Suivant"
+
+    * je renseigne les informations du délégué à la protection des données
+    * je renseigne les informations du contact métier
+
+    * je clique sur "Suivant"
+
+    * j'adhère aux conditions générales
+    * je clique sur "Soumettre la demande d'habilitation"
+
+    Alors il y a un message de succès contenant "soumise avec succès"
+    Et je suis sur la page "Demandes et habilitations"
+
   Scénario: Je vois un lien vers API particulier quand je consulte une habilitation validée
     Quand j'ai déjà une demande d'habilitation "API Particulier" validée avec token
     Et que je vais sur la page du tableau de bord

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -350,6 +350,7 @@ FactoryBot.define do
       api-particulier-aides-sociales-ccas-dont-facultatives
       api-particulier-tarification-transports
       api-particulier-gestion-rh-secteur-public
+      api-particulier-formulaire-de-collecte-du-quotient-familial
     ].each do |form_uid|
       trait form_uid.tr('-', '_') do
         api_particulier


### PR DESCRIPTION
Formulaire qui permettra aux petites communes sans éditeur d'accéder à l'API QF en passant par HubEE. Ce formulaire :
- ne doit pas générer de jeton API Particulier
- doit ouvrir des comptes/droits sur HubEE aux communes, sans activer leur abonnement