### PR TITLE
Introduce foreign organizations

### DIFF
--- a/app/bridges/hubee_base_bridge.rb
+++ b/app/bridges/hubee_base_bridge.rb
@@ -5,12 +5,12 @@ class HubEEBaseBridge < ApplicationBridge
     {
       type: 'SI',
       companyRegister: organization.siret,
-      branchCode: organization.code_commune,
+      branchCode: organization_code_commune,
       name: organization.denomination,
-      code: organization.sigle_unite_legale,
+      code: organization_sigle_unite_legale,
       country: 'France',
-      postalCode: organization.code_postal,
-      territory: organization.libele_commune,
+      postalCode: organization_code_postal,
+      territory: organization_libelle_commune,
       email: authorization_request.administrateur_metier_email,
       phoneNumber: authorization_request.administrateur_metier_phone_number.gsub(/[ .-]/, ''),
       status: 'Actif'
@@ -46,13 +46,29 @@ class HubEEBaseBridge < ApplicationBridge
   end
 
   def find_or_create_organization
-    hubee_api_client.get_organization(organization.siret, organization.code_commune)
+    hubee_api_client.get_organization(organization.siret, organization_code_commune)
   rescue Faraday::ResourceNotFound
     hubee_api_client.create_organization(organization_create_payload)
   end
 
   def hubee_api_client
     @hubee_api_client ||= HubEEAPIClient.new
+  end
+
+  def organization_code_commune
+    organization.insee_payload.dig('etablissement', 'adresseEtablissement', 'codeCommuneEtablissement')
+  end
+
+  def organization_sigle_unite_legale
+    organization.insee_payload.dig('etablissement', 'uniteLegale', 'sigleUniteLegale')
+  end
+
+  def organization_libelle_commune
+    organization.insee_payload.dig('etablissement', 'adresseEtablissement', 'libelleCommuneEtablissement')
+  end
+
+  def organization_code_postal
+    organization.insee_payload.dig('etablissement', 'adresseEtablissement', 'codePostalEtablissement')
   end
 
   def organization

--- a/app/components/historical_authorization_request_event_component.rb
+++ b/app/components/historical_authorization_request_event_component.rb
@@ -49,7 +49,7 @@ class HistoricalAuthorizationRequestEventComponent < ApplicationComponent
     if entity.from_type == 'User'
       "#{entity.to.full_name} (#{entity.to.email})"
     else
-      "l'organisation #{entity.to.raison_sociale} (numéro SIRET : #{entity.to.siret})"
+      "l'organisation #{entity.to.name} (numéro SIRET : #{entity.to.siret})"
     end
   end
 

--- a/app/controllers/instruction/authorization_requests_controller.rb
+++ b/app/controllers/instruction/authorization_requests_controller.rb
@@ -26,7 +26,7 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   def redirect_to_searched_authorization_request
     return unless search_terms_is_a_possible_id?
 
-    potential_authorization_request = AuthorizationRequest.find_by(id: params[:search_query][:within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont].to_i)
+    potential_authorization_request = AuthorizationRequest.find_by(id: params[:search_query][main_search_input_key])
 
     return unless potential_authorization_request
 
@@ -40,7 +40,7 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   def search_terms_is_a_possible_id?
     return false if params[:search_query].blank?
 
-    main_search_input = params[:search_query][:within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont]
+    main_search_input = params[:search_query][main_search_input_key]
 
     return false if main_search_input.blank?
 
@@ -58,6 +58,10 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   def save_or_load_search_params
     session[search_key] = params[:search_query] if params[:search_query].present?
     params[:search_query] = session[search_key] if params[:search_query].blank?
+  end
+
+  def main_search_input_key
+    :within_data_or_organization_name_or_organization_legal_entity_id_or_applicant_email_or_applicant_family_name_cont
   end
 
   def search_key

--- a/app/controllers/instruction/authorization_requests_controller.rb
+++ b/app/controllers/instruction/authorization_requests_controller.rb
@@ -26,7 +26,7 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   def redirect_to_searched_authorization_request
     return unless search_terms_is_a_possible_id?
 
-    potential_authorization_request = AuthorizationRequest.find_by(id: params[:search_query][:within_data_or_organization_raison_sociale_or_organization_siret_or_applicant_email_or_applicant_family_name_cont].to_i)
+    potential_authorization_request = AuthorizationRequest.find_by(id: params[:search_query][:within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont].to_i)
 
     return unless potential_authorization_request
 
@@ -40,7 +40,7 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   def search_terms_is_a_possible_id?
     return false if params[:search_query].blank?
 
-    main_search_input = params[:search_query][:within_data_or_organization_raison_sociale_or_organization_siret_or_applicant_email_or_applicant_family_name_cont]
+    main_search_input = params[:search_query][:within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont]
 
     return false if main_search_input.blank?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -46,7 +46,7 @@ class SessionsController < ApplicationController
 
     success_message(
       title: t('sessions.change_current_organization.success.title'),
-      description: t('sessions.change_current_organization.success.description', organization_name: current_organization.raison_sociale, organization_siret: current_organization.siret),
+      description: t('sessions.change_current_organization.success.description', organization_name: current_organization.name, organization_siret: current_organization.siret),
     )
 
     redirect_to after_prompt_path

--- a/app/controllers/transfer_authorization_requests_controller.rb
+++ b/app/controllers/transfer_authorization_requests_controller.rb
@@ -61,7 +61,7 @@ class TransferAuthorizationRequestsController < AuthenticatedUserController
   def affect_local_error(organizer)
     @error = t(
       ".#{to_new_applicant}.error.#{organizer.error}",
-      organization_name: @authorization_request.organization.raison_sociale,
+      organization_name: @authorization_request.organization.name,
       organization_siret: @authorization_request.organization.siret,
     )
   end

--- a/app/interactors/find_or_create_organization.rb
+++ b/app/interactors/find_or_create_organization.rb
@@ -11,7 +11,8 @@ class FindOrCreateOrganization < ApplicationInteractor
 
   def find_or_initialize_organization
     Organization.where(
-      siret: info_payload['siret'],
+      legal_entity_id: info_payload['siret'],
+      legal_entity_registry: 'insee_sirene',
     ).first_or_initialize
   end
 

--- a/app/jobs/register_organization_with_contacts_on_crm_job.rb
+++ b/app/jobs/register_organization_with_contacts_on_crm_job.rb
@@ -34,7 +34,7 @@ class RegisterOrganizationWithContactsOnCRMJob < ApplicationJob
   def create_company_on_crm
     crm_client.create_company(
       siret: organization.siret,
-      name: organization.raison_sociale,
+      name: organization.name,
       categorie_juridique: organization.categorie_juridique.try(:code),
       n_datapass: authorization_request.id.to_s,
       bouquets_utilises: extract_bouquet(:company)

--- a/app/jobs/register_organization_with_contacts_on_crm_job.rb
+++ b/app/jobs/register_organization_with_contacts_on_crm_job.rb
@@ -35,7 +35,7 @@ class RegisterOrganizationWithContactsOnCRMJob < ApplicationJob
     crm_client.create_company(
       siret: organization.siret,
       name: organization.name,
-      categorie_juridique: organization.categorie_juridique.try(:code),
+      categorie_juridique: organization_categorie_juridique.try(:code),
       n_datapass: authorization_request.id.to_s,
       bouquets_utilises: extract_bouquet(:company)
     )
@@ -188,6 +188,14 @@ class RegisterOrganizationWithContactsOnCRMJob < ApplicationJob
     else
       contact.type.to_s
     end
+  end
+
+  def organization_categorie_juridique
+    return if organization.insee_payload.blank?
+
+    CategorieJuridique.find(organization.insee_payload['etablissement']['uniteLegale']['categorieJuridiqueUniteLegale'])
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def organization

--- a/app/jobs/update_organization_insee_payload_job.rb
+++ b/app/jobs/update_organization_insee_payload_job.rb
@@ -8,6 +8,7 @@ class UpdateOrganizationINSEEPayloadJob < ApplicationJob
     @organization = Organization.find(organization_id)
 
     return if last_update_within_24h?
+    return if organization.foreign?
 
     update_organization_insee_payload
   # rubocop:disable Lint/SuppressedException

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -150,7 +150,7 @@ class Seeds
 
   def create_organization(siret:, name:)
     Organization.create!(
-      siret:,
+      legal_entity_id: siret,
       last_mon_compte_pro_updated_at: DateTime.now,
       mon_compte_pro_payload: {
         label: name

--- a/app/mailers/france_connect_mailer.rb
+++ b/app/mailers/france_connect_mailer.rb
@@ -14,6 +14,6 @@ class FranceConnectMailer < ApplicationMailer
   private
 
   def new_scopes_subject(authorization_request)
-    "[DataPass] nouveaux scopes pour \"#{authorization_request.organization.raison_sociale} - #{authorization_request.id}\""
+    "[DataPass] nouveaux scopes pour \"#{authorization_request.organization.name} - #{authorization_request.id}\""
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,14 +36,6 @@ class Organization < ApplicationRecord
     insee_latest_etablissement_period['etatAdministratifEtablissement'] == 'F'
   end
 
-  def categorie_juridique
-    return if insee_payload.blank?
-
-    CategorieJuridique.find(insee_payload['etablissement']['uniteLegale']['categorieJuridiqueUniteLegale'])
-  rescue ActiveRecord::RecordNotFound
-    nil
-  end
-
   def self.ransackable_attributes(_auth_object = nil)
     %w[
       siret

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,24 +22,8 @@ class Organization < ApplicationRecord
     denomination || "l'organisation #{siret} (nom inconnu)"
   end
 
-  def code_commune
-    insee_payload.dig('etablissement', 'adresseEtablissement', 'codeCommuneEtablissement')
-  end
-
   def denomination
     insee_payload.dig('etablissement', 'uniteLegale', 'denominationUniteLegale')
-  end
-
-  def sigle_unite_legale
-    insee_payload.dig('etablissement', 'uniteLegale', 'sigleUniteLegale')
-  end
-
-  def code_postal
-    insee_payload.dig('etablissement', 'adresseEtablissement', 'codePostalEtablissement')
-  end
-
-  def libele_commune
-    insee_payload.dig('etablissement', 'adresseEtablissement', 'libelleCommuneEtablissement')
   end
 
   def insee_payload

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -18,7 +18,7 @@ class Organization < ApplicationRecord
     class_name: 'AuthorizationRequest',
     inverse_of: :organization
 
-  def raison_sociale
+  def name
     denomination || "l'organisation #{siret} (nom inconnu)"
   end
 
@@ -63,7 +63,7 @@ class Organization < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[
       siret
-      raison_sociale
+      name
     ]
   end
 
@@ -71,7 +71,7 @@ class Organization < ApplicationRecord
     []
   end
 
-  ransacker :raison_sociale do |parent|
+  ransacker :name do |parent|
     payload_node = parent.table[:insee_payload]
 
     etablissement_node = Arel::Nodes::InfixOperation.new('->', payload_node, Arel::Nodes.build_quoted('etablissement'))

--- a/app/serializers/webhook_organization_serializer.rb
+++ b/app/serializers/webhook_organization_serializer.rb
@@ -1,5 +1,5 @@
 class WebhookOrganizationSerializer < ApplicationSerializer
   attributes :id,
-    :raison_sociale,
+    :name,
     :siret
 end

--- a/app/services/dgfip_spreadsheet_generator.rb
+++ b/app/services/dgfip_spreadsheet_generator.rb
@@ -63,7 +63,7 @@ class DGFIPSpreadsheetGenerator
       authorization_request.created_at,
       authorization_request.events.order(created_at: :desc).limit(1).first&.created_at,
       authorization_request.organization.siret,
-      authorization_request.organization.raison_sociale,
+      authorization_request.organization.name,
       authorization_request.organization.insee_payload.to_json,
     ]
   end

--- a/app/views/admin/users_with_roles/index.html.erb
+++ b/app/views/admin/users_with_roles/index.html.erb
@@ -53,7 +53,7 @@
                   <ul>
                     <% user.organizations.each do |organization| %>
                       <li>
-                        <%= organization.raison_sociale %> (<%= link_to organization.siret, "https://annuaire-entreprises.data.gouv.fr/etablissement/#{organization.siret}", target: '_blank' %>)
+                        <%= organization.name %> (<%= link_to organization.siret, "https://annuaire-entreprises.data.gouv.fr/etablissement/#{organization.siret}", target: '_blank' %>)
                       </li>
                     <% end %>
                   </ul>

--- a/app/views/authorization_request_forms/_unicity_callout.html.erb
+++ b/app/views/authorization_request_forms/_unicity_callout.html.erb
@@ -6,6 +6,6 @@
     <%= t('.title')%>
   </h3>
         
-  <%= simple_format t(".#{callout_key}.content", organization_raison_sociale: current_organization.raison_sociale), { class: 'fr-callout__text fr-my-3w' }, wrapper_tag: 'p' %>
-  <%= link_to t(".#{callout_key}.cta", organization_raison_sociale: current_organization.raison_sociale), authorization_request_path(authorization_request), class: 'fr-link fr-btn--icon-right fr-icon-arrow-right-line' %>
+  <%= simple_format t(".#{callout_key}.content", organization_name: current_organization.name), { class: 'fr-callout__text fr-my-3w' }, wrapper_tag: 'p' %>
+  <%= link_to t(".#{callout_key}.cta", organization_name: current_organization.name), authorization_request_path(authorization_request), class: 'fr-link fr-btn--icon-right fr-icon-arrow-right-line' %>
 </div>

--- a/app/views/authorization_request_forms/new.html.erb
+++ b/app/views/authorization_request_forms/new.html.erb
@@ -7,13 +7,13 @@
     <div class="border-frame-text fr-my-6w">
       <% if @authorization_request_form.name.present? %>
         <%= simple_format t(".organization.start_text_with_form_name",
-          organization_raison_sociale: current_organization.raison_sociale,
+          organization_name: current_organization.name,
           organization_siret: current_organization.siret,
           authorization_request_form_name: @authorization_request_form.name),
           {}, wrapper_tag: 'div' %>
       <% else %>
         <%= simple_format t(".organization.start_text",
-          organization_raison_sociale: current_organization.raison_sociale,
+          organization_name: current_organization.name,
           organization_siret: current_organization.siret),
           {}, wrapper_tag: 'div' %>
       <% end %>

--- a/app/views/authorization_request_forms/shared/_organization.html.erb
+++ b/app/views/authorization_request_forms/shared/_organization.html.erb
@@ -47,7 +47,7 @@
 
           <ul>
             <li>
-              <strong><%= organization.raison_sociale %></strong>
+              <strong><%= organization.name %></strong>
             </li>
             <% %i[siret].each do |attr| %>
               <li>

--- a/app/views/authorization_request_mailer/hubee_cert_dc/approve.text.erb
+++ b/app/views/authorization_request_mailer/hubee_cert_dc/approve.text.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'mailer/shared/applicant/header', locals: { entity_name: @authorization_request.applicant.full_name } %>
 
-Votre demande d’abonnement à la démarche CertDc pour <%= @authorization_request.organization.raison_sociale %> a été validée.
+Votre demande d’abonnement à la démarche CertDc pour <%= @authorization_request.organization.name %> a été validée.
 
 <% if @authorization_request.applicant.email == @authorization_request.administrateur_metier_email %>
   Un compte de type administrateur a été créé pour vous sur le Portail HubEE afin de finaliser la procédure d’abonnement.

--- a/app/views/authorization_request_mailer/hubee_dila/approve.text.erb
+++ b/app/views/authorization_request_mailer/hubee_dila/approve.text.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'mailer/shared/applicant/header', locals: { entity_name: @authorization_request.applicant.full_name } %>
 
-Votre demande d’abonnement aux démarches service-public.fr pour <%= @authorization_request.organization.raison_sociale %> a été validée.
+Votre demande d’abonnement aux démarches service-public.fr pour <%= @authorization_request.organization.name %> a été validée.
 
 <% if @authorization_request.applicant.email == @authorization_request.administrateur_metier_email %>
   Un compte de type administrateur a été créé pour vous sur le Portail HubEE afin de finaliser la procédure d’abonnement.

--- a/app/views/authorization_requests/closed_organization.html.erb
+++ b/app/views/authorization_requests/closed_organization.html.erb
@@ -8,7 +8,7 @@
         <%= t('.subtitle') %>
       </h2>
       <p class="fr-text--lg">
-        <%= t('.reason', organization_raison_sociale: current_organization.raison_sociale, organization_siret: current_organization.siret).html_safe %>
+        <%= t('.reason', organization_name: current_organization.name, organization_siret: current_organization.siret).html_safe %>
       </p>
 
       <%= form_with(url: "/auth/mon_compte_pro?prompt=select_organization", method: :post, data: { turbo: false }, class: 'fr-pt-1w') do |f| %>

--- a/app/views/authorization_requests/new/default.html.erb
+++ b/app/views/authorization_requests/new/default.html.erb
@@ -5,7 +5,7 @@
 <div class="fr-mb-4w">
   <div class="border-frame-text fr-my-3w">
     <%= simple_format t("authorization_request_forms.new.organization.start_text",
-      organization_raison_sociale: current_organization.raison_sociale,
+      organization_name: current_organization.name,
       organization_siret: current_organization.siret).html_safe,
       {}, wrapper_tag: 'div' %>
   </div>

--- a/app/views/authorization_requests/shared/_organization_and_applicant.html.erb
+++ b/app/views/authorization_requests/shared/_organization_and_applicant.html.erb
@@ -39,7 +39,7 @@
           </div>
 
           <div class="contact-card__full_name">
-            <%= @authorization_request.organization.raison_sociale %>
+            <%= @authorization_request.organization.name %>
           </div>
 
           <%

--- a/app/views/cancel_authorization_reopenings/new.html.erb
+++ b/app/views/cancel_authorization_reopenings/new.html.erb
@@ -15,7 +15,7 @@
                 t(
                   ".initial.description.organization",
                   authorization_request_name: sanitize(@authorization_request.name),
-                  organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                  organization_name: @authorization_request.organization.name,
                   organization_siret: @authorization_request.organization.siret,
                 )
               %>

--- a/app/views/france_connect_mailer/new_scopes.text.erb
+++ b/app/views/france_connect_mailer/new_scopes.text.erb
@@ -1,6 +1,6 @@
 Bonjour,
 
-Une <%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> <%= @authorization_request.definition.name %> pour le FS <%= @authorization_request.organization.raison_sociale %> (identifiant DataPass de l’<%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> FranceConnect associée : <%= @france_connect_authorization_request.id %>) vient d’être validée.
+Une <%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> <%= @authorization_request.definition.name %> pour le FS <%= @authorization_request.organization.name %> (identifiant DataPass de l’<%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> FranceConnect associée : <%= @france_connect_authorization_request.id %>) vient d’être validée.
 
 En conséquence, merci d’autoriser les scopes suivant pour le sus-mentionné FS :
 

--- a/app/views/gdpr_contact_mailer/delegue_protection_donnees.text.erb
+++ b/app/views/gdpr_contact_mailer/delegue_protection_donnees.text.erb
@@ -5,7 +5,7 @@
   raw t(
     '.description',
     authorization_request_applicant_email: @authorization_request.applicant.email,
-    authorization_request_organization: @authorization_request.organization.raison_sociale,
+    authorization_request_organization: @authorization_request.organization.name,
     authorization_request_contact_kind: contact_kind,
     authorization_request_name: @authorization_request.name,
     authorization_request_definition_name: @authorization_request.definition.name_with_stage,

--- a/app/views/gdpr_contact_mailer/responsable_traitement.text.erb
+++ b/app/views/gdpr_contact_mailer/responsable_traitement.text.erb
@@ -4,7 +4,7 @@
   t(
     '.description',
     authorization_request_applicant_email: @authorization_request.applicant.email,
-    authorization_request_organization: @authorization_request.organization.raison_sociale,
+    authorization_request_organization: @authorization_request.organization.name,
     authorization_request_contact_kind: t("authorization_request.contacts.responsable_traitement"),
     authorization_request_name: @authorization_request.name,
     authorization_request_definition_name: @authorization_request.definition.name_with_stage,

--- a/app/views/instruction/approve_authorization_requests/new.html.erb
+++ b/app/views/instruction/approve_authorization_requests/new.html.erb
@@ -14,7 +14,7 @@
               t(
                 ".#{namespace}.description.organization",
                 authorization_request_name: sanitize(@authorization_request.name),
-                organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                organization_name: @authorization_request.organization.name,
                 organization_siret: @authorization_request.organization.siret,
               )
             %>

--- a/app/views/instruction/authorization_request_mailer/reopening_submit.text.erb
+++ b/app/views/instruction/authorization_request_mailer/reopening_submit.text.erb
@@ -5,7 +5,7 @@
     '.description',
     applicant_full_name: @authorization_request.applicant.full_name,
     applicant_email: @authorization_request.applicant.email,
-    organization_raison_sociale: @authorization_request.organization.raison_sociale,
+    organization_name: @authorization_request.organization.name,
     authorization_request_instruction_url: instruction_authorization_request_url(@authorization_request),
   )
 %>

--- a/app/views/instruction/authorization_request_mailer/submit.text.erb
+++ b/app/views/instruction/authorization_request_mailer/submit.text.erb
@@ -5,7 +5,7 @@
     '.description',
     applicant_full_name: @authorization_request.applicant.full_name,
     applicant_email: @authorization_request.applicant.email,
-    organization_raison_sociale: @authorization_request.organization.raison_sociale,
+    organization_name: @authorization_request.organization.name,
     authorization_request_instruction_url: instruction_authorization_request_url(@authorization_request),
   )
 %>

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -3,8 +3,8 @@
 <%= search_form_for(@search_engine, url: instruction_authorization_requests_path, html: { method: :get, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 300, 'auto-submit-form-event-mode-value' => 'input', turbo_frame: 'authorization_requests_table' }, class: %w[search-box] }) do |f| %>
   <div class="search-inputs">
     <div class="fr-input-group main-input input">
-      <%= f.label :within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont, t('.search.main_input.label'), class: %w[fr-label] %>
-      <%= f.search_field :within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont, class: %[fr-input], placeholder: t('.search.main_input.placeholder'), id: 'instructor_search_input' %>
+      <%= f.label :within_data_or_organization_name_or_organization_legal_entity_id_or_applicant_email_or_applicant_family_name_cont, t('.search.main_input.label'), class: %w[fr-label] %>
+      <%= f.search_field :within_data_or_organization_name_or_organization_legal_entity_id_or_applicant_email_or_applicant_family_name_cont, class: %[fr-input], placeholder: t('.search.main_input.placeholder'), id: 'instructor_search_input' %>
     </div>
 
     <% if current_user.authorization_definition_roles_as(:reporter).count > 1 %>

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -3,8 +3,8 @@
 <%= search_form_for(@search_engine, url: instruction_authorization_requests_path, html: { method: :get, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 300, 'auto-submit-form-event-mode-value' => 'input', turbo_frame: 'authorization_requests_table' }, class: %w[search-box] }) do |f| %>
   <div class="search-inputs">
     <div class="fr-input-group main-input input">
-      <%= f.label :within_data_or_organization_raison_sociale_or_organization_siret_or_applicant_email_or_applicant_family_name_cont, t('.search.main_input.label'), class: %w[fr-label] %>
-      <%= f.search_field :within_data_or_organization_raison_sociale_or_organization_siret_or_applicant_email_or_applicant_family_name_cont, class: %[fr-input], placeholder: t('.search.main_input.placeholder'), id: 'instructor_search_input' %>
+      <%= f.label :within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont, t('.search.main_input.label'), class: %w[fr-label] %>
+      <%= f.search_field :within_data_or_organization_name_or_organization_siret_or_applicant_email_or_applicant_family_name_cont, class: %[fr-input], placeholder: t('.search.main_input.placeholder'), id: 'instructor_search_input' %>
     </div>
 
     <% if current_user.authorization_definition_roles_as(:reporter).count > 1 %>
@@ -79,7 +79,7 @@
             <%= authorization_request.last_submitted_at&.strftime("%d/%m/%y") || '-' %>
           </td>
           <td class="authorization-request-organization">
-            <%= authorization_request.organization.raison_sociale %>
+            <%= authorization_request.organization.name %>
           </td>
           <td class="authorization-request-project-name">
             <%= authorization_request.name %>

--- a/app/views/instruction/cancel_authorization_reopenings/new.html.erb
+++ b/app/views/instruction/cancel_authorization_reopenings/new.html.erb
@@ -13,7 +13,7 @@
                 t(
                   ".initial.description.organization",
                   authorization_request_name: sanitize(@authorization_request.name),
-                  organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                  organization_name: @authorization_request.organization.name,
                   organization_siret: @authorization_request.organization.siret,
                 )
               %>

--- a/app/views/instruction/refuse_authorization_requests/new.html.erb
+++ b/app/views/instruction/refuse_authorization_requests/new.html.erb
@@ -15,7 +15,7 @@
                 t(
                   ".#{namespace}.description.organization",
                   authorization_request_name: sanitize(@authorization_request.name),
-                  organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                  organization_name: @authorization_request.organization.name,
                   organization_siret: @authorization_request.organization.siret,
                 )
               %>

--- a/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
+++ b/app/views/instruction/request_changes_on_authorization_requests/new.html.erb
@@ -15,7 +15,7 @@
                 t(
                   ".#{namespace}.description.organization",
                   authorization_request_name: sanitize(@authorization_request.name),
-                  organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                  organization_name: @authorization_request.organization.name,
                   organization_siret: @authorization_request.organization.siret,
                 )
               %>

--- a/app/views/instruction/revoke_authorization_requests/new.html.erb
+++ b/app/views/instruction/revoke_authorization_requests/new.html.erb
@@ -13,7 +13,7 @@
                 t(
                   ".initial.description.organization",
                   authorization_request_name: sanitize(@authorization_request.name),
-                  organization_raison_sociale: @authorization_request.organization.raison_sociale,
+                  organization_name: @authorization_request.organization.name,
                   organization_siret: @authorization_request.organization.siret,
                 )
               %>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -8,7 +8,7 @@
           </h1>
 
           <%= form_with(url: "/auth/mon_compte_pro?prompt=select_organization", method: :post, data: { turbo: false }, class: 'fr-pt-1w') do |f| %>
-            <%= f.button current_organization.raison_sociale, class: %w(fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-hotel-line) %>
+            <%= f.button current_organization.name, class: %w(fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-hotel-line) %>
           <% end %>
         </div>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,8 +4,8 @@ default: &default
 
 development:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DB') { 'development' } %>
+  database: <%= ENV.fetch('POSTGRES_DB') { 'data_pass_development' } %>
 
 test:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DB') { 'test' } %>
+  database: <%= ENV.fetch('POSTGRES_DB') { 'data_pass_test' } %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -303,7 +303,7 @@ fr:
       title: Désolé, vous ne pouvez pas faire de nouvelle demande
       subtitle: Pourquoi ?
       reason: |
-        Vous êtes connecté pour le compte de <strong>%{organization_raison_sociale}</strong> (SIRET : %{organization_siret}) et cette organisation est fermée, vous ne pouvez donc pas soumettre de nouvelle demande d’habilitation.
+        Vous êtes connecté pour le compte de <strong>%{organization_name}</strong> (SIRET : %{organization_siret}) et cette organisation est fermée, vous ne pouvez donc pas soumettre de nouvelle demande d’habilitation.
       change_organization: Changer d’organisation
       error:
         description: Vous pensez que c’est une erreur ?
@@ -362,8 +362,8 @@ fr:
       back_to_dashboard: Retour à l’accueil
       title: *start_new_habilitation_title
       organization:
-        start_text: Vous êtes sur le point de démarrer une nouvelle demande d’habilitation pour le compte de <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/%{organization_siret}" target="_blank">%{organization_raison_sociale}</a>.
-        start_text_with_form_name: Vous êtes sur le point de démarrer une nouvelle demande d’habilitation pour le compte de <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/%{organization_siret}" target="_blank">%{organization_raison_sociale}</a> via le formulaire <strong>%{authorization_request_form_name}</strong>.
+        start_text: Vous êtes sur le point de démarrer une nouvelle demande d’habilitation pour le compte de <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/%{organization_siret}" target="_blank">%{organization_name}</a>.
+        start_text_with_form_name: Vous êtes sur le point de démarrer une nouvelle demande d’habilitation pour le compte de <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/%{organization_siret}" target="_blank">%{organization_name}</a> via le formulaire <strong>%{authorization_request_form_name}</strong>.
       intro:
         title: Les objectifs de ce formulaire
       single_form:
@@ -377,10 +377,10 @@ fr:
     unicity_callout:
       title: Vous ne pouvez pas créer de nouvelle habilitation
       habilitation:
-        content: Votre organisation <strong>%{organization_raison_sociale}</strong> possède déjà une habilitation pour ce service.
+        content: Votre organisation <strong>%{organization_name}</strong> possède déjà une habilitation pour ce service.
         cta: Consulter l'habilitation existante
       demande:
-        content: Votre organisation <strong>%{organization_raison_sociale}</strong> possède déjà une demande en cours pour ce service.
+        content: Votre organisation <strong>%{organization_name}</strong> possède déjà une demande en cours pour ce service.
         cta: Consulter la demande en cours
 
     create_for_single_page_form:
@@ -605,7 +605,7 @@ fr:
           title: Validation de la demande d'habilitation
           description:
             organization: |
-              Vous êtes sur le point de valider la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de valider la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               <strong>Cette action est irréversible</strong>. Veuillez vérifier que la demande d'habilitation est bien conforme aux règles de gestion.
           cancel: Annuler
@@ -614,7 +614,7 @@ fr:
           title: Validation de la demande de mise à jour de l'habilitation.
           description:
             organization: |
-              Vous êtes sur le point de valider la demande de mise à jour de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de valider la demande de mise à jour de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               <strong>Cette action est irréversible</strong>. Veuillez vérifier que la demande de mise à jour de l'habilitation est bien conforme aux règles de gestion.
           cancel: Annuler
@@ -631,7 +631,7 @@ fr:
           title: Refus de la demande d'habilitation
           description:
             organization: |
-              Vous êtes sur le point de refuser la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de refuser la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               <strong>Cette action est irréversible</strong>.
               Merci de renseigner une raison ci-dessous qui sera communiquée au demandeur.
@@ -641,7 +641,7 @@ fr:
           title: Refus de la demande de mise à jour de l'habilitation
           description:
             organization: |
-              Vous êtes sur le point de refuser la demande de mise à jour de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de refuser la demande de mise à jour de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               Merci de renseigner une raison ci-dessous qui sera communiquée au demandeur. A noter que lors du refus, les modifications apportées par le demandeur depuis le début de la réouverture seront annulées. L'habilitation sera toujours valide.
           cancel: Annuler
@@ -658,7 +658,7 @@ fr:
           title: Révocation de l'habilitation
           description:
             organization: |
-              Vous êtes sur le point de révoquer cette habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de révoquer cette habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               <strong>Cette action est irréversible</strong>.
               Merci de renseigner les motifs qui seront communiqués au demandeur.
@@ -675,7 +675,7 @@ fr:
           title: Annulation de la réouverture de l'habilitation
           description:
             organization: |
-              Vous êtes sur le point d'annuler la réouverture de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point d'annuler la réouverture de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               <strong>Cette action est irréversible</strong>.
               Merci de renseigner les motifs de cette annulation, ceci à des fins d'historisation.
@@ -694,7 +694,7 @@ fr:
           title: Demande de modifications
           description:
             organization: |
-              Vous êtes sur le point de demander des modifications sur la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de demander des modifications sur la demande d'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               Merci de renseigner les raisons ci-dessous qui sera communiquée au demandeur.
           cancel: Annuler
@@ -703,7 +703,7 @@ fr:
           title: Demande de modifications
           description:
             organization: |
-              Vous êtes sur le point de demander des modifications sur la mise à jour de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_raison_sociale}' (numéro de siret: %{organization_siret}).
+              Vous êtes sur le point de demander des modifications sur la mise à jour de l'habilitation '%{authorization_request_name}' au profit de l'organisation '%{organization_name}' (numéro de siret: %{organization_siret}).
             disclaimer: |
               Merci de renseigner les raisons ci-dessous qui sera communiquée au demandeur.
           cancel: Annuler

--- a/config/locales/mailer.fr.yml
+++ b/config/locales/mailer.fr.yml
@@ -105,13 +105,13 @@ fr:
       submit:
         subject: Nouvelle demande d'habilitation sur DataPass
         description: |
-          %{applicant_full_name} (%{applicant_email}) a soumis une nouvelle demande d'habilitation sur DataPass pour le compte de l'organisation %{organization_raison_sociale}
+          %{applicant_full_name} (%{applicant_email}) a soumis une nouvelle demande d'habilitation sur DataPass pour le compte de l'organisation %{organization_name}
 
           Vous pouvez modérer cette demande d'habilitation en suivant le lien suivant: %{authorization_request_instruction_url}
       reopening_submit:
         subject: Nouvelle demande de réouverture d'habilitation sur DataPass
         description: |
-          %{applicant_full_name} (%{applicant_email}) a soumis une nouvelle demande de réouverture d'habilitation sur DataPass pour le compte de l'organisation %{organization_raison_sociale}
+          %{applicant_full_name} (%{applicant_email}) a soumis une nouvelle demande de réouverture d'habilitation sur DataPass pour le compte de l'organisation %{organization_name}
 
           Vous pouvez modérer cette demande de réouverture d'habilitation en suivant le lien suivant: %{authorization_request_instruction_url}
 

--- a/config/openapi/v1.yaml
+++ b/config/openapi/v1.yaml
@@ -234,7 +234,7 @@ components:
           type: string
           example: "13002526500013"
           description: Numéro de SIRET de l'organisation
-        raison_sociale:
+        name:
           type: string
           example: Direction interministérielle du numerique (DINUM)
           description: Raison sociale de l'organisation

--- a/db/migrate/20250425130021_migrate_to_multi_countries_attributes_on_organizations.rb
+++ b/db/migrate/20250425130021_migrate_to_multi_countries_attributes_on_organizations.rb
@@ -1,0 +1,37 @@
+class MigrateToMultiCountriesAttributesOnOrganizations < ActiveRecord::Migration[8.0]
+  def up
+    add_column :organizations, :legal_entity_id, :string
+    change_column_null :organizations, :siret, true
+
+    add_column :organizations, :legal_entity_registry, :string, default: 'insee_sirene', null: false
+    add_column :organizations, :extra_legal_entity_infos, :jsonb
+
+    remove_index :organizations, column: :siret
+
+    say_with_time "Copying siret into new legal_entity_id column" do
+      execute <<~SQL.squish
+        UPDATE organizations
+           SET legal_entity_id = siret;
+      SQL
+    end
+
+    change_column_null :organizations, :legal_entity_id, false
+    add_index :organizations, [:legal_entity_id, :legal_entity_registry], unique: true
+  end
+
+  def down
+    say_with_time "Copying legal_entity_id into siret column" do
+      execute <<~SQL.squish
+        UPDATE organizations
+           SET siret = legal_entity_id;
+      SQL
+    end
+
+    remove_column :organizations, :legal_entity_id, :string
+    remove_column :organizations, :legal_entity_registry, :string
+    remove_column :organizations, :extra_legal_entity_infos, :jsonb
+
+    change_column_null :organizations, :siret, true
+    add_index :organizations, :siret, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_21_084542) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_25_130021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -343,15 +343,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_21_084542) do
   end
 
   create_table "organizations", force: :cascade do |t|
