### PR TITLE
Remove eager loading detected in DashboardController

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -18,7 +18,7 @@ class DashboardController < AuthenticatedUserController
       return
     end
 
-    @authorization_requests = @authorization_requests.not_archived.order(created_at: :desc).includes(:authorizations)
+    @authorization_requests = @authorization_requests.not_archived.order(created_at: :desc)
   end
 
   private


### PR DESCRIPTION
  - Résout un problème de requêtes N+1 dans le tableau de bord en supprimant l'appel à .includes(:authorizations) qui est redondant avec le left join déjà  présent dans base_relation.