### PR TITLE
Remove form_uid on authorizations

### DIFF
--- a/app/interactors/create_authorization.rb
+++ b/app/interactors/create_authorization.rb
@@ -42,7 +42,6 @@ class CreateAuthorization < ApplicationInteractor
     {
       data: authorization_request.data,
       applicant: authorization_request.applicant,
-      form_uid: authorization_request.form_uid,
     }
   end
 end

--- a/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
+++ b/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
@@ -17,7 +17,19 @@ class TransitionAuthorizationRequestToStageOfAuthorization < ApplicationInteract
   end
 
   def lookup_form_id_from_previous_stages
-    authorization.request.definition.stage.find_previous_stage_for_authorization(authorization)[:form].uid
+    find_previous_stage_form_for_request(authorization.request).uid
+  end
+
+  def find_previous_stage_form_for_request(authorization_request)
+    previous_stage = find_previous_stage_for_request(authorization_request)
+
+    previous_stage[:form] || raise(ActiveRecord::RecordNotFound, "Couldn't find form within previous stages with id '#{previous_stage[:form_id]}'")
+  end
+
+  def find_previous_stage_for_request(authorization_request)
+    authorization_request.definition.stage.previous_stages.find do |previous|
+      previous[:definition].authorization_request_class.to_s == authorization.authorization_request_class
+    end
   end
 
   def authorization = context.authorization

--- a/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
+++ b/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
@@ -2,7 +2,7 @@ class TransitionAuthorizationRequestToStageOfAuthorization < ApplicationInteract
   def call
     context.fail! unless context.authorization.reopenable?
 
-    return if context.authorization_request.is_a? context.authorization.authorization_request_class.constantize
+    return if context.authorization_request.type == context.authorization.authorization_request_class
 
     transition_to_authorization_stage
   end
@@ -12,7 +12,21 @@ class TransitionAuthorizationRequestToStageOfAuthorization < ApplicationInteract
   def transition_to_authorization_stage
     context.authorization_request.update!(
       type: context.authorization.authorization_request_class.to_s,
-      form_uid: context.authorization.form_uid,
+      form_uid: lookup_form_id_from_previous_stages,
     )
+  end
+
+  def lookup_form_id_from_previous_stages
+    authorization.request.definition.stage.previous_stages.find { |stage|
+      stage[:definition].authorization_request_class.to_s == authorization.authorization_request_class
+    }[:form].uid
+  end
+
+  def authorization
+    context.authorization
+  end
+
+  def authorization_definition
+    authorization.definition
   end
 end

--- a/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
+++ b/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
@@ -25,8 +25,4 @@ class TransitionAuthorizationRequestToStageOfAuthorization < ApplicationInteract
   def authorization
     context.authorization
   end
-
-  def authorization_definition
-    authorization.definition
-  end
 end

--- a/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
+++ b/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
@@ -17,9 +17,7 @@ class TransitionAuthorizationRequestToStageOfAuthorization < ApplicationInteract
   end
 
   def lookup_form_id_from_previous_stages
-    authorization.request.definition.stage.previous_stages.find { |stage|
-      stage[:definition].authorization_request_class.to_s == authorization.authorization_request_class
-    }[:form].uid
+    authorization.request.definition.stage.find_previous_stage_for_authorization(authorization)[:form].uid
   end
 
   def authorization

--- a/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
+++ b/app/interactors/transition_authorization_request_to_stage_of_authorization.rb
@@ -20,7 +20,5 @@ class TransitionAuthorizationRequestToStageOfAuthorization < ApplicationInteract
     authorization.request.definition.stage.find_previous_stage_for_authorization(authorization)[:form].uid
   end
 
-  def authorization
-    context.authorization
-  end
+  def authorization = context.authorization
 end

--- a/app/models/authorization_definition/stage.rb
+++ b/app/models/authorization_definition/stage.rb
@@ -19,6 +19,12 @@ class AuthorizationDefinition::Stage
     # do nothing
   end
 
+  def find_previous_stage_for_authorization(authorization)
+    previous_stages.find do |previous|
+      previous[:definition].authorization_request_class.to_s == authorization.authorization_request_class
+    end
+  end
+
   def next_stage_form
     return nil if next_stage_definition.blank?
 