-    t.string "siret", null: false
+    t.string "siret"
     t.jsonb "mon_compte_pro_payload", default: {}, null: false
     t.datetime "last_mon_compte_pro_updated_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "insee_payload"
     t.datetime "last_insee_payload_updated_at"
+    t.string "legal_entity_id", null: false
+    t.string "legal_entity_registry", default: "insee_sirene", null: false
+    t.jsonb "extra_legal_entity_infos"
     t.index "((((insee_payload -> 'etablissement'::text) -> 'uniteLegale'::text) ->> 'denominationUniteLegale'::text))", name: "index_organizations_on_denomination_unite_legale"
-    t.index ["siret"], name: "index_organizations_on_siret", unique: true
+    t.index ["legal_entity_id", "legal_entity_registry"], name: "idx_on_legal_entity_id_legal_entity_registry_7d149bf422", unique: true
   end
 
   create_table "organizations_users", id: false, force: :cascade do |t|

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -121,7 +121,7 @@ Un exemple de payload pour `model_data`:
   // Payload de l'organisation
   "organization": {
     "id": 9002,
-    "raison_sociale": "UMAD CORP",
+    "name": "UMAD CORP",
     "siret": "98043033400022"
   },
   // Payload du demandeur

--- a/features/support/organizations.rb
+++ b/features/support/organizations.rb
@@ -1,5 +1,5 @@
 def find_or_create_organization_by_name(name)
