### PR TITLE
Harden archived event behaviour

### DIFF
--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -69,6 +69,12 @@ class AuthorizationRequest < ApplicationRecord
     inverse_of: :request,
     dependent: :destroy
 
+  has_many :active_authorizations,
+    -> { where(state: 'active') },
+    class_name: 'Authorization',
+    inverse_of: :request,
+    dependent: :destroy
+
   has_many :messages,
     dependent: :destroy
 
@@ -205,7 +211,7 @@ class AuthorizationRequest < ApplicationRecord
     end
 
     event :archive do
-      transition from: all - %i[archived validated], to: :archived, unless: ->(authorization_request) { authorization_request.reopening? }
+      transition from: all - %i[submitted changes_requested archived validated], to: :archived, unless: ->(authorization_request) { authorization_request.active_authorizations.any? }
     end
 
     event :reopen do

--- a/features/archiver_habilitation.feature
+++ b/features/archiver_habilitation.feature
@@ -30,6 +30,7 @@ Fonctionnalité: Supprimer une habilitation
     Et il y a un message de succès contenant "a été supprimée"
     Et un webhook avec l'évènement "archive" est envoyé
 
+  @Pending
   Scénario: Si je veux supprimer une de mes habilitations ayant une étape précédente, il y a un message d'alerte explicitant que cela archive l'entiéreté de la demande
     Quand j'ai 1 demande d'habilitation "API Impôt Particulier" à l'étape "Production" en brouillon
     Et que je me rends sur cette demande d'habilitation

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -142,6 +142,48 @@ RSpec.describe AuthorizationRequest do
     end
   end
 
+  describe 'archive conditions' do
+    subject { authorization_request.can_archive? }
+
+    context 'when authorization request has at least one authorization' do
+      let(:authorization_request) { create(:authorization, state:).request }
+
+      context 'when authorization is active' do
+        let(:state) { 'active' }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context 'when authorization request has no authorizations' do
+      let(:authorization_request) { create(:authorization_request, :api_entreprise, state:) }
+
+      context 'when authorization request is in draft state' do
+        let(:state) { 'draft' }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when authorization request is in submitted state' do
+        let(:state) { 'submitted' }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when authorization request is in request changes state' do
+        let(:state) { 'changes_requested' }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when authorization request is in refused state' do
+        let(:state) { 'refused' }
+
+        it { is_expected.to be_truthy }
+      end
+    end
+  end
+
   describe 'save context' do
     subject(:save_authorization_request) { authorization_request.save(context:) }
 

--- a/spec/organizers/archive_authorization_request_spec.rb
+++ b/spec/organizers/archive_authorization_request_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe ArchiveAuthorizationRequest do
 
     let(:user) { create(:user) }
 
-    context 'with authorization request in submitted state' do
-      let!(:authorization_request) { create(:authorization_request, authorization_request_kind, :submitted) }
+    context 'with authorization request in draft state' do
+      let!(:authorization_request) { create(:authorization_request, authorization_request_kind, :draft) }
       let(:authorization_request_kind) { :hubee_cert_dc }
 
       it { is_expected.to be_success }
 
       it 'changes state to archived' do
-        expect { archive_authorization_request }.to change { authorization_request.reload.state }.from('submitted').to('archived')
+        expect { archive_authorization_request }.to change { authorization_request.reload.state }.from('draft').to('archived')
       end
 
       it_behaves_like 'creates an event', event_name: :archive


### PR DESCRIPTION
    The pending test is no longer valid and should be replaced with a cancel
    action similar to the cancel reopening : we do not want to archive a
    request with active authorizations.

    This is a trade off, if there is some support in the future we will
    reconsider to implement this feature.

    Keep the pending test for the history and blames.