### PR TITLE
[TO DISCUSS cf coms] Generator: add legal step for production

### DIFF
--- a/lib/generators/multi_stages_definition/templates/forms.yml.erb
+++ b/lib/generators/multi_stages_definition/templates/forms.yml.erb
@@ -22,5 +22,6 @@
   static_blocks: *<%= name.underscore %>_steps
   steps:
     - name: operational_acceptance
+    - name: legal
     - name: safety_certification
     - name: volumetrie

--- a/lib/generators/multi_stages_definition/templates/scenario.feature.erb
+++ b/lib/generators/multi_stages_definition/templates/scenario.feature.erb
@@ -41,6 +41,9 @@ Fonctionnalité: Soumission d'une demande d'habilitation <%= humanized_name %>
     * je renseigne la recette fonctionnelle
     * je clique sur "Suivant"
 
+    * je renseigne le cadre légal
+    * je clique sur "Suivant"
+
     * je renseigne l'homologation de sécurité
     * je clique sur "Suivant"
 


### PR DESCRIPTION
There is a legal block in v1 for DGFIP forms.
Not sure if it's relevant (it had been remove on API Impot Particulier), better to be present than absent (easier to remove than add).