### PR TITLE
Admin: introduce users with roles module

### DIFF
--- a/app/controllers/admin/users_with_roles_controller.rb
+++ b/app/controllers/admin/users_with_roles_controller.rb
@@ -5,4 +5,51 @@ class Admin::UsersWithRolesController < AdminController
 
     @users = @search_engine.result(distinct: true).page(params[:page]).per(50)
   end
+
+  def new
+    @user = User.new
+  end
+
+  def edit
+    @user = User.find(params[:id])
+
+    render 'new'
+  end
+
+  def create
+    @user = User.find_by(email: user_params[:email]) || User.new(user_params)
+
+    if @user.new_record?
+      error_message(title: t('.not_found', user_email: user_params[:email]))
+
+      render 'new', status: :unprocessable_entity
+    else
+      update
+    end
+  end
+
+  def update
+    @user ||= User.find(params[:id])
+
+    organizer = Admin::UpdateUserRoles.call(admin: current_user, user: @user, roles: user_roles_param)
+
+    if organizer.success?
+      success_message(title: t('.success', user_email: @user.email))
+
+      redirect_to admin_users_with_roles_path
+    else
+      error_message(title: t('.error'), message: organizer.error)
+    end
+  end
+
+  private
+
+  def user_roles_param
+    roles = user_params[:roles] || ''
+    roles.split("\n").map(&:strip)
+  end
+
+  def user_params
+    params.expect(user: %i[email roles])
+  end
 end

--- a/app/controllers/admin/users_with_roles_controller.rb
+++ b/app/controllers/admin/users_with_roles_controller.rb
@@ -1,0 +1,8 @@
+class Admin::UsersWithRolesController < AdminController
+  def index
+    @search_engine = User.with_roles.includes(:organizations).ransack(params[:search_query])
+    @search_engine.sorts = 'created_at desc' if @search_engine.sorts.empty?
+
+    @users = @search_engine.result(distinct: true).page(params[:page]).per(50)
+  end
+end

--- a/app/interactors/admin/notify_admins_for_roles_update.rb
+++ b/app/interactors/admin/notify_admins_for_roles_update.rb
@@ -1,0 +1,5 @@
+class Admin::NotifyAdminsForRolesUpdate < ApplicationInteractor
+  def call
+    AdminMailer.with(user: context.user, old_roles: context.admin_before_attributes[:roles]).notify_user_roles_change.deliver_later
+  end
+end

--- a/app/interactors/admin/track_event.rb
+++ b/app/interactors/admin/track_event.rb
@@ -1,0 +1,27 @@
+class Admin::TrackEvent < ApplicationInteractor
+  def call
+    create_event!
+  end
+
+  private
+
+  def create_event!
+    AdminEvent.create!(
+      name: context.admin_event_name,
+      admin: context.admin,
+      before_attributes: context.admin_before_attributes,
+      after_attributes:,
+      entity:,
+    )
+  end
+
+  def entity
+    context.send(context.admin_entity_key)
+  end
+
+  def after_attributes
+    context.admin_before_attributes.keys.index_with do |key|
+      entity.send(key)
+    end
+  end
+end

--- a/app/interactors/admin/update_user_roles_attribute.rb
+++ b/app/interactors/admin/update_user_roles_attribute.rb
@@ -1,0 +1,13 @@
+class Admin::UpdateUserRolesAttribute < ApplicationInteractor
+  def call
+    user.roles = context.roles
+    user.roles.uniq!
+    user.save
+  end
+
+  private
+
+  def user
+    context.user
+  end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,18 @@
+class AdminMailer < ApplicationMailer
+  def notify_user_roles_change
+    @user = params[:user]
+    @old_roles = params[:old_roles] || []
+    @new_roles = @user.roles - @old_roles
+
+    mail(
+      bcc: admin_users.pluck(:email),
+      subject: "Nouveaux rôles ajouté à l'utilisateur #{@user.email}",
+    )
+  end
+
+  private
+
+  def admin_users
+    User.admin
+  end
+end

--- a/app/models/admin_event.rb
+++ b/app/models/admin_event.rb
@@ -1,0 +1,10 @@
+class AdminEvent < ApplicationRecord
+  validates :name, presence: true
+
+  belongs_to :admin,
+    class_name: 'User',
+    inverse_of: :admin_events
+
+  belongs_to :entity,
+    polymorphic: true
+end

