### PR TITLE
Feature/dat 1003 fix lannulation de reouverture multi stage

### DIFF
--- a/app/controllers/cancel_authorization_reopenings_controller.rb
+++ b/app/controllers/cancel_authorization_reopenings_controller.rb
@@ -20,6 +20,7 @@ class CancelAuthorizationReopeningsController < AuthenticatedUserController
       redirect_to dashboard_path,
         status: :see_other
     else
+      debugger
       render 'new', alert: t('.error')
     end
   end

--- a/app/interactors/restore_authorization_request_to_latest_authorization.rb
+++ b/app/interactors/restore_authorization_request_to_latest_authorization.rb
@@ -1,4 +1,7 @@
 class RestoreAuthorizationRequestToLatestAuthorization < ApplicationInteractor
+  delegate :authorization_request, to: :context, private: true
+  delegate :latest_authorization, to: :authorization_request, private: true
+
   def call
     return if latest_authorization.nil?
 
@@ -15,6 +18,8 @@ class RestoreAuthorizationRequestToLatestAuthorization < ApplicationInteractor
       authorization_request_params:,
       save_context: :submit,
     )
+    authorization_request.type = latest_authorization.authorization_request_class
+    authorization_request.reopening = false
 
     return if interactor.success?
 
@@ -23,13 +28,5 @@ class RestoreAuthorizationRequestToLatestAuthorization < ApplicationInteractor
 
   def authorization_request_params
     ActionController::Parameters.new(latest_authorization.data)
-  end
-
-  def authorization_request
-    context.authorization_request
-  end
-
-  def latest_authorization
-    authorization_request.latest_authorization
   end
 end

--- a/app/models/authorization_request/api_impot_particulier.rb
+++ b/app/models/authorization_request/api_impot_particulier.rb
@@ -29,4 +29,6 @@ class AuthorizationRequest::APIImpotParticulier < AuthorizationRequest
   add_scopes
 
   contact :contact_technique, validation_condition: ->(record) { record.need_complete_validation?(:contacts) }
+
+  add_checkbox :dpd_homologation_checkbox
 end

--- a/app/organizers/cancel_authorization_reopening.rb
+++ b/app/organizers/cancel_authorization_reopening.rb
@@ -5,6 +5,6 @@ class CancelAuthorizationReopening < ApplicationOrganizer
   end
 
   organize CreateAuthorizationRequestReopeningCancellation,
-    RestoreAuthorizationRequestToLatestAuthorization,
-    ExecuteAuthorizationRequestTransitionWithCallbacks
+    ExecuteAuthorizationRequestTransitionWithCallbacks,
+    RestoreAuthorizationRequestToLatestAuthorization
 end

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -113,7 +113,6 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et que je clique sur le dernier "Consulter"
     Alors il y a un badge "Validée"
 
-
   Scénario: Initialisation d'une réouverture bac à sable d'une demande validée en production
     Quand j'ai 1 demande d'habilitation "API Impôt Particulier" validée
     Et que je vais sur la page tableau de bord
@@ -133,6 +132,35 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et il y a un badge "Bac à sable"
     Et il y a un badge "En cours"
 
+  Scénario: Annulation d'une demande de réouverture multi stage
+    Quand j'ai 1 demande d'habilitation "API Impôt Particulier" validée
+    Et que je vais sur la page tableau de bord
+    Et que je clique sur "Mettre à jour"
+    Et que je clique sur "Mettre à jour l'habilitation bac à sable"
+    Alors je suis sur la page "Demande libre (Bac à sable) - API Impôt Particulier"
+    Et il y a un message de succès contenant "a bien été réouverte"
+    # Quand je clique sur "Modifier" dans le bloc de résumé "Les personnes impliquées"
+    # Et que je remplis les informations du contact "Responsable de traitement" avec :
+    #   | Nom     | Prénom | Email                 | Téléphone  | Fonction                  |
+    #   |Jean     | Louis  | nouveau.louis@gouv.fr | 0836656560 | Directeur associé d'exploitation  |
+    # Et que je clique sur "Enregistrer les modifications"
+    # Et que j'adhère aux conditions générales
+    # Et que je coche "J’atteste que mon organisation devra déclarer à la DGFiP l’accomplissement des formalités en matière de protection des données à caractère personnel et qu’elle veillera à procéder à l’homologation de sécurité de son projet."
+    # Et que je clique sur "Envoyer ma demande de modification"
+    # Alors il y a un message de succès contenant "soumise avec succès"
+    # Et il y a un badge "Bac à sable"
+    # Et il y a un badge "En cours"
+    Et que je vais sur la page tableau de bord
+    Et que je clique sur le dernier "Consulter"
+    Alors il y a un bouton "Annuler ma demande de modification"
+    Et que je clique sur "Annuler ma demande de modification"
+    Alors il y a un titre contenant "Annulation de vos modifications"
+    Alors il y a un bouton "Annuler ma demande de modification"
+    Et que je clique sur "Annuler ma demande de modification"
+    Alors montre moi la page
+    # Alors il y a un message de succès contenant "a été annulée"
+    Alors la page contient "Production"
+    Alors la page contient "Validée"
 
   Scénario: Initialisation d'une réouverture production d'une demande validée en production
     Quand j'ai 1 demande d'habilitation "API Impôt Particulier" validée

