### PR TITLE
Install tidewave

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :development do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
   gem 'rubocop-rspec_rails', require: false
+  gem 'tidewave'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,35 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     drb (2.2.1)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-initializer (3.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-schema (1.14.1)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.5)
+      dry-types (~> 1.8)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.2)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     emailable (4.1.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -230,6 +259,12 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.3.1)
       faraday (~> 2.0)
+    fast-mcp (1.3.1)
+      base64
+      dry-schema (~> 1.14)
+      json (~> 2.0)
+      mime-types (~> 3.4)
+      rack (~> 3.1)
     ferrum (0.15)
       addressable (~> 2.5)
       concurrent-ruby (~> 1.1)
@@ -356,6 +391,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.6.2)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0429)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.7.2)
@@ -606,6 +645,10 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.3.2)
+    tidewave (0.1.1)
+      fast-mcp (~> 1.3.0)
+      rack (>= 2.0)
+      rails (>= 7.2.0)
     timeout (0.4.3)
     turbo-rails (2.0.13)
       actionpack (>= 7.1.0)
@@ -729,6 +772,7 @@ DEPENDENCIES
   state_machines-activerecord
   state_machines-rspec
   stimulus-rails
+  tidewave
   turbo-rails
   tzinfo-data
   uri (= 1.0.3)


### PR DESCRIPTION
> Tidewave speeds up development with an AI assistant that understands your web application, how it runs, and what it delivers. Our current release connects your editor's assistant to your web framework runtime via MCP.

More info: https://tidewave.ai/