### PR TITLE
fix header badge when there is no stage

### DIFF
--- a/app/views/authorization_request_forms/shared/_header_badge.erb
+++ b/app/views/authorization_request_forms/shared/_header_badge.erb
@@ -21,7 +21,7 @@
       </li>
     <% end %>
 
-    <% if authorization_request.definition.stage.present? %>
+    <% if authorization_request.definition.stage.exists? %>
       <li>
         <%= authorization_request_stage_badge(authorization_request) %>
       </li>


### PR DESCRIPTION
On veut éviter ça : 

![image](https://github.com/user-attachments/assets/1218d00d-8ede-45c9-96fe-0c21e2e8aace)