-  Organization.find_by(siret: organization_name_to_siret(name)) ||
+  Organization.find_by(legal_entity_id: organization_name_to_siret(name), legal_entity_registry: 'insee_sirene') ||
     create(:organization, name:, siret: organization_name_to_siret(name))
 end
 

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe OrganizationDecorator, type: :decorator do
+  describe '#adresse' do
+    subject { organization.decorate.address }
+
+    context 'with organization is from INSEE Sirene registry' do
+      let(:organization) { create(:organization, siret: '13002526500013') }
+
+      it do
+        expect(subject).to eq('20 AV DE SEGUR<br />75007 PARIS 7')
+      end
+    end
+
+    context 'when organization is from foreign registry but with address within extra_legal_entity_infos' do
+      let(:organization) { create(:organization, :foreign, extra_legal_entity_infos: { 'address' => 'Foreign address' }) }
+
+      it { is_expected.to eq('Foreign address') }
+    end
+  end
+end

--- a/spec/factories/hubee_payloads.rb
+++ b/spec/factories/hubee_payloads.rb
@@ -10,11 +10,7 @@ FactoryBot.define do
     after(:build) do |hubee_organization_payload, evaluator|
       if evaluator.organization.present?
         hubee_organization_payload['companyRegister'] = evaluator.organization.siret
