### PR TITLE
Enhance label_with_hint

### DIFF
--- a/app/form_builders/dsfr_form_builder.rb
+++ b/app/form_builders/dsfr_form_builder.rb
@@ -49,9 +49,7 @@ class DSFRFormBuilder < ActionView::Helpers::FormBuilder
         @template.safe_join(
           [
             check_box(attribute, class: input_classes(opts), disabled: check_box_disabled, **enhance_input_options(opts).except(:class)),
-            @template.content_tag(:label, class: 'fr-label', for: "#{object_name}_#{attribute}") do
-              @template.safe_join([opts[:label] || label_with_hint(attribute, opts)])
-            end
+            @template.safe_join([opts[:label] || label_with_hint(attribute, opts)])
           ]
         )
       end
@@ -135,12 +133,15 @@ class DSFRFormBuilder < ActionView::Helpers::FormBuilder
 
   def label_with_hint(attribute, opts = {})
     label(attribute, class: 'fr-label') do
-      label_value = [label_value(attribute)]
-      label_value.push(required_tag) if opts[:required]
+      label_text_container = @template.content_tag(:span) do
+        label_value = [label_value(attribute)]
+        label_value.push(required_tag) if opts[:required]
+        @template.safe_join(label_value)
+      end
 
       @template.safe_join(
         [
-          label_value,
+          label_text_container,
           hint(attribute)
         ]
       )


### PR DESCRIPTION
This fixes commit ac37ded0afad20847183738e518cabc2fe6435ac

Previously we tried to fix the asterisk not being aligned with the text by changing the template on the checkbox group creation

This forced us to nest a label inside a label, which in tech terms, sucks (also made testing harder)

A better solution is to create the checkbox label with the required tag in the same container