### PR TITLE
Tests: double chrome window size to mitigate flaky tests

### DIFF
--- a/spec/support/configure_javascript_driver.rb
+++ b/spec/support/configure_javascript_driver.rb
@@ -32,7 +32,7 @@ Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
-    window_size: [1200, 800],
+    window_size: [2400, 1600],
     browser_options: remote_chrome ? { 'no-sandbox' => nil } : {},
     inspector:,
     headless: !inspector && ENV['HEADLESS'] != 'false', **remote_options


### PR DESCRIPTION
Find a way to almost replicate flaky tests by running the following command within Docker (1/2 executions failed randomly)

```
cucumber features/sous-domaine_tableau_de_bord.feature features/habilitations/api_entreprise/choix_formulaire.feature --order random:6697
```

Flaky tests in CI were in `features/habilitations/api_entreprise/choix_formulaire.feature`, but not on `features/habilitations/api_particulier/choix_formulaire.feature`, which was suspicious.

It's almost the same UI/UX, there's a difference on editors blocks size, because of the number of existing editors for API Entreprise, which is more important than API Particulier within our tests (8 editors on first view for API Entreprise, only 1 for API Particulier)

This flaky test only exists within Docker, where we load and configure the chrome driver within spec/support/configure_javascript_driver.rb

Tried to change the window size in order to avoid a potential bug with a difference between window (which is visible) and document.

After applying the patch and running several times (~10), it's green.

Maybe it's a coincidence, we don't really know with E2E tests with javascript, maybe it'll fail again in the future : stay tuned!