--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -49,6 +49,14 @@ class AuthorizationDefinition < StaticApplicationRecord
     )
   end
 
+  def name_with_stage
+    if stage.exists?
+      "#{name} (#{stage.name})"
+    else
+      name
+    end
+  end
+
   def reopenable?
     !next_stage?
   end

--- a/app/models/authorization_definition/stage.rb
+++ b/app/models/authorization_definition/stage.rb
@@ -9,6 +9,10 @@ class AuthorizationDefinition::Stage
     type.present?
   end
 
+  def name
+    I18n.t("authorization_request.stage.#{type}")
+  end
+
   def next_stage_definition
     AuthorizationDefinition.find(next_stage[:id])
   rescue NotExists

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,17 @@ class User < ApplicationRecord
     )
   }
 
+  scope :admin, lambda {
+    where(
+      "EXISTS (
+        SELECT 1
+        FROM unnest(roles) AS role
+        WHERE role in (?)
+      )",
+      ['admin']
+    )
+  }
+
   add_instruction_boolean_settings :submit_notifications, :messages_notifications
 
   has_many :oauth_applications,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ApplicationRecord
     class_name: 'Authorization',
     inverse_of: :applicant
 
+  has_many :admin_events,
+    inverse_of: :admin,
+    dependent: :restrict_with_exception
+
   scope :with_roles, -> { where("roles <> '{}'") }
 
   scope :instructor_for, lambda { |authorization_request_type|

--- a/app/organizers/admin/update_user_roles.rb
+++ b/app/organizers/admin/update_user_roles.rb
@@ -1,0 +1,17 @@
+class Admin::UpdateUserRoles < ApplicationOrganizer
+  before do
+    context.admin_entity_key = :user
+    context.admin_event_name = 'user_roles_changed'
+    context.admin_before_attributes = {
+      roles: context.user.roles,
+    }
+  end
+
+  organize Admin::UpdateUserRolesAttribute,
+    Admin::TrackEvent,
+    Admin::NotifyAdminsForRolesUpdate
+
+  after do
+    context.user.save
+  end
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -13,5 +13,6 @@
 
   <ul>
     <li><%= link_to 'Emails en liste blanche', admin_whitelisted_verified_emails_path %></li>
+    <li><%= link_to 'Utilisateurs avec des rôles', admin_users_with_roles_path %></li>
   </ul>
 </div>

--- a/app/views/admin/users_with_roles/index.html.erb
+++ b/app/views/admin/users_with_roles/index.html.erb
@@ -33,7 +33,6 @@
                   email
                   organizations
                   roles
-                  created_at
                   actions
                 ].each do |attr|
               %>
@@ -67,9 +66,6 @@
                       </li>
                     <% end %>
                   </ul>
-                </td>
-                <td class="user-created_at">
-                  <%= user.created_at.to_date %>
                 </td>
                 <td class="user-actions">
                   <%= link_to t('.edit'), edit_admin_users_with_role_path(user), class: %[fr-btn fr-btn--sm] %>

