### PR TITLE
Hide add new authorization if on v2 subdomain

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -12,9 +12,11 @@
           <% end %>
         </div>
 
-        <div>
-          <%= link_to 'Nouvelle habilitation', authorization_definitions_path, class: %w(fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left) %>
-        </div>
+        <% if app_subdomain != 'v2' %>
+          <div>
+            <%= link_to 'Nouvelle habilitation', authorization_definitions_path, class: %w(fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left) %>
+          </div>
+        <% end %>
       </div>
     </div>
 


### PR DESCRIPTION
We do not want to be able to add authorization request on https://v2.datapass.api.gouv.fr/