### PR TITLE
Améliore la réouverture multistage

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,7 +5,7 @@ class DashboardController < AuthenticatedUserController
     redirect_to dashboard_show_path(id: 'moi')
   end
 
-  def show
+  def show # rubocop:disable Metrics/AbcSize
     case params[:id]
     when 'moi'
       @authorization_requests = policy_scope(base_relation).where(applicant: current_user)
@@ -18,7 +18,7 @@ class DashboardController < AuthenticatedUserController
       return
     end
 
-    @authorization_requests = @authorization_requests.not_archived.order(created_at: :desc)
+    @authorization_requests = @authorization_requests.not_archived.order(created_at: :desc).includes(:authorizations)
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,6 +52,8 @@ module ApplicationHelper
   end
 
   def authorization_request_stage_badge(authorization_request, css_class: nil)
+    return unless authorization_request.definition.stage.exists?
+
     stage_badge(authorization_request.definition.stage.type, css_class: css_class)
   end
 

--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -98,6 +98,10 @@ class AuthorizationDefinition < StaticApplicationRecord
     value_or_default(@startable_by_applicant, true)
   end
 
+  def multi_stage?
+    stage.exists?
+  end
+
   delegate :next_stage_form, :next_stage_definition, :next_stage?, to: :stage
 
   def authorization_request_class

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -103,7 +103,7 @@
       <%= render_custom_block_or_default(@authorization_request, block[:name], f:, editable: @authorization_request.filling? && block[:editable]) %>
     <% end %>
 
-    <% if @authorization_request.draft? && !@authorization_request.reopening? && !displayed_on_a_public_page? %>
+    <% if @authorization_request.draft? && !displayed_on_a_public_page? %>
       <%= render partial: 'authorization_request_forms/shared/tos_checkboxes', locals: { f: f } %>
     <% end %>
   </div>
@@ -142,6 +142,18 @@
           <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--between">
             <li class="fr-ml-auto">
               <%= link_to t('authorization_request_forms.form.start_next_stage'), next_authorization_request_stage_path(@authorization_request), class: %w(fr-btn fr-mb-0) %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+  <% elsif policy(@authorization_request).ongoing_request? %>
+    <% content_for :sticky_bar do %>
+      <div class="fr-container fr-grid-row">
+        <div class="fr-col-12">
+          <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--between">
+            <li class="fr-ml-auto">
+              <%= link_to t('authorization_request_forms.form.ongoing_request'), authorization_request_path(@authorization_request), class: %w(fr-btn fr-mb-0) %>
             </li>
           </ul>
         </div>

--- a/app/views/dashboard/card/_authorization_request_card.html.erb
+++ b/app/views/dashboard/card/_authorization_request_card.html.erb
@@ -51,11 +51,9 @@
     </div>
   </div>
 
-  <% if authorization_request.reopening? %>
+  <% if authorization_request.display_card_reopening_footer? %>
     <%= render partial: 'dashboard/card/card_reopening_footer', locals: { authorization_request: authorization_request } %>
-  <% end %>
-
-  <% if authorization_request.display_stage_footer? %>
+  <% elsif authorization_request.display_card_stage_footer? %>
     <%= render partial: 'dashboard/card/stage_footer', locals: { authorization_request: authorization_request } %>
   <% end %>
 

--- a/app/views/dashboard/card/_card_reopening_footer.html.erb
+++ b/app/views/dashboard/card/_card_reopening_footer.html.erb
@@ -11,6 +11,7 @@
     </div>
 
     <div class="footer__badge">
+      <%= authorization_request_stage_badge(authorization_request) %>
       <%= authorization_request_status_badge(authorization_request) %>
     </div>
   </div>

--- a/app/views/dashboard/card/_stage_footer.html.erb
+++ b/app/views/dashboard/card/_stage_footer.html.erb
@@ -5,7 +5,11 @@
         <% if authorization_request.next_stage_already_started? %>
           <%= t('.next_stage_title_production') %>
         <% else %>
-          <%= t('.next_stage_title') %>
+          <% if authorization_request.reopening? %> 
+            <%= t('.next_stage_reopening_title') %>
+          <% else %>
+            <%= t('.next_stage_title') %>
+          <% end %>
         <% end %>
       </p>
 
@@ -13,7 +17,11 @@
         <% if authorization_request.next_stage_already_started? %>
           <%= t('.next_stage_subtitle_production') %>
         <% else %>