--- a/app/views/admin/users_with_roles/index.html.erb
+++ b/app/views/admin/users_with_roles/index.html.erb
@@ -1,0 +1,82 @@
+<%= search_form_for(@search_engine, url: admin_users_with_roles_path, html: { method: :get, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 500, 'auto-submit-form-event-mode-value' => 'input', turbo_frame: 'users_table' }, class: %w[search-box] }) do |f| %>
+  <div class="search-inputs">
+    <div class="fr-input-group main-input input">
+      <%= f.label :email_eq, t('.search.main_input.label'), class: %w[fr-label] %>
+      <%= f.search_field :email_eq, class: %[fr-input], placeholder: t('.search.main_input.placeholder') %>
+    </div>
+
+    <div class="fr-select-group input">
+      <%= f.label :api_role_cont, 'API rôle égal à', class: %w[fr-label] %>
+      <% options = AuthorizationDefinition.all.map { |ad| [ad.name_with_stage, ad.id] } %>
+      <%= f.select :api_role_cont, options_for_select([['Toutes les données', '']].concat(options), selected: params[:search_query].try(:[], :api_role_cont)), {}, class: %w[fr-select] %>
+    </div>
+  </div>
+
+  <div class="actions">
+    <%= f.button t('.search.btn'), type: :submit, class: %w[fr-btn fr-btn--primary] %>
+  </div>
+<% end %>
+
+<turbo-frame id="users_with_roles_table">
+  <div class="fr-table fr-table--bordered">
+    <div class="fr-table__container">
+      <div class="fr-table__content">
+        <table>
+          <thead>
+            <tr>
+              <%
+                %w[
+                  email
+                  organizations
+                  roles
+                  created_at
+                  actions
+                ].each do |attr|
+              %>
+                <th scope="col">
+                  <%= t(".table.header.#{attr}") %>
+                </th>
+              <% end %>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @users.each do |user| %>
+              <tr id="<%= dom_id(user) %>" class="user">
+                <td class="user-email">
+                  <%= user.email %>
+                </td>
+                <td class="user-organizations">
+                  <ul>
+                    <% user.organizations.each do |organization| %>
+                      <li>
+                        <%= organization.raison_sociale %> (<%= link_to organization.siret, "https://annuaire-entreprises.data.gouv.fr/etablissement/#{organization.siret}", target: '_blank' %>)
+                      </li>
+                    <% end %>
+                  </ul>
+                </td>
+                <td class="user-roles">
+                  <ul>
+                    <% user.roles.each do |role| %>
+                      <li>
+                        <%= role %>
+                      </li>
+                    <% end %>
+                  </ul>
+                </td>
+                <td class="user-created_at">
+                  <%= user.created_at.to_date %>
+                </td>
+                <td class="user-actions">
+                  Edit
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <%= paginate @users %>
+</turbo-frame>

--- a/app/views/admin/users_with_roles/index.html.erb
+++ b/app/views/admin/users_with_roles/index.html.erb
@@ -1,3 +1,7 @@
+<%= content_for(:header_action) do %>
+  <%= link_to t('.add'), new_admin_users_with_role_path, class: %[fr-btn] %>
+<% end %>
+
 <%= search_form_for(@search_engine, url: admin_users_with_roles_path, html: { method: :get, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 500, 'auto-submit-form-event-mode-value' => 'input', turbo_frame: 'users_table' }, class: %w[search-box] }) do |f| %>
   <div class="search-inputs">
     <div class="fr-input-group main-input input">
@@ -68,7 +72,7 @@
                   <%= user.created_at.to_date %>
                 </td>
                 <td class="user-actions">
-                  Edit
+                  <%= link_to t('.edit'), edit_admin_users_with_role_path(user), class: %[fr-btn fr-btn--sm] %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/admin/users_with_roles/index.html.erb
+++ b/app/views/admin/users_with_roles/index.html.erb
@@ -49,7 +49,7 @@
                 <td class="user-email">
                   <%= user.email %>
                 </td>
-                <td class="user-organizations">
+                <td class="user-organizations fr-cell--multiline">
                   <ul>
                     <% user.organizations.each do |organization| %>
                       <li>

--- a/app/views/admin/users_with_roles/new.html.erb
+++ b/app/views/admin/users_with_roles/new.html.erb
@@ -1,0 +1,41 @@
+<div class="fr-container">
+  <div class="fr-grid-row">
+    <div class="fr-col-6">
+      <%= form_with(model: @user, url: @user.persisted? ? admin_users_with_role_path(@user) : admin_users_with_roles_path) do |f| %>
+        <%= f.dsfr_email_field :email, required: true, disabled: @user.persisted?, placeholder: t('.form.email.placeholder') %>
+        <%= f.dsfr_text_area :roles, value: @user.roles.split(',').join("\n"), required: true, placeholder: t('.form.roles.placeholder'), rows: 20 %>
+        <%= f.submit t('.cta'), class: %w[fr-btn fr-btn--sm] %>
+      <% end %>
+    </div>
+
+    <div class="fr-col-6 fr-pl-4v">
+      <h3>Instructions</h3>
+
+      <p>
+        Dans le champ "Rôles" : mettre 1 rôle par ligne, de la forme <code>habilitation_code:role_code</code>.
+      </p>
+
+      <hr />
+
+      <strong>Liste des rôles</strong>
+
+      <ul>
+        <li>Rapporteur (code: reporter)</li>
+        <li>Instructeur (code: instructor)</li>
+        <li>Développeur (code: developer)</li>
+      </ul>
+
+      <hr />
+
+      <strong>Liste des habilitations</strong>
+
+      <ul>
+        <% AuthorizationDefinition.all.each do |authorization_definition| %>
+          <li>
+            <%= authorization_definition.name_with_stage %> (code: <%= authorization_definition.id %>)
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/whitelisted_verified_emails/index.html.erb
+++ b/app/views/admin/whitelisted_verified_emails/index.html.erb
@@ -45,4 +45,3 @@
 
   <%= paginate @verified_emails %>
 </turbo-frame>
