### PR TITLE
restore all the missing APIs in authorization_definition

### DIFF
--- a/config/authorization_definitions/base.yml
+++ b/config/authorization_definitions/base.yml
@@ -628,3 +628,408 @@ api_hermes:
     - name: operational_acceptance
     - name: safety_certification
     - name: volumetrie
+
+api_e_contacts_sandbox:
+  name: API E-Contacts
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_bas_e_contacts_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-e-contacts.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_e_contacts
+      form_id: api-e-contacts-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_e_contacts:
+  name: API E-Contacts
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_prod_e_contacts_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-e-contacts.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_e_contacts_sandbox
+        form_id: api-e-contacts-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_ocfi_sandbox:
+  name: API OCFI
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/pcr_v1/cgu_bas_ocfi_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-ocfi.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_ocfi
+      form_id: api-ocfi-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_ocfi:
+  name: API OCFI
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_prod_ocfi_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-ocfi.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_ocfi_sandbox
+        form_id: api-ocfi-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_e_pro_sandbox:
+  name: API E-PRO
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_bas_e_pro_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-e-pro.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_e_pro
+      form_id: api-e-pro-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_e_pro:
+  name: API E-PRO
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_prod_e_pro_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-e-pro.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_e_pro_sandbox
+        form_id: api-e-pro-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_robf_sandbox:
+  name: API ROBF
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_bas_robf_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-robf.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_robf
+      form_id: api-robf-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+
+api_robf:
+  name: API ROBF
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_prod_robf_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-robf.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_robf_sandbox
+        form_id: api-robf-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_cpr_pro_adelie_sandbox:
+  name: API CPR PRO-ADELIE
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_bas_cpr_pro_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-pro-adelie.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_cpr_pro_adelie
+      form_id: api-cpr-pro-adelie-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_cpr_pro_adelie:
+  name: API CPR PRO-ADELIE
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/prc_v1/cgu_prod_cpr_pro_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-pro-adelie.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_cpr_pro_adelie_sandbox
+        form_id: api-cpr-pro-adelie-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_imprimfip_sandbox:
+  name: API IMPRIM’FIP
+  description: Utilisez la solution éditique IMPRIM’FIP pour délocaliser le traitement de vos courriers administratifs sortants (impression, mise sous pli, affranchissement et remise à La Poste) vers les centres éditiques industriels de la DGFIP.
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://www.data.gouv.fr/fr/dataservices/api-imprimfip/"
+  cgu_link: "/cgus/dgfip/cgu_bas_imprimfip_v.2023_09.pdf"
+  # FEEDME
+  access_link: "https://api-imprimfip.gouv.fr/tokens/%<external_provider_id>"
+  public: true
+  stage:
+    type: sandbox
+    next:
+      id: api_imprimfip
+      form_id: api-imprimfip-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_imprimfip:
+  name: API IMPRIM’FIP
+  description: Utilisez la solution éditique IMPRIM’FIP pour délocaliser le traitement de vos courriers administratifs sortants (impression, mise sous pli, affranchissement et remise à La Poste) vers les centres éditiques industriels de la DGFIP.
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://www.data.gouv.fr/fr/dataservices/api-imprimfip/"
+  cgu_link: "/cgus/dgfip/cgu_prod_imprimfip_v.2023_09.pdf"
+  access_link: "https://api-imprimfip.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_imprimfip_sandbox
+        form_id: api-imprimfip-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_satelit_sandbox:
+  name: API Satelit
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/pcr_v1/cgu_bas_satelit_v.2022_v1.pdf"
+  # FEEDME
+  access_link: "https://api-satelit.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_satelit
+      form_id: api-satelit-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_satelit:
+  name: API Satelit
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/pcr_v1/cgu_prod_satelit_v.2022_v1.pdf"
+  # FEEDME
+  access_link: "https://api-satelit.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_satelit_sandbox
+        form_id: api-satelit-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_mire_sandbox:
+  name: API Mire
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/pcr_v1/cgu_bas_mire_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-mire.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_mire
+      form_id: api-mire-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_mire:
+  name: API Mire
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/pcr_v1/cgu_prod_mire_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-mire.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_mire_sandbox
+        form_id: api-mire-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie
+
+api_ensu_documents_sandbox:
+  name: API ENSU Documents
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/pcr_v1/cgu_bas_ensu_doc_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-ensu-documents.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: sandbox
+    next:
+      id: api_ensu_documents
+      form_id: api-ensu-documents-production
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+
+api_ensu_documents:
+  name: API ENSU Documents
+  description: "FEEDME"
+  provider: "dgfip"
+  kind: 'api'
+  link: "https://api.gouv.fr/producteurs/dgfip"
+  cgu_link: "/cgus/dgfip/pcr_v1/cgu_prod_ensu_doc_v.2023_11.pdf"
+  # FEEDME
+  access_link: "https://api-ensu-documents.gouv.fr/tokens/%<external_provider_id>"
+  public: false
+  stage:
+    type: production
+    previouses:
+      - id: api_ensu_documents_sandbox
+        form_id: api-ensu-documents-sandbox
+  blocks:
+    - name: basic_infos
+    - name: personal_data
+    - name: legal
+    - name: contacts
+    - name: operational_acceptance
+    - name: safety_certification
+    - name: volumetrie


### PR DESCRIPTION
Since the split of the authorization_definitions.yml, several APIs have been added. I restored the missing ones from the develop branch, which should adress the merge conflict