-        hubee_organization_payload['branchCode'] = evaluator.organization.code_commune
         hubee_organization_payload['name'] = evaluator.organization.denomination
-        hubee_organization_payload['code'] = evaluator.organization.sigle_unite_legale
-        hubee_organization_payload['postalCode'] = evaluator.organization.code_postal
-        hubee_organization_payload['territory'] = evaluator.organization.libele_commune
       end
 
       if evaluator.authorization_request.present?
@@ -55,21 +51,16 @@ FactoryBot.define do
         hubee_subscription_payload['email'] = evaluator.authorization_request.administrateur_metier_email
         hubee_subscription_payload['localAdministrator'] = { 'email' => evaluator.authorization_request.administrateur_metier_email }
       end
-
-      hubee_subscription_payload['subscriber'] =
-        if evaluator.organization.present?
-          {
-            'type' => 'SI',
-            'companyRegister' => evaluator.organization.siret,
-            'branchCode' => evaluator.organization.code_commune,
-          }
-        end
     end
 
     datapassId { 1 }
     processCode { 'SOME CODE' }
     subscriber do
-      nil
+      {
+        'type' => 'SI',
+        'companyRegister' => '21920023500014',
+        'branchCode' => '92023',
+      }
     end
     notificationFrequency { 'unitaire' }
     validateDateTime { '2024-07-18T14:00:55+02:00' }

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,13 +1,21 @@
 FactoryBot.define do
   factory :organization do
