### PR TITLE
Corrige l'affichage du footer d'étape pour les demandes en production

### DIFF
--- a/app/decorators/authorization_request_decorator.rb
+++ b/app/decorators/authorization_request_decorator.rb
@@ -63,11 +63,16 @@ class AuthorizationRequestDecorator < ApplicationDecorator
       return false if reopening? && any_next_stage_authorization_exists? && (draft? || submitted?)
     else
       return false if reopening?
+      return false if last_stage_request_without_previous_stages_authorizations? && (draft? || submitted?)
       return true if draft? || submitted?
       return false unless definition.next_stage?
     end
 
     validated? || submitted?
+  end
+
+  def last_stage_request_without_previous_stages_authorizations?
+    authorization_request.authorizations.where.not(authorization_request_class: type).none?
   end
 
   def display_card_reopening_footer?


### PR DESCRIPTION
  - Ce commit corrige un bug dans la méthode `display_card_stage_footer?` qui retournait systématiquement `true` lorsqu'une demande d'autorisation multi-étape était créé directement en production et que son état était draft ou submitted.