### PR TITLE
Harden historic for copy event with merged/deleted authorization requests

### DIFF
--- a/app/components/historical_authorization_request_event_component.rb
+++ b/app/components/historical_authorization_request_event_component.rb
@@ -77,7 +77,11 @@ class HistoricalAuthorizationRequestEventComponent < ApplicationComponent
   def copied_from_authorization_request_id
     return unless name == 'copy'
 
-    entity.copied_from_request.id
+    if entity.present?
+      "la demande #{entity.copied_from_request.id}"
+    else
+      'une demande qui n\'existe plus (celle-ci a été supprimée ou fusionnée avec cette demande)'
+    end
   end
 
   def external_link?


### PR DESCRIPTION
Due to v1->v2 migration, mostly for DGFIP requests with multiple copies which had been merged.

This is a temporary fix, should be investigate later (or clean events ?).