-          <%= t('.next_stage_subtitle') %>
+          <% if authorization_request.reopening? %> 
+            <%= t('.next_stage_reopening_subtitle') %>
+          <% else %>
+            <%= t('.next_stage_subtitle') %>
+          <% end %>
         <% end %>
       </p>
     </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -19,6 +19,10 @@ Rails.application.configure do
 
     Bullet.add_safelist type: :unused_eager_loading, class_name: 'AuthorizationRequestEvent', association: :entity
     Bullet.add_safelist type: :unused_eager_loading, class_name: 'AuthorizationRequestEvent', association: :user
+    Bullet.add_safelist type: :unused_eager_loading, class_name: 'AuthorizationRequest', association: :authorizations
+    AuthorizationRequestForm.all.map(&:authorization_request_class).each do |klass|
+      Bullet.add_safelist type: :unused_eager_loading, class_name: klass.to_s, association: :authorizations
+    end
   end
 
   # Settings specified here will take precedence over those in config/application.rb.
@@ -30,12 +34,12 @@ Rails.application.configure do
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -132,6 +132,8 @@ ignore_unused:
   - "authorization_request_forms.build.update.{reopening_,}error.*"
   - "transfer_authorization_requests.create.to_another.error.*"
   - "instruction.{approve,refuse,request_changes_on,revoke}_authorization_requests.create.{reopening_,}success.title"
+  - "instruction.cancel_authorization_reopenings.create.reopening_success.title"
+  - "cancel_authorization_reopenings.create.reopening_success.title"
   - "instruction.cancel_authorization_reopenings.create.success.title"
   - "cancel_authorization_reopenings.create.success.title"
   - "gdpr_contact_mailer.delegue_protection_donnees.subject"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -183,7 +183,9 @@ fr:
         show_cta: Consulter
       stage_footer:
         next_stage_title: Votre demande d’accès au bac à sable a été validée !
+        next_stage_reopening_title: Votre demande de réouverture d’accès au bac à sable a été validée !
         next_stage_subtitle: Vous pouvez poursuivre votre demande afin d’accéder à la production.
+        next_stage_reopening_subtitle: Vous pouvez poursuivre votre demande afin d’accéder à la production.
         start_next_stage_cta: Démarrer ma demande d’habilitation en production
         next_stage_title_production: Votre demande d’accès à la production
         next_stage_subtitle_production: Vous serez notifiés lorsque votre demande aura été instruite.
@@ -452,6 +454,7 @@ fr:
       start_stage_generic: Démarrer ma demande d’habilitation
       start_first_stage: Démarrer ma demande d’habilitation en bac à sable
       start_next_stage: Démarrer ma demande d’habilitation en production
+      ongoing_request: Reprendre ma demande d'habilitation en cours
     shared:
       organization:
         you:
@@ -679,6 +682,8 @@ fr:
           cancel_reopening: Annuler la réouverture de cette demande
 
       create:
+        reopening_success:
+          title: La réouverture de l'habilitation %{name} a été annulée.
         success:
           title: La réouverture de l'habilitation %{name} a été annulée.
 
@@ -871,6 +876,8 @@ fr:
         cancel: Annuler
         cancel_reopening: Annuler ma demande de modification
     create:
+      reopening_success:
+        title: La réouverture de l'habilitation %{name} a été annulée.
       success:
         title: La réouverture de l'habilitation %{name} a été annulée.
       error: Une erreur s'est produite, merci de contacter le support

