### PR TITLE
No longer returns ActiveRecord::NotFoundError for static entries

### DIFF
--- a/app/helpers/subdomains_helper.rb
+++ b/app/helpers/subdomains_helper.rb
@@ -3,7 +3,7 @@ module SubdomainsHelper
 
   def registered_subdomain
     Subdomain.find(app_subdomain)
-  rescue ActiveRecord::RecordNotFound
+  rescue StaticApplicationRecord::EntryNotFound
     nil
   end
 

--- a/app/models/static_application_record.rb
+++ b/app/models/static_application_record.rb
@@ -2,6 +2,8 @@ class StaticApplicationRecord
   include ActiveModel::Model
   include Draper::Decoratable
 
+  class EntryNotFound < StandardError; end
+
   def self.inherited(base)
     base.extend ClassMethods
 
@@ -34,7 +36,7 @@ class StaticApplicationRecord
     end
 
     def find(id)
-      all.find { |entry| entry.id == id } || fail(ActiveRecord::RecordNotFound, "Couldn't find #{name} with 'id'=#{id}")
+      all.find { |entry| entry.id == id } || fail(EntryNotFound, "Couldn't find #{name} with 'id'=#{id} within static entries")
     end
 
     def values_includes_entry_attribute?(entry, attr, values)


### PR DESCRIPTION
With an exception `ActiveRecord::NotFoundError` raised, rails handles this error within the controller as a 404 error, which seems legit for these kinds of error.

However, with static content like forms, if we remove or rename/change forms we don't want to have a 404 error but a 500 error if it happens (better not to have error ofc, but best case is to catch it and fix it)