### PR TITLE
use trigger click

### DIFF
--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -96,7 +96,7 @@ end
 
 Quand('je choisis {string}') do |option|
   if javascript?
-    find('label', text: option, visible: :all)&.click
+    find('label', text: option, visible: :all).trigger('click')
   else
     choose option
   end
@@ -104,7 +104,7 @@ end
 
 Quand('je coche {string}') do |label|
   if javascript?
-    find('label', text: label, visible: :all)&.click
+    find('label', text: label, visible: :all).trigger('click')
   else
     check label
   end


### PR DESCRIPTION
To prevent flaky tests, we make sure to always trigger the js click event when choosing a radio or checking a checkbox, even if the element is not immediatly visible because of the previous step revealing it.