### PR TITLE
Add authorization number in Consulter l'habilitation N°x 

### DIFF
--- a/app/components/historical_authorization_request_event_component.html.erb
+++ b/app/components/historical_authorization_request_event_component.html.erb
@@ -34,7 +34,7 @@
     <% if external_link? %>
       <div class="fr-mt-1w">
         <%= render LinkComponent.new(
-          text: t('instruction.authorization_request_events.authorization_request_event.approve.view_authorization'),
+          text: t('instruction.authorization_request_events.authorization_request_event.approve.view_authorization', authorization: authorization_request_event.authorization.id).html_safe,
           path: authorization_request_authorization_path(
             authorization_request_event.authorization_request,
             authorization_request_event.authorization

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -774,7 +774,7 @@ fr:
         approve:
           message_summary: |
             <strong>%{user_full_name}</strong> a approuvé la demande.
-          view_authorization: Consulter l'habilitation
+          view_authorization: Consulter l'habilitation N°<strong>%{authorization}</strong>.
         request_changes:
           message_summary: |
             <strong>%{user_full_name}</strong> a demandé des modifications sur la demande :


### PR DESCRIPTION
in `historical_authorization_request_event_component` so the instructeur can have access it without clicking on link

<img width="1198" alt="Capture d’écran 2025-04-15 à 15 26 42" src="https://github.com/user-attachments/assets/50376ad5-abb8-429d-b9cb-86f1ff85bcf5" />
