### PR TITLE
AuthorizationRequestFormsController not found redirect with an alert

### DIFF
--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -3,6 +3,10 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
   helper AuthorizationRequestsHelpers
   include AuthorizationRequestsFlashes
 
+  rescue_from StaticApplicationRecord::EntryNotFound do
+    redirect_to root_path, alert: t('authorization_request_forms.form_not_found')
+  end
+
   allow_unauthenticated_access only: [:new]
 
   before_action :extract_authorization_request_form

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -293,6 +293,7 @@ fr:
     cta: Débuter ma demande
 
   authorization_request_forms:
+    form_not_found: Le formulaire demandé n'existe pas
     new:
       back_to_dashboard: Retour à l’accueil
       title: *start_new_habilitation_title

--- a/spec/controllers/authorization_request_forms_controller_spec.rb
+++ b/spec/controllers/authorization_request_forms_controller_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe AuthorizationRequestFormsController, type: :controller do
+  describe 'GET #new' do
+    subject(:new_authorization_request_form) { get :new, params: { form_uid: } }
+
+    context 'with invalid form uid' do
+      let(:form_uid) { 'invalid' }
+
+      it 'redirects to root path with an error message' do
+        new_authorization_request_form
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("Le formulaire demandé n'existe pas")
+      end
+    end
+  end
+end


### PR DESCRIPTION
No more 500 error.

Closes https://errors.data.gouv.fr/organizations/sentry/issues/247132/