-    siret
+    legal_entity_registry { 'insee_sirene' }
     last_mon_compte_pro_updated_at { DateTime.now }
 
+    trait :foreign do
+      legal_entity_id { '0000000107219812' }
+      legal_entity_registry { 'isni' }
+    end
+
     transient do
+      siret { generate(:siret) }
       name { nil }
     end
 
     after(:build) do |organization, evaluator|
+      organization.legal_entity_id ||= evaluator.siret if organization.legal_entity_registry == 'insee_sirene'
+
       organization.mon_compte_pro_payload = build(:organization_hash_from_mon_compte_pro, siret: organization.siret, label: evaluator.name) if organization.mon_compte_pro_payload.blank?
 
       if Rails.root.join('spec', 'fixtures', 'insee', "#{organization.siret}.json").exist?

--- a/spec/jobs/update_organization_insee_payload_job_spec.rb
+++ b/spec/jobs/update_organization_insee_payload_job_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe UpdateOrganizationINSEEPayloadJob do
     end
   end
 
+  context 'with foreign organization' do
+    let(:organization_id) { create(:organization, :foreign).id }
+
+    it 'does not call the API' do
+      expect(INSEESireneAPIClient).not_to receive(:new)
+
+      update_organization_insee_payload_job
+    end
+  end
+
   context 'with valid organization' do
     let(:organization_id) { organization.id }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -3,27 +3,6 @@ RSpec.describe Organization do
     expect(build(:organization, siret: '21920023500014')).to be_valid
   end
 
