### PR TITLE
Expression besoin specifique cadre always displayed

### DIFF
--- a/app/javascript/controllers/toggle_element_display_based_on_checkbox_controller.js
+++ b/app/javascript/controllers/toggle_element_display_based_on_checkbox_controller.js
@@ -11,10 +11,12 @@ export default class extends Controller {
 
   show () {
     this.elementTarget.classList.remove(this.hiddenClass)
+    this.elementTarget.disabled = false
   }
 
   hide () {
     this.elementTarget.classList.add(this.hiddenClass)
+    this.elementTarget.disabled = true
   }
 
   showElement () {

--- a/app/views/authorization_request_forms/shared/_specific_requirements.html.erb
+++ b/app/views/authorization_request_forms/shared/_specific_requirements.html.erb
@@ -1,4 +1,4 @@
-<div class="fr-form-group fr-my-5w" data-controller="toggle-element-display-based-on-checkbox" data-toggle-element-display-based-on-checkbox-hidden-class="fr-hidden">
+<div class="fr-form-group fr-my-5w" data-controller="toggle-element-display-based-on-checkbox" data-toggle-element-display-based-on-checkbox-hidden-class="disabled">
   <h3 class="fr-mt-0 fr-mb-1w">
     <%= f.wording_for('specific_requirements.title') %>
   </h3>
@@ -9,9 +9,10 @@
 
   <%= f.dsfr_check_box :specific_requirements, data: { toggle_element_display_based_on_checkbox_target: "checkbox", action: "click->toggle-element-display-based-on-checkbox#showElement" } %>
 
-  <fieldset class="fr-fieldset fr-p-2w fr-mx-0-5v specific_requirements__border fr-hidden" aria-label="feedme" aria-describedby="name-1-fieldset-messages" data-toggle-element-display-based-on-checkbox-target="element">
-    <div class="fr-fieldset__element">
+  <fieldset class="fr-fieldset fr-p-2w fr-mx-0-5v specific_requirements__border" aria-label="selectionner-votre-fichier" aria-describedby="expression-besoin-specifique" data-toggle-element-display-based-on-checkbox-target="element" disabled>
+    <div id="expression-besoin-specifique" class="fr-fieldset__element">
       <%= f.dsfr_file_field :specific_requirements_document %>
     </div>
   </fieldset>
+
 </div>


### PR DESCRIPTION
  - Adapt stimulus controller to disabled fieldset when checkbox is not selected
  - Fix one broken ARIA in expression besoin specifique fieldset

<img width="1376" alt="Capture d’écran 2025-04-16 à 12 37 46" src="https://github.com/user-attachments/assets/909ee804-b9f0-4e03-8e46-41aae799bdf1" />

<img width="1376" alt="Capture d’écran 2025-04-16 à 12 37 51" src="https://github.com/user-attachments/assets/97256b5f-844d-471e-8778-918c73177598" />
