### PR TITLE
Harden API authentification

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,7 +5,7 @@ class APIController < ActionController::API
 
   def user_id_session
     {
-      'value' => doorkeeper_token.try(:resource_owner_id),
+      'value' => doorkeeper_token.try(:application).try(:owner),
       'expires_at' => (doorkeeper_token.try(:expires_in) || 0) + Time.current.to_i,
     }
   end

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -294,7 +294,6 @@ class Seeds
   def create_oauth_app
     Doorkeeper::Application.create!(
       name: 'API Entreprise',
-      redirect_uri: 'http://whatever.fr/callback',
       uid: 'client_id',
       secret: 'so_secret',
       owner: api_entreprise_instructor,

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -1,6 +1,7 @@
 class Seeds
   def perform
     create_entities
+    create_oauth_app
     create_all_verified_emails
 
     create_authorization_requests_for_clamart
@@ -110,7 +111,7 @@ class Seeds
       job_title: 'Responsable des instructions',
       phone_number: '0423456789',
       current_organization: dinum_organization,
-      roles: ['api_entreprise:instructor']
+      roles: ['api_entreprise:instructor', 'api_entreprise:developer']
     )
   end
 
@@ -288,6 +289,16 @@ class Seeds
         create_verified_email(authorization_request.send(:"#{contact_type}_email"), 'deliverable')
       end
     end
+  end
+
+  def create_oauth_app
+    Doorkeeper::Application.create!(
+      name: 'API Entreprise',
+      redirect_uri: 'http://whatever.fr/callback',
+      uid: 'client_id',
+      secret: 'so_secret',
+      owner: api_entreprise_instructor,
+    )
   end
 
   def create_verified_email(email, status)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -305,7 +305,7 @@ Doorkeeper.configure do
   #
   # You can completely disable this feature with:
   #
-  # allow_blank_redirect_uri false
+  allow_blank_redirect_uri true
   #
   # Or you can define your custom check:
   #
@@ -366,7 +366,7 @@ Doorkeeper.configure do
   #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
   #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
   #
-  # grant_flows %w[authorization_code client_credentials]
+  grant_flows %w[client_credentials]
 
   # Allows to customize OAuth grant flows that +each+ application support.
   # You can configure a custom block (or use a class respond to `#call`) that must

--- a/db/migrate/20250410130724_remove_non_null_constraint_for_redirect_uri_on_oauth_applications.rb
+++ b/db/migrate/20250410130724_remove_non_null_constraint_for_redirect_uri_on_oauth_applications.rb
@@ -1,0 +1,7 @@
+class RemoveNonNullConstraintForRedirectUriOnOauthApplications < ActiveRecord::Migration[8.0]
+  def up
+    change_column_null :oauth_applications, :redirect_uri, true
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_08_104945) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_10_130724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -332,7 +332,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_104945) do
     t.string "name", null: false
     t.string "uid", null: false
     t.string "secret", null: false
-    t.text "redirect_uri", null: false
+    t.text "redirect_uri"
     t.string "scopes", default: "", null: false
     t.boolean "confidential", default: true, null: false
     t.datetime "created_at", null: false

--- a/spec/requests/api/v1/authorization_requests_controller_spec.rb
+++ b/spec/requests/api/v1/authorization_requests_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'API: Authorization requests' do
   let(:user) { create(:user, :developer, authorization_request_types: %w[api_entreprise]) }
   let(:application) { create(:oauth_application, owner: user) }
-  let(:access_token) { create(:access_token, application:, resource_owner_id: user.id) }
+  let(:access_token) { create(:access_token, application:) }
 
   describe 'index' do
     subject(:get_index) do

--- a/spec/requests/api/v1/credentials_controller_spec.rb
+++ b/spec/requests/api/v1/credentials_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'API: Credentials' do
   context 'when authorized' do
     let(:user) { create(:user) }
     let(:application) { create(:oauth_application, owner: user) }
-    let(:access_token) { create(:access_token, application:, resource_owner_id: user.id) }
+    let(:access_token) { create(:access_token, application:) }
 
     it 'returns the current user' do
       get '/api/v1/me', params: {}, headers: { 'Authorization' => "Bearer #{access_token.token}" }


### PR DESCRIPTION
We're using a client_credentials approach: token has no owner. The
current_user is the application owner here.

An example cURL script which works with local seeds: https://gist.github.com/skelz0r/802471ff8e5593372f3ff40c1c240925