### PR TITLE
Migre les données du statut des habilitations

### DIFF
--- a/db/migrate/20250401140609_fill_authorizations_state.rb
+++ b/db/migrate/20250401140609_fill_authorizations_state.rb
@@ -1,0 +1,31 @@
+class FillAuthorizationsState < ActiveRecord::Migration[8.0]
+  # rubocop:disable Rails/SkipsModelValidations
+  def up
+    Authorization.where(revoked: true).update_all(state: :revoked)
+    Authorization.where(revoked: false).update_all(state: :obsolete)
+    Authorization.where(id: last_authorizations_by_stage_ids).update_all(state: :active)
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  def down
+  end
+
+  private
+
+  # https://claude.ai/share/a27acb83-d2d0-4f73-9232-4e0cbc479274
+  def last_authorizations_by_stage_ids
+    subquery = Authorization
+      .select('id, request_id, form_uid, created_at,
+               ROW_NUMBER() OVER (PARTITION BY request_id, form_uid ORDER BY created_at DESC) as rn')
+      .to_sql
+
+    result = Authorization.connection.execute(<<-SQL.squish)
+      SELECT request_id, array_agg(id) as authorization_ids
+      FROM (#{subquery}) as latest_auths
+      WHERE rn = 1
+      GROUP BY request_id
+    SQL
+
+    result.map { |row| row['authorization_ids'].tr('{}', '').split(',').map(&:to_i) }.flatten
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_19_100316) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_01_140609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"


### PR DESCRIPTION
Copie du contenu du script adhoc de remplissage du statut des habilitation (vu que celui-ci va être supprimé à terme) dans une migration pour faciliter les déploiements.