-

--- a/app/views/admin_mailer/notify_user_roles_change.text.erb
+++ b/app/views/admin_mailer/notify_user_roles_change.text.erb
@@ -1,0 +1,30 @@
+Bonjour,
+
+L'utilisateur <%= @user.email %> s'est vu affecter des nouveaux droits sur les habilitations.
+
+<% if @new_roles.any? %>
+La liste des rôles ajoutés est la suivante :
+
+<% @new_roles.each do |role| %>
+* <%= role %>
+<% end %>
+<% end %>
+
+<% if @old_roles.any? %>
+La liste des rôles retirés est la suivante :
+
+<% @old_roles.each do |role| %>
+* <%= role %>
+<% end %>
+<% end %>
+
+La liste finale est la suivante :
+
+<% @user.roles.each do |role| %>
+* <%= role %>
+<% end %>
+
+Vous êtes notifié car vous êtes un administrateur de DataPass.
+
+Cordialement,
+L'équipe DataPass

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -137,6 +137,7 @@ ignore_unused:
   - "gdpr_contact_mailer.responsable_traitement.subject"
   - "instruction.authorization_requests.index.status.*"
   - "wicked.*"
+  - 'admin.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -5,6 +5,7 @@ fr:
     users_with_roles:
       index:
         title: Utilisateurs avec rôles
+        add: Ajouter des rôles à un utilisateur sans rôle
         search:
           main_input:
             label: Rechercher un utilisateur avec son email
@@ -17,6 +18,27 @@ fr:
             roles: Roles
             created_at: Date de création
             actions: Actions
+        edit: Éditer
+      new:
+        title: Ajouter un rôle à un utilisateur
+        form: &admin_users_with_roles_new_form
+          email:
+            label: Email
+            placeholder: user@gouv.fr
+          roles:
+            label: Rôles
+            placeholder: "api_entreprise:instructor\napi_particulier:reporter"
+        cta: Mettre à jour les rôles
+      update: &admin_user_with_roles_create
+        success: L'utilisateur %{user_email} a été mis à jour avec succès
+        error: Une erreur est survenue
+      create:
+        <<: *admin_user_with_roles_create
+        title: Ajouter un rôle à un utilisateur
+        not_found: L'utilisateur avec l'email %{user_email} n'existe pas
+      edit:
+        title: Éditer les rôles de l'utilisateur
+        form: *admin_users_with_roles_new_form
 
     whitelisted_verified_emails:
       index:

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -2,6 +2,22 @@ fr:
   admin:
     index:
       title: Espace administrateur
+    users_with_roles:
+      index:
+        title: Utilisateurs avec rôles
+        search:
+          main_input:
+            label: Rechercher un utilisateur avec son email
+            placeholder: user@gouv.fr
+          btn: Rechercher
+        table:
+          header:
+            email: Email
+            organizations: Organisations
+            roles: Roles
+            created_at: Date de création
+            actions: Actions
+
     whitelisted_verified_emails:
       index:
         title: Emails en liste blanche

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :whitelisted_verified_emails, only: %w[index new create], path: 'emails-verifies'
+    resources :users_with_roles, only: %i[index], path: 'utilisateurs-avec-roles'
   end
 
   use_doorkeeper scope: '/api/oauth' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :whitelisted_verified_emails, only: %w[index new create], path: 'emails-verifies'
-    resources :users_with_roles, only: %i[index], path: 'utilisateurs-avec-roles'
+    resources :users_with_roles, only: %i[index new create edit update], path: 'utilisateurs-avec-roles'
   end
 
   use_doorkeeper scope: '/api/oauth' do