--- a/features/habilitation_en_plusieurs_paliers.feature
+++ b/features/habilitation_en_plusieurs_paliers.feature
@@ -61,3 +61,6 @@ Fonctionnalité: Interactions avec des habilitations en plusieurs paliers (bac �
 
     Alors il y a un message de succès contenant "soumise avec succès"
     Et je suis sur la page "Demandes et habilitations"
+    Et il y a un badge "Production"
+    Et il y a un badge "En cours"
+    Et la page contient "Votre demande d’accès à la production"

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -121,6 +121,18 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et que je clique sur "Mettre à jour l'habilitation bac à sable"
     Alors je suis sur la page "Demande libre (Bac à sable) - API Impôt Particulier"
     Et il y a un message de succès contenant "a bien été réouverte"
+    Quand je clique sur "Modifier" dans le bloc de résumé "Les personnes impliquées"
+    Et que je remplis les informations du contact "Responsable de traitement" avec :
+      | Nom     | Prénom | Email                 | Téléphone  | Fonction                  |
+      |Jean     | Louis  | nouveau.louis@gouv.fr | 0836656560 | Directeur associé d'exploitation  |
+    Et que je clique sur "Enregistrer les modifications"
+    Et que j'adhère aux conditions générales
+    Et que je coche "J’atteste que mon organisation devra déclarer à la DGFiP l’accomplissement des formalités en matière de protection des données à caractère personnel et qu’elle veillera à procéder à l’homologation de sécurité de son projet."
+    Et que je clique sur "Envoyer ma demande de modification"
+    Alors il y a un message de succès contenant "soumise avec succès"
+    Et il y a un badge "Bac à sable"
+    Et il y a un badge "En cours"
+
 
   Scénario: Initialisation d'une réouverture production d'une demande validée en production
     Quand j'ai 1 demande d'habilitation "API Impôt Particulier" validée
@@ -129,3 +141,40 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et que je clique sur "Mettre à jour l'habilitation de production"
     Alors je suis sur la page "Demande libre (Production) - API Impôt Particulier"
     Et il y a un message de succès contenant "a bien été réouverte"
+
+  Scénario: Je peux terminer un cycle de réouverture d'une demande avec plusieurs paliers
+    Quand j'ai 1 demande d'habilitation "API Impôt Particulier" validée
+    Et que je vais sur la page tableau de bord
+    Et que je clique sur "Mettre à jour"
+    Et que je clique sur "Mettre à jour l'habilitation bac à sable"
+    Alors je suis sur la page "Demande libre (Bac à sable) - API Impôt Particulier"
+    Et il y a un message de succès contenant "a bien été réouverte"
+    Quand je clique sur "Modifier" dans le bloc de résumé "Les personnes impliquées"
+    Et que je remplis les informations du contact "Responsable de traitement" avec :
+      | Nom     | Prénom | Email                 | Téléphone  | Fonction                  |
+      |Jean     | Louis  | nouveau.louis@gouv.fr | 0836656560 | Directeur associé d'exploitation  |
+    Et que je clique sur "Enregistrer les modifications"
+    Et que j'adhère aux conditions générales
+    Et que je coche "J’atteste que mon organisation devra déclarer à la DGFiP l’accomplissement des formalités en matière de protection des données à caractère personnel et qu’elle veillera à procéder à l’homologation de sécurité de son projet."
+    Et que je clique sur "Envoyer ma demande de modification"
+    Alors il y a un message de succès contenant "soumise avec succès"
+    Et qu'un instructeur a validé la demande d'habilitation
+    Et que je vais sur la page tableau de bord
+    Et il y a un badge "Bac à sable"
+    Et il y a un badge "Validé"
+    Et la page ne contient pas "Demande de mise à jour"
+    Et que je vais sur la page tableau de bord
+    Alors je clique sur "Démarrer ma demande d’habilitation en production"
+    Et je clique sur "Débuter ma demande"
+    Et que j'adhère aux conditions générales
+    Et je clique sur "Envoyer ma demande de modification"
+    Et il y a un badge "Bac à sable"
+    Et il y a un badge "Validé"
+    Et il y a un badge "Production"
+    Et il y a un badge "En cours"
+    Et la page contient "Demande de mise à jour"
+    Alors un instructeur a validé la demande d'habilitation
+    Et que je vais sur la page tableau de bord
+    Et il y a un badge "Production"
+    Et il y a un badge "Validé"
+    Et la page ne contient pas "Demande de mise à jour"

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -232,6 +232,13 @@ Quand("un instructeur a révoqué la demande d'habilitation") do
   end
 end
 
+Quand("un instructeur a validé la demande d'habilitation") do
+  authorization_request = AuthorizationRequest.last
+  instructor = create_instructor(authorization_request.definition.id)
+  instructor.update!(roles: AuthorizationDefinition.all.map { |definition| "#{definition.id}:instructor" })
+  ApproveAuthorizationRequest.call(authorization_request: authorization_request, user: instructor)
+end
+
 Quand('cette demande a été {string}') do |status|
   authorization_request = AuthorizationRequest.last
   user = User.last

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -1,3 +1,7 @@
+Alors('montre moi la page') do
+  save_and_open_page # rubocop:disable Lint/Debugger
+end
+
 Quand('print the page') do
   log page.body
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -60,3 +60,8 @@ Seeds.new.flushdb
 Kredis.redis.flushdb
 
 ActiveJob::Base.queue_adapter = :test
+
+Bullet.add_safelist type: :unused_eager_loading, class_name: 'AuthorizationRequest', association: :authorizations
+AuthorizationRequestForm.all.map(&:authorization_request_class).each do |klass|
+  Bullet.add_safelist type: :unused_eager_loading, class_name: klass.to_s, association: :authorizations
+end


### PR DESCRIPTION
Modifie la logique lors des réouvertures multistage et règle des problèmes d'affichage liés à ces réouvertures.

La complexité se retrouve concentrée dans la méthode
`display_card_stage_footer` du decorator. Un follow up est prévu pour
régler ça (mise à plat métier et création d'un PORO facilement
testable).