-  describe '#categorie_juridique' do
-    subject { organization.categorie_juridique }
-
-    context 'with an organization with an insee payload' do
-      let(:organization) { build(:organization, siret: '13002526500013') }
-
-      it { is_expected.to be_a(CategorieJuridique) }
-
-      it 'returns the correct categorie juridique' do
-        expect(subject.code).to eq('7120')
-        expect(subject.libelle).to eq('Service central d\'un ministère')
-      end
-    end
-
-    context 'with an organization without an insee payload' do
-      let(:organization) { build(:organization) }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
   describe '#closed?' do
     subject { organization }
 

--- a/spec/services/hubee_api_client_spec.rb
+++ b/spec/services/hubee_api_client_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe HubEEAPIClient do
     subject(:get_organization) { hubee_api_client.get_organization(siret, code_commune) }
 
     let(:siret) { authorization_request.organization.siret }
-    let(:code_commune) { authorization_request.organization.code_commune }
+    let(:code_commune) { '92023' }
     let(:organization_payload) { build(:hubee_organization_payload, organization:, authorization_request:) }
 
     context 'when organization already exists in HubEE' do


### PR DESCRIPTION
Minimal changes, for the migration.

- Migrate specific methods within organization in their classes: keep model simple
- Can handle multiple registry for organizations

Data should be manually added within the `extra_legal_entity_infos` for foreign countries for now.

Closes https://linear.app/pole-api/issue/DAT-999