### PR TITLE
improve UX of table for instructors

### DIFF
--- a/app/assets/stylesheets/components/clickable_rows.css
+++ b/app/assets/stylesheets/components/clickable_rows.css
@@ -1,0 +1,6 @@
+.clickable-row {
+  cursor: pointer;
+}
+.clickable-row:hover {
+  background-color: #ededed !important;
+}

--- a/app/javascript/controllers/clickable_rows_controller.js
+++ b/app/javascript/controllers/clickable_rows_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  visit (event) {
+    const row = event.currentTarget
+    const path = row.attributes['data-href'].value
+    window.location.assign(path)
+  }
+}

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -58,9 +58,9 @@
         </tr>
       </thead>
 
-    <tbody>
+    <tbody data-controller="clickable-rows">
       <% @authorization_requests.each do |authorization_request| %>
-        <tr id="<%= dom_id(authorization_request) %>" class="authorization-request">
+        <tr id="<%= dom_id(authorization_request) %>" class="authorization-request clickable-row" data-action="click->clickable-rows#visit" data-href="<%= instruction_authorization_request_path(authorization_request) %>">
           <td class="authorization-request-id">
             <%= authorization_request.id %>
           </td>


### PR DESCRIPTION
Par ce qu'on a vu que sur les (petits) écrans des instructeurs DGFIP, ils voyaient pas la colonne avec le bouton "consulter" et qu'il y avait peu d'indications sur le fait qu'il fallait scroller horizontalement pour la voir. Ils cliquaient partout sur la row pour essayer d'accéder à une demande.

J'ai donc rendu la row clickable (et j'ai laissé aussi le bouton consulter pour l'habitude, et l'accessibilité) :point_down: 


https://github.com/user-attachments/assets/e618fcc6-ae8a-4316-82a2-5ec2217acd2d

Closes https://linear.app/pole-api/issue/DAT-798/etq-instructeur-le-bouton-consulter-est-cache-a-droite-dans-le-tableau
