### PR TITLE
FIX invalid format for API Impot Particulier cadre_juridique_nature

### DIFF
--- a/config/authorization_request_forms/api_impot_particulier.yml
+++ b/config/authorization_request_forms/api_impot_particulier.yml
@@ -113,7 +113,7 @@ api-impot-particulier-cantine-scolaire-sandbox:
       Simplification de la souscription à la cantine scolaire pour les usagers par l’utilisation des données fiscales fournies par la DGFiP afin de déterminer les tarifs applicables.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de souscription à la cantine scolaire
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -140,7 +140,7 @@ api-impot-particulier-cantine-scolaire-editeur:
       Simplification de la souscription à la cantine scolaire pour les usagers par l’utilisation des données fiscales fournies par la DGFiP afin de déterminer les tarifs applicables.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de souscription à la cantine scolaire
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -160,7 +160,7 @@ api-impot-particulier-place-creche-sandbox:
       Simplification des demandes de place en crèche pour les usagers par l’utilisation des données fiscales fournies par la DGFiP.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de place en crèche
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -188,7 +188,7 @@ api-impot-particulier-place-creche-editeur:
       Simplification des demandes de place en crèche pour les usagers par l’utilisation des données fiscales fournies par la DGFiP.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de place en crèche
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -208,7 +208,7 @@ api-impot-particulier-activites-periscolaires-sandbox:
       Simplification de la souscription aux activités périscolaires pour les usagers par l’utilisation des données fiscales fournies par la DGFiP afin de déterminer les tarifs applicables.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de souscription aux activités périscolaires
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -236,7 +236,7 @@ api-impot-particulier-activites-periscolaires-editeur:
       Simplification de la souscription aux activités périscolaires pour les usagers par l’utilisation des données fiscales fournies par la DGFiP afin de déterminer les tarifs applicables.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de souscription aux activités périscolaires
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -256,7 +256,7 @@ api-impot-particulier-stationnement-residentiel-sandbox:
       Simplification des demandes de carte de stationnement résidentiel pour les usagers par l’utilisation des données fiscales fournies par la DGFiP.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de carte de stationnement résidentiel
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -284,7 +284,7 @@ api-impot-particulier-stationnement-residentiel-editeur:
       Simplification des demandes de carte de stationnement résidentiel pour les usagers par l’utilisation des données fiscales fournies par la DGFiP.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de carte de stationnement résidentiel
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -304,7 +304,7 @@ api-impot-particulier-aides-sociales-facultatives-sandbox:
       Simplification des demandes d’aides sociales facultatives pour les usagers par l’utilisation des données fiscales fournies par la DGFiP pour déterminer l’éligibilité au service.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes d’aides sociales facultatives
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -331,7 +331,7 @@ api-impot-particulier-aides-sociales-facultatives-editeur:
       Simplification des demandes d’aides sociales facultatives pour les usagers par l’utilisation des données fiscales fournies par la DGFiP pour déterminer l’éligibilité au service.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes d’aides sociales facultatives
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -351,7 +351,7 @@ api-impot-particulier-carte-transport-sandbox:
       Simplification de la souscription à la carte de transport pour les usagers par l’utilisation des données fiscales fournies par la DGFiP pour déterminer le tarif applicable.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de carte de transport
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
@@ -379,7 +379,8 @@ api-impot-particulier-carte-transport-editeur:
       Simplification de la souscription à la carte de transport pour les usagers par l’utilisation des données fiscales fournies par la DGFiP pour déterminer le tarif applicable.
       (A compléter par le demandeur)
     destinataire_donnees_caractere_personnel: Agents instructeurs des demandes de carte de transport
-    cadre_juridique_nature:
+    cadre_juridique_nature: |
       - Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016, relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données (RGPD)
       - Les articles L. 114-8 et suivants du code des relations entre le public et l’administration (CRPA)
       - Délibération de la collectivité (ou autre fondement juridique)
+


### PR DESCRIPTION
It was an array of string instead of a proper string.