### PR TITLE
Feature/dat 656 les liens de cgu des scopes sont differents pour la sandbox

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,4 +6,12 @@ class PagesController < ApplicationController
   def home
     redirect_to dashboard_path if user_signed_in?
   end
+
+  def cgu_api_impot_particulier_bas
+    render 'static_pages/cgu_api_impot_particulier_bas'
+  end
+
+  def cgu_api_impot_particulier_prod
+    render 'static_pages/cgu_api_impot_particulier_prod'
+  end
 end

--- a/app/views/static_pages/cgu_api_impot_particulier_bas.html.erb
+++ b/app/views/static_pages/cgu_api_impot_particulier_bas.html.erb
@@ -1,0 +1,18 @@
+<div class="fr-my-5w">
+  <h1 class="fr-h2">Conditions Générales d'Utilisation de l'API Impôt Particulier (environnement bac à sable)</h1>
+</div>
+
+<div>
+  <p class="fr-text--lg">
+    Retrouvez ci-dessous les mentions légales et les conditions d'utilisation de l'API Impôt Particulier.
+  </p>
+
+  <ul class="fr-text--md fr-text--bold fr-my-3w">
+    <li>
+      <%= link_to "CGUs sans connexion France Connect", "/cgus/dgfip/cgu_api_impot_particulier_bac_a_sable_connexion_hors_fc_septembre2020_v2.6.pdf" %>
+    </li>
+    <li>
+      <%= link_to "CGUs avec connexion France Connect", "/cgus/dgfip/cgu_api_impot_particulier_bac_a_sable_connexion_fc_septembre2020_v2.6.pdf" %>
+    </li>
+  </ul>
+</div>

--- a/app/views/static_pages/cgu_api_impot_particulier_prod.html.erb
+++ b/app/views/static_pages/cgu_api_impot_particulier_prod.html.erb
@@ -1,0 +1,18 @@
+<div class="fr-my-5w">
+  <h1 class="fr-h2">Conditions Générales d'Utilisation de l'API Impôt Particulier (environnement de production)</h1>
+</div>
+
+<div>
+  <p class="fr-text--lg">
+    Retrouvez ci-dessous les mentions légales et les conditions d'utilisation de l'API Impôt Particulier.
+  </p>
+
+  <ul class="fr-text--md fr-text--bold fr-my-3w">
+    <li>
+      <%= link_to "CGUs sans connexion France Connect", "/cgus/dgfip/cgu_api_impot_particulier_production_hors_connexion_fc_decembre2022_v4.0.pdf" %>
+    </li>
+    <li>
+      <%= link_to "CGUs avec connexion France Connect", "/cgus/dgfip/cgu_api_impot_particulier_production_connexion_fc_septembre2020_v5.5.pdf" %>
+    </li>
+  </ul>
+</div>

--- a/config/authorization_definitions.yml
+++ b/config/authorization_definitions.yml
@@ -333,7 +333,7 @@ shared:
     public: true
     kind: 'api'
     link: "https://api.gouv.fr/les-api/impot-particulier"
-    cgu_link: "/cgus/dgfip/cgu_api_impot_particulier_production_hors_connexion_fc_decembre2022_v4.0.pdf"
+    cgu_link: "/cgu_api_impot_particulier_prod"
     provider: "dgfip"
     stage:
       type: production
@@ -475,7 +475,7 @@ shared:
     provider: "dgfip"
     kind: 'api'
     link: "https://api.gouv.fr/les-api/impot-particulier"
-    cgu_link: "/cgus/dgfip/cgu_api_impot_particulier_bac_a_sable_connexion_hors_fc_septembre2020_v2.6.pdf"
+    cgu_link: "/cgu_api_impot_particulier_bas"
     access_link: "https://api-impot-particulier-sandbox.gouv.fr/tokens/%<external_provider_id>s"
     public: false
     stage:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,9 @@ Rails.application.routes.draw do
       resources :authorization_request_from_templates, only: %i[index create], path: 'templates'
     end
 
+    get 'cgu_api_impot_particulier_bas', to: 'pages#cgu_api_impot_particulier_bas', as: :cgu_api_impot_particulier_bas
+    get 'cgu_api_impot_particulier_prod', to: 'pages#cgu_api_impot_particulier_prod', as: :cgu_api_impot_particulier_prod
+
     get 'demandes/:id/reopen-from-external', to: 'external_reopen_authorization_requests#create'
 
     resources :authorization_requests, only: [] do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe PagesController, type: :controller do
+  describe 'GET #cgu_api_impot_particulier_bas' do
+    it 'returns a 200 response' do
+      get :cgu_api_impot_particulier_bas
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET #cgu_api_impot_particulier_prod' do
+    it 'returns a 200 response' do
+      get :cgu_api_impot_particulier_prod
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Ajout de 2 static pages pour afficher les CGU's API Impot particulier
- environnement bac a sable avec et sans FC 
- environnement production avec et sans FC 

<img width="1491" alt="Capture d’écran 2024-12-05 à 15 56 17" src="https://github.com/user-attachments/assets/97ddbd54-6490-40af-9911-b3270f6fc1c2">


<img width="1491" alt="Capture d’écran 2024-12-05 à 15 56 33" src="https://github.com/user-attachments/assets/02d43128-b284-4c6a-9e09-a2bb35ce23af">