--- a/app/models/authorization_definition/stage.rb
+++ b/app/models/authorization_definition/stage.rb
@@ -19,12 +19,6 @@ class AuthorizationDefinition::Stage
     # do nothing
   end
 
-  def find_previous_stage_for_authorization(authorization)
-    previous_stages.find do |previous|
-      previous[:definition].authorization_request_class.to_s == authorization.authorization_request_class
-    end
-  end
-
   def next_stage_form
     return nil if next_stage_definition.blank?
 

--- a/app/serializers/api/v1/authorization_serializer.rb
+++ b/app/serializers/api/v1/authorization_serializer.rb
@@ -1,7 +1,6 @@
 class API::V1::AuthorizationSerializer < ActiveModel::Serializer
   attributes :id,
     :slug,
-    :form_uid,
     :revoked,
     :state,
     :created_at,

--- a/db/migrate/20250421084542_remove_form_uid_on_authorizations.rb
+++ b/db/migrate/20250421084542_remove_form_uid_on_authorizations.rb
@@ -1,0 +1,18 @@
+class RemoveFormUidOnAuthorizations < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_column :authorizations, :form_uid, :string
+  end
+
+  def down
+    add_column :authorizations, :form_uid, :string
+
+    execute <<-SQL.squish
+      UPDATE authorizations
+      SET form_uid = authorization_requests.form_uid
+      FROM authorization_requests
+      WHERE authorizations.request_id = authorization_requests.id;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_10_130724) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_21_084542) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -145,7 +145,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_130724) do
     t.string "slug"
     t.string "authorization_request_class", null: false
     t.boolean "revoked", default: false
-    t.string "form_uid"
     t.string "state"
     t.index ["applicant_id"], name: "index_authorizations_on_applicant_id"
     t.index ["request_id"], name: "index_authorizations_on_request_id"

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -200,7 +200,6 @@ FactoryBot.define do
           authorization_request_class: previous_stage[:definition].authorization_request_class,
           data: authorization_request.data.presence || { 'what' => 'ever' },
           created_at: previous_authorization_created_at,
-          form_uid: previous_stage[:form].id
         )
       end
     end

--- a/spec/factories/authorizations.rb
+++ b/spec/factories/authorizations.rb
@@ -19,7 +19,6 @@ FactoryBot.define do
       authorization.data = authorization.request.data.dup
 
       authorization.data['what'] = 'ever' if authorization.data.blank?
-      authorization.form_uid ||= authorization.request.form_uid
     end
   end
 end

--- a/spec/organizers/approve_authorization_request_spec.rb
+++ b/spec/organizers/approve_authorization_request_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe ApproveAuthorizationRequest do
         expect { approve_authorization_request }.to have_enqueued_mail(GDPRContactMailer, :responsable_traitement)
       end
 
-      it 'stores the form_uid of the authorization_request in the generated authorization' do
-        expect { approve_authorization_request }.to change { authorization_request.authorizations.where(form_uid: authorization_request.form_uid).count }.from(0).to(1)
-      end
-
       {
         hubee_cert_dc: HubEECertDCBridge,
         hubee_dila: HubEEDilaBridge,

--- a/spec/requests/api/v1/authorization_requests_controller_spec.rb
+++ b/spec/requests/api/v1/authorization_requests_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'API: Authorization requests' do
           get_index
 
           auth_response = response.parsed_body[0]['habilitations'].first
-          expect(auth_response).to include('id', 'slug', 'form_uid', 'state', 'created_at')
+          expect(auth_response).to include('id', 'slug', 'state', 'created_at')
         end
       end
 

--- a/spec/serializers/api/v1/authorization_serializer_spec.rb
+++ b/spec/serializers/api/v1/authorization_serializer_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe API::V1::AuthorizationSerializer, type: :serializer do
       expect(serializable_hash).to include(
         id: authorization.id,
         slug: authorization.slug,
-        form_uid: authorization.form_uid,
         revoked: authorization.revoked,
         state: authorization.state,
         created_at: authorization.created_at,


### PR DESCRIPTION
Multiple reasons:

1. Can be infered from authorization request (within this commit)
2. Will be a pain when we'll going to change/migrate forms
3. Form is only a mold for the authorization, it should be linked to it

Moreover, there was no change on the view, so... it is not used nowhere,
so this data is useless.