### PR TITLE
Fix habilitation title

### DIFF
--- a/app/views/authorization_request_forms/shared/_header_badge.erb
+++ b/app/views/authorization_request_forms/shared/_header_badge.erb
@@ -2,7 +2,7 @@
 
 <div class="authorization-request-form-header__badges">
   <ul class="fr-badge-group">
-    <% if authorization_request.reopening? %>
+    <% if authorization_request.reopening? && @authorization.blank? %>
       <li>
         <%= authorization_request_reopening_badge %>
       </li>

--- a/app/views/authorization_requests/shared/_title.html.erb
+++ b/app/views/authorization_requests/shared/_title.html.erb
@@ -1,4 +1,4 @@
-<% if @authorization_request.reopening? %>
+<% if @authorization_request.reopening? && @authorization.blank? %>
   <h1 class="authorization-request-form-header__name">
     <span class="fr-icon-edit-box-fill fr-icon--lg fr-text-blue-france" aria-hidden="true"></span>
     <%= t('.update') %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -368,7 +368,7 @@ fr:
 
       reopening_alerts:
         update_in_progress:
-          title: Une mise à jour de cette demande est en cours.
+          title: Une mise à jour de cette habilitation est en cours.
           message: "Vous avez initié une mise à jour de cette habilitation. Vous pouvez y accéder en cliquant ici : %{link}"
         old_version:
           title: Attention, vous consultez une version ancienne de cette habilitation

--- a/features/consultation_habilitation.feature
+++ b/features/consultation_habilitation.feature
@@ -119,7 +119,7 @@ Fonctionnalité: Consultation d'une demande d'habilitation
   Scénario: Je consulte la dernière habilitation validée dont la demande a été réouverte
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte
     Et que je me rends sur l'habilitation validée
-    Alors la page contient "Une mise à jour de cette demande est en cours"
+    Alors la page contient "Une mise à jour de cette habilitation est en cours"
 
   Scénario: Je consulte une ancienne habilitation validée dont la demande a été réouverte
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -54,6 +54,8 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et il n'y a pas de bouton "Mettre à jour"
     Et il n'y a pas de bouton "Enregistrer"
     Et il y a un message d'info contenant "Une mise à jour de cette habilitation est en cours."
+    Et il n'y a pas de titre contenant "Demande de mise à jour des informations"
+    Et il n'y a pas de badge "Mise à jour"
 
   Scénario: Consultation de la demande de mise à jour associée à une réouverture
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte
@@ -62,6 +64,7 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Alors je suis sur la page "API Entreprise"
     Et il y a un badge "Mise à jour"
     Et il y a un badge "Brouillon"
+    Et il y a un titre contenant "Demande de mise à jour des informations"
     Et il n'y a pas de bouton "Enregistrer"
 
   Scénario: Annulation d'une demande de réouverture

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -53,7 +53,7 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et il y a un badge "Validée"
     Et il n'y a pas de bouton "Mettre à jour"
     Et il n'y a pas de bouton "Enregistrer"
-    Et il y a un message d'info contenant "Une mise à jour de cette demande est en cours."
+    Et il y a un message d'info contenant "Une mise à jour de cette habilitation est en cours."
 
   Scénario: Consultation de la demande de mise à jour associée à une réouverture
     Quand j'ai 1 demande d'habilitation "API Entreprise" réouverte

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -21,6 +21,17 @@ Alors('je suis sur la page {string}') do |text|
   step "il y a un titre contenant \"#{text}\""
 end
 
+Alors("il n'y a pas de titre contenant {string}") do |text|
+  elements = [
+    page.all('h1').first,
+    page.all('p.fr-h2').first,
+    page.all('h2').first,
+    page.all('table caption').first,
+  ]
+
+  expect(elements.none? { |element| element&.text&.include?(text) }).to be_truthy
+end
+
 Quand(/je clique sur (le (?:dernier|premier) )?"([^"]+)"\s*$/) do |position, label|
   case position
   when 'le dernier '
@@ -225,6 +236,10 @@ end
 
 Alors('il y a un badge {string}') do |text|
   expect(page).to have_css('.fr-badge', text:)
+end
+
+Alors("il n'y a pas de badge {string}") do |text|
+  expect(page).to have_no_css('.fr-badge', text:)
 end
 
 Alors('la page contient le logo du fournisseur de données {string}') do |authorization_definition|


### PR DESCRIPTION
On a eu un gros eurêka sur pas mal de confusion dans l'UI (et le code de l'UI) dûes au fait que c'est jamais très clair si on regarde une demande ou une habilitation. On va sûrement à l'avenir plus clairement séparer ces deux concepts dans l'UI, mais pour l'instant voici juste un fix d'un truc symptomatique de cette confusion : le titre d'une habilitation ne doit pas dépendre du statut de la demande associée.

J'ai failli aussi supprimer le badge "validée", mais je me suis dit que ça aurait ptet des conséquences innatendues (nottamment pour les révoquées, ce statut devrait être associé à l'habilitation pas à la demande). Donc je l'ai laissé pour le moment.

Ce fix est laid, mais nécessaire. On fera mieux quand on séparera plus clairement l'UI d'une demande de l'UI d'une habilitation.

Closes https://linear.app/pole-api/issue/DAT-800/corriger-le-titre-dune-habilitation-qui-possede-une-demande-de