### PR TITLE
Harden CancelAuthorizationReopening on disjonction with snapshot

### DIFF
--- a/app/controllers/cancel_authorization_reopenings_controller.rb
+++ b/app/controllers/cancel_authorization_reopenings_controller.rb
@@ -20,7 +20,7 @@ class CancelAuthorizationReopeningsController < AuthenticatedUserController
       redirect_to dashboard_path,
         status: :see_other
     else
-      render 'new'
+      render 'new', alert: t('.error')
     end
   end
 

--- a/app/interactors/restore_authorization_request_to_latest_authorization.rb
+++ b/app/interactors/restore_authorization_request_to_latest_authorization.rb
@@ -2,14 +2,14 @@ class RestoreAuthorizationRequestToLatestAuthorization < ApplicationInteractor
   def call
     return if latest_authorization.nil?
 
-    restore_attributes!
+    fill_authorization_request_with_latest_authorization_data!
 
     authorization_request.save
   end
 
   private
 
-  def restore_attributes!
+  def fill_authorization_request_with_latest_authorization_data!
     interactor = AssignParamsToAuthorizationRequest.call(
       authorization_request:,
       authorization_request_params:,

--- a/app/interactors/restore_authorization_request_to_latest_authorization.rb
+++ b/app/interactors/restore_authorization_request_to_latest_authorization.rb
@@ -2,11 +2,28 @@ class RestoreAuthorizationRequestToLatestAuthorization < ApplicationInteractor
   def call
     return if latest_authorization.nil?
 
-    authorization_request.data = latest_authorization.data
+    restore_attributes!
+
     authorization_request.save
   end
 
   private
+
+  def restore_attributes!
+    interactor = AssignParamsToAuthorizationRequest.call(
+      authorization_request:,
+      authorization_request_params:,
+      save_context: :submit,
+    )
+
+    return if interactor.success?
+
+    context.fail!
+  end
+
+  def authorization_request_params
+    ActionController::Parameters.new(latest_authorization.data)
+  end
 
   def authorization_request
     context.authorization_request

--- a/app/models/concerns/authorization_core/attributes.rb
+++ b/app/models/concerns/authorization_core/attributes.rb
@@ -52,6 +52,7 @@ module AuthorizationCore::Attributes
 
       def self.override_array_writer(name)
         define_method(:"#{name}=") do |value|
+          value = JSON.parse(value) if value.is_a?(String)
           raise(TypeError, "#{name} should be an array") unless value.is_a?(Array) || value.nil?
 
           value = (value || []).compact_blank.map(&:strip).uniq

--- a/app/views/cancel_authorization_reopenings/new.html.erb
+++ b/app/views/cancel_authorization_reopenings/new.html.erb
@@ -1,4 +1,3 @@
-
 <div class="simple-page-action-wrapper fr-pt-5w">
   <div class="fr-grid-row fr-grid-row--center">
     <div class="fr-col-md-offset-1 fr-col-md-10">
@@ -8,6 +7,8 @@
             <h1 class="fr-modal__title">
               <%= t(".initial.title", authorization_request_name: @authorization_request.name) %>
             </h1>
+
+            <%= render partial: 'shared/alerts' %>
 
             <p>
               <%=

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -807,3 +807,5 @@ fr:
     create:
       success:
         title: La réouverture de l'habilitation %{name} a été annulée.
+      error: Une erreur s'est produite, merci de contacter le support
+

--- a/spec/models/authorization_request/api_impot_particulier_spec.rb
+++ b/spec/models/authorization_request/api_impot_particulier_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe AuthorizationRequest::APIImpotParticulier, type: :model do
     before { authorization_request.current_build_step = 'modalities' }
 
     context 'with a non array value' do
-      it 'raises a type error' do
-        expect { authorization_request.modalities = 'non array value' }.to raise_error(TypeError)
+      it 'raises an error' do
+        expect { authorization_request.modalities = 'non array value' }.to raise_error(JSON::ParserError)
       end
     end
 

--- a/spec/organizers/cancel_authorization_reopening_spec.rb
+++ b/spec/organizers/cancel_authorization_reopening_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CancelAuthorizationReopening, type: :organizer do
             expect { cancel_authorization_reopening }.to change { authorization_request.reload.administrateur_metier_email }.from('new@gouv.fr').to('old@gouv.fr')
           end
 
-          describe 'when there is changes between the latest authorization keys and the actual authorization request' do
+          describe 'when there are changes between the latest authorization keys and the actual authorization request' do
             let(:authorization) { authorization_request.latest_authorization }
 
             before do


### PR DESCRIPTION
There is some cases where authorization request can be mass updated for some
reason, but not the snapshots (authorization model) (should be fixed).

For some mass update, we can remove and add keys (for example a
migration of a contact from one type to another) : on these cases,
if we try to just replace the `data` key of the authorization request
with the snapshot, we override potential some required key with a null
value : in this case, the authorization request is no longer valid, and
the organizer did not handle this edge case well.

The real life example/bug: we migrate for API Particulier the
"responsable traitement" to "contact metier", with the old behaviour we
erased old infos regarding the "contact metier" on the authorization
request if it was validated before the mass update
(because fields were not present on the snapshot), which leads to a fail
of the organizer, but did not displayed any message.

Closes https://linear.app/pole-api/issue/DAT-774