--- a/db/migrate/20250131124408_create_admin_events.rb
+++ b/db/migrate/20250131124408_create_admin_events.rb
@@ -1,0 +1,13 @@
+class CreateAdminEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :admin_events do |t|
+      t.string :name, null: false
+      t.references :admin, null: false, foreign_key: { to_table: :users }
+      t.references :entity, polymorphic: true, null: false
+      t.json :before_attributes, default: {}
+      t.json :after_attributes, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_06_144515) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_31_124408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -42,6 +42,19 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_06_144515) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "admin_events", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "admin_id", null: false
+    t.string "entity_type", null: false
+    t.bigint "entity_id", null: false
+    t.json "before_attributes", default: {}
+    t.json "after_attributes", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_id"], name: "index_admin_events_on_admin_id"
+    t.index ["entity_type", "entity_id"], name: "index_admin_events_on_entity"
   end
 
   create_table "authorization_documents", force: :cascade do |t|
@@ -385,6 +398,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_06_144515) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "admin_events", "users", column: "admin_id"
   add_foreign_key "authorization_documents", "authorizations"
   add_foreign_key "authorization_request_changelogs", "authorization_requests"
   add_foreign_key "authorization_request_reopening_cancellations", "authorization_requests", column: "request_id"

--- a/features/admin/utilisateurs_avec_roles.feature
+++ b/features/admin/utilisateurs_avec_roles.feature
@@ -1,7 +1,8 @@
 # language: fr
 
 Fonctionnalité: Espace admin: utilisateurs avec rôles
-  En tant qu'administrateur, je peux voir les utilisateurs possédant des rôles
+  En tant qu'administrateur, je peux voir les utilisateurs possédant des rôles. Je peux ajouter et mettre à jours
+  des rôles sur les utilisateurs.
 
   Contexte:
     Sachant que je suis un administrateur
@@ -41,4 +42,33 @@ Fonctionnalité: Espace admin: utilisateurs avec rôles
     Et que je remplis "Rechercher un utilisateur" avec "no-role@gouv.fr"
     Et que je clique sur "Rechercher"
     Alors la page ne contient pas "no-role@gouv.fr"
+
+  Scénario: Je peux modifier des rôles sur un utilisateur
+    Quand il y a l'utilisateur "api-entreprise@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
+    Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
+    Et que je clique sur "Éditer" pour l'utilisateur "api-entreprise@gouv.fr"
+    Et que je remplis "Role" avec "api_entreprise:reporter"
+    Et que je clique sur "Mettre à jour"
+    Alors il y a un message de succès contenant "mis à jour"
+    Et la page contient "api_entreprise:reporter"
+    Et la page ne contient pas "api_entreprise:instructor"
+
+  Scénario: Je veux ajouter des rôles à un utilisateur sans rôle
+    Quand il y a l'utilisateur "api-entreprise@gouv.fr" sans rôle
+    Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
+    Et que je clique sur "Ajouter des rôles à un utilisateur"
+    Et que je remplis "Email" avec "api-entreprise@gouv.fr"
+    Et que je remplis "Role" avec "api_entreprise:reporter"
+    Et que je clique sur "Mettre à jour"
+    Alors il y a un message de succès contenant "mis à jour"
+    Et la page contient "api_entreprise:reporter"
+
+  Scénario: Je veux ajouter des rôles à un utilisateur qui n'existe pas
+    Quand il y a l'utilisateur "api-entreprise@gouv.fr" sans rôle
+    Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
+    Et que je clique sur "Ajouter des rôles à un utilisateur"
+    Et que je remplis "Email" avec "inconnu@gouv.fr"
+    Et que je remplis "Role" avec "api_entreprise:reporter"
+    Et que je clique sur "Mettre à jour"
+    Alors il y a un message d'erreur contenant "n'existe pas"
 