--- a/features/reouverture_habilitation.feature
+++ b/features/reouverture_habilitation.feature
@@ -139,28 +139,17 @@ Fonctionnalité: Réouverture d'une habilitation validée
     Et que je clique sur "Mettre à jour l'habilitation bac à sable"
     Alors je suis sur la page "Demande libre (Bac à sable) - API Impôt Particulier"
     Et il y a un message de succès contenant "a bien été réouverte"
-    # Quand je clique sur "Modifier" dans le bloc de résumé "Les personnes impliquées"
-    # Et que je remplis les informations du contact "Responsable de traitement" avec :
-    #   | Nom     | Prénom | Email                 | Téléphone  | Fonction                  |
-    #   |Jean     | Louis  | nouveau.louis@gouv.fr | 0836656560 | Directeur associé d'exploitation  |
-    # Et que je clique sur "Enregistrer les modifications"
-    # Et que j'adhère aux conditions générales
-    # Et que je coche "J’atteste que mon organisation devra déclarer à la DGFiP l’accomplissement des formalités en matière de protection des données à caractère personnel et qu’elle veillera à procéder à l’homologation de sécurité de son projet."
-    # Et que je clique sur "Envoyer ma demande de modification"
-    # Alors il y a un message de succès contenant "soumise avec succès"
-    # Et il y a un badge "Bac à sable"
-    # Et il y a un badge "En cours"
-    Et que je vais sur la page tableau de bord
-    Et que je clique sur le dernier "Consulter"
+    Quand que je vais sur la page tableau de bord
+    Alors il y a un badge "Bac à sable"
+    Et il y a un badge "Brouillon"
+    Quand je clique sur le dernier "Consulter"
     Alors il y a un bouton "Annuler ma demande de modification"
     Et que je clique sur "Annuler ma demande de modification"
     Alors il y a un titre contenant "Annulation de vos modifications"
     Alors il y a un bouton "Annuler ma demande de modification"
     Et que je clique sur "Annuler ma demande de modification"
-    Alors montre moi la page
-    # Alors il y a un message de succès contenant "a été annulée"
-    Alors la page contient "Production"
-    Alors la page contient "Validée"
+    Alors il y a un badge "Production"
+    Et il y a un badge "Validée"
 
   Scénario: Initialisation d'une réouverture production d'une demande validée en production
     Quand j'ai 1 demande d'habilitation "API Impôt Particulier" validée

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -464,6 +464,7 @@ FactoryBot.define do
 
     trait :api_impot_particulier do
       api_impot_particulier_common
+      dpd_homologation_checkbox { '1' } 
 
       has_previous_authorization_validated
     end

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -464,7 +464,6 @@ FactoryBot.define do
 
     trait :api_impot_particulier do
       api_impot_particulier_common
-      dpd_homologation_checkbox { '1' } 
 
       has_previous_authorization_validated
     end


### PR DESCRIPTION
J'ouvre ça en draft pour en discuter, on a déjà fait un point rapide avec @skelz0r dessus.

Le problème ici ce sont les tests : 
on n'a pas actuellement le tooling pour setup via les factory une demande multistage assez proche de la réalité
en gros la demande de prod n'est pas passée par la demande de sandbox donc certains attributs n'ont pas de valeur (ici la checkbox (dpd_homologation*) ce qui bloque la validation à l'annulation de la réouverture

une solution évoquée est de rajouter ces checkbox dans le modèle de demande de production (ie prod devrait contenir tout sandbox) mais ici ça implique de changer les vues car on boucle sur ces "extra_checkboxes" pour les afficher au pied du résumé

sinon il faut changer le tooling pour que la factory ait un comportement plus proche de la réalité

WDYT?