### PR TITLE
Publication dans l'arbre de décision de formulaire existant

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -564,7 +564,7 @@ api-particulier-agedi-proxima-enf:
   authorization_request: APIParticulier
   use_case: tarification_municipale_enfance
   service_provider_id: agedi
-  public: false
+  public: true
   introduction: *api_particulier_introduction_editor_with_editable_scopes
   steps: *api_particulier_editor_steps_with_editable_scopes
   static_blocks: *api_particulier_editor_static_blocks_with_editable_scopes
@@ -604,7 +604,7 @@ api-particulier-ecorestauration-loyfeey:
   authorization_request: APIParticulier
   use_case: tarification_municipale_enfance
   service_provider_id: ecorestauration
-  public: false
+  public: true
   introduction: *api_particulier_introduction_editor_with_fixed_scopes
   steps: *api_particulier_editor_steps_with_fixed_scopes
   static_blocks: *api_particulier_editor_static_blocks_with_fixed_scopes
@@ -781,7 +781,7 @@ api-particulier-kosmos-education:
   authorization_request: APIParticulier
   use_case: cantines-colleges-lycees-tarification
   service_provider_id: kosmos
-  public: false
+  public: true
   introduction: *api_particulier_introduction_editor_with_fixed_scopes
   steps: *api_particulier_editor_steps_with_fixed_scopes
   static_blocks: *api_particulier_editor_static_blocks_with_fixed_scopes


### PR DESCRIPTION
Il y avait 3 formulaires dans l'arbre de décision qui n'apparaissaient pas, bien que le nom de l'éditeur était présent parce que j'avais laissé la clé 'public' en false.
![image](https://github.com/user-attachments/assets/bf6dfd50-3938-450a-a8aa-a9189c480809)

 Je passe donc la clé en 'true' pour que les FS puissent accéder au formulaire de leur éditeur depuis l'arbre de décision