--- a/features/admin/utilisateurs_avec_roles.feature
+++ b/features/admin/utilisateurs_avec_roles.feature
@@ -1,0 +1,44 @@
+# language: fr
+
+Fonctionnalité: Espace admin: utilisateurs avec rôles
+  En tant qu'administrateur, je peux voir les utilisateurs possédant des rôles
+
+  Contexte:
+    Sachant que je suis un administrateur
+    Et que je me connecte
+
+  Scénario: Je peux consulter la liste des utilisateurs avec des rôles (l'utilisateur courant est inclut car est un administrateur)
+    Quand il y a l'utilisateur "api-entreprise@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
+    Et qu'il y a l'utilisateur "api-particulier@gouv.fr" avec le rôle "Rapporteur" pour "API Particulier"
+    Et qu'il y a l'utilisateur "datapass@gouv.fr" avec le rôle "Rapporteur" pour "FranceConnect"
+    Et qu'il y a l'utilisateur "datapass@gouv.fr" avec le rôle d'administrateur
+    Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
+    Alors la page contient 4 utilisateurs
+
+  Scénario: Je peux chercher un utilisateur ayant un rôle avec son email
+    Quand il y a l'utilisateur "api-entreprise@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
+    Et qu'il y a l'utilisateur "api-particulier@gouv.fr" avec le rôle "Rapporteur" pour "API Particulier"
+    Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
+    Et que je remplis "Rechercher un utilisateur" avec "api-entreprise@gouv.fr"
+    Et que je clique sur "Rechercher"
+    Alors la page contient 1 utilisateurs
+    Et la page contient "api-entreprise@gouv.fr"
+    Et la page ne contient pas "api-particulier@gouv.fr"
+
+  Scénario: Je peux chercher un utilisateur avec un rôle
+    Quand il y a l'utilisateur "api-entreprise@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
+    Et qu'il y a l'utilisateur "api-particulier@gouv.fr" avec le rôle "Rapporteur" pour "API Particulier"
+    Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
+    Et que je sélectionne "API Entreprise" pour "API rôle égal à"
+    Et que je clique sur "Rechercher"
+    Alors la page contient 1 utilisateurs
+    Et la page contient "api-entreprise@gouv.fr"
+
+  Scénario: Je ne peux pas chercher un utilisateur sans rôle
+    Quand il y a l'utilisateur "api-entreprise@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
+    Et qu'il y a l'utilisateur "no-role@gouv.fr" sans rôle
+    Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
+    Et que je remplis "Rechercher un utilisateur" avec "no-role@gouv.fr"
+    Et que je clique sur "Rechercher"
+    Alors la page ne contient pas "no-role@gouv.fr"
+

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -13,3 +13,11 @@ end
 Alors('la page contient {int} utilisateurs') do |count|
   expect(page).to have_css('.user', count:)
 end
+
+Quand("je clique sur {string} pour l'utilisateur {string}") do |link, email|
+  user = User.find_by(email:)
+
+  within("#user_#{user.id}") do
+    click_link_or_button link
+  end
+end

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -9,3 +9,7 @@ end
 Alors("je suis sur l'espace administrateur") do
   expect(page).to have_current_path(/admin/)
 end
+
+Alors('la page contient {int} utilisateurs') do |count|
+  expect(page).to have_css('.user', count:)
+end

--- a/features/step_definitions/users_roles_steps.rb
+++ b/features/step_definitions/users_roles_steps.rb
@@ -1,0 +1,33 @@
+Quand("il y a l'utilisateur {string} avec le rôle {string} pour {string}") do |email, humanized_role, authorization_definition_name|
+  user = User.find_by(email:) || FactoryBot.create(:user, email: email)
+
+  case humanized_role.downcase
+  when 'instructeur'
+    role = 'instructor'
+  when 'rapporteur'
+    role = 'reporter'
+  when 'développeur'
+    role = 'developer'
+  else
+    raise "Unknown role #{humanized_role}"
+  end
+
+  user.roles << "#{find_factory_trait_from_name(authorization_definition_name)}:#{role}"
+  user.roles.uniq!
+  user.save!
+end
+
+Quand("il y a l'utilisateur {string} avec le rôle d'administrateur") do |email|
+  user = User.find_by(email:) || FactoryBot.create(:user, email: email)
+
+  user.roles << 'admin'
+  user.roles.uniq!
+  user.save!
+end
+
+Quand("il y a l'utilisateur {string} sans rôle") do |email|
+  user = User.find_by(email:) || FactoryBot.create(:user, email: email)
+
+  user.roles = []
+  user.save!
+end

--- a/spec/factories/admin_events.rb
+++ b/spec/factories/admin_events.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :admin_event do
+    name { 'user_roles_changed' }
+    admin { create(:user, :admin) }
+    entity { create(:user) }
+    before_attributes do
+      {
+        'roles' => [],
+      }
+    end
+
+    after_attributes do
+      {
+        'roles' => ['admin'],
+      }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -56,5 +56,11 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :admin do
+      after(:build) do |user|
+        user.roles << 'admin'
+      end
+    end
   end
 end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe AdminMailer, type: :mailer do
+  describe '#notify_user_roles_change' do
+    let(:mail) { described_class.with(user:, old_roles: %w[api_entreprise:reporter]).notify_user_roles_change }
+
+    let(:user) { create(:user, roles: %w[api_entreprise:instructeur]) }
+    let!(:admins) { create_list(:user, 2, :admin) }
+
+    it 'sends emails to admins in bcc' do
+      expect(mail.bcc).to match_array(User.admin.map(&:email))
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to include(user.email)
+      expect(mail.body.encoded).to include('api_entreprise:instructeur')
+      expect(mail.body.encoded).to include('api_entreprise:reporter')
+    end
+  end
+end

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,0 +1,11 @@
+class AdminMailerPreview < ActionMailer::Preview
+  def notify_user_roles_change
+    AdminMailer.with(user:, old_roles: %w[old_api:instructor]).notify_user_roles_change
+  end
+
+  private
+
+  def user
+    User.with_roles.first
+  end
+end

--- a/spec/models/admin_event_spec.rb
+++ b/spec/models/admin_event_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe AdminEvent, type: :model do
+  it 'has valid factory' do
+    expect(build(:admin_event)).to be_valid
+  end
+end

--- a/spec/organizers/admin/update_user_roles_spec.rb
+++ b/spec/organizers/admin/update_user_roles_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Admin::UpdateUserRoles, type: :organizer do
+  describe '.call' do
+    subject(:update_user_roles) { described_class.call(admin:, user:, roles:) }
+
+    let(:admin) { create(:user, :admin) }
+    let(:user) { create(:user, roles: %w[old_role:reporter]) }
+    let(:roles) { %w[new_role:instructor] }
+
+    before do
+      ActiveJob::Base.queue_adapter = :inline
+    end
+
+    after do
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    it { is_expected.to be_success }
+
+    it 'creates an admin event' do
+      expect {
+        update_user_roles
+      }.to change(AdminEvent, :count).by(1)
+
+      admin_event = AdminEvent.last
+
+      expect(admin_event.name).to eq('user_roles_changed')
+      expect(admin_event.admin).to eq(admin)
+      expect(admin_event.entity).to eq(user)
+      expect(admin_event.before_attributes).to eq('roles' => %w[old_role:reporter])
+      expect(admin_event.after_attributes).to eq('roles' => %w[new_role:instructor])
+    end
+
+    it 'updates the user roles' do
+      expect {
+        update_user_roles
+      }.to change { user.reload.roles }.from(%w[old_role:reporter]).to(%w[new_role:instructor])
+    end
+
+    it 'notifies admins for roles update' do
+      expect {
+        update_user_roles
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
https://www.loom.com/share/5b613f2c74074d9295d01f3c82501b0e

Quelques notes:

* l'ajout/modification est un peu "raw" pour le moment, il faudra bien entendu itérer, mais vu que c'est restreint aux admins pour le moment imo c'est OK à court terme. Dès qu'on voudra mettre ça côté admin des habilitations faudra clairement une meilleure UI
* La modification des rôles est tracé en base de données dans une table `admin_events`
* l'ensemble des administrateurs DataPass sont notifiés en cci avec ce qui a été ajouté, retiré et la liste finale
* Je n'ai pas suivi exactement le [design](https://www.figma.com/design/ANSlIiYhXtQNnsDVWtePH3/Datapass-V2?node-id=6579-126652&t=bVHv1eDfeLkpPRT1-0) qui mentionne l'ensemble des utilisateurs -> j'ai fait aussi un tradeoff pour gérer uniquement les utilisateurs avec des rôles, et surtout, il ne me semble pas opportun de pouvoir ajouter/modifier des données d'utilisateurs pour le moment, vu que l'on passe par ProConnect a qui on délègue l'ensemble de ces tâches. Pour la consultation de tous les utilisateurs, on peut à court terme embed un tableau metabase, ce qui est assez trivial à faire.

--

* [x] Search by API
* [x] Edit -> add/remove rôles
* [x] Add
* [x] Mailing add/remove rôles
* [x] Afficher les rôles dans les settings (related point précédent)
* [x] Review