### PR TITLE
Consistent uppercase in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 ARG RUBY_VERSION=3.4.1
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
to fix annoying github warning

![image](https://github.com/user-attachments/assets/3c964b8c-d6de-4e07-96c6-876a6c67531a)

je merge direct au vert