### PR TITLE
FIX cookie overflow issue by using multiple cookies

### DIFF
--- a/app/controllers/authorization_request_forms/build_controller.rb
+++ b/app/controllers/authorization_request_forms/build_controller.rb
@@ -61,7 +61,7 @@ class AuthorizationRequestForms::BuildController < AuthorizationRequestFormsCont
   end
 
   def save_current_step
-    session[current_build_step_cache_key] = next_step
+    cookies[current_build_step_cache_key] = { value: next_step, expires: 7.days.from_now }
   end
 
   def extract_authorization_request

--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -129,7 +129,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
   end
 
   def redirect_to_current_build_step
-    step = session.fetch(current_build_step_cache_key, t("wicked.#{@authorization_request_form.steps.first[:name]}"))
+    step = cookies.fetch(current_build_step_cache_key, t("wicked.#{@authorization_request_form.steps.first[:name]}"))
 
     redirect_to authorization_request_form_build_path(
       form_uid: @authorization_request_form.uid,
@@ -139,7 +139,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
   end
 
   def current_build_step_cache_key
-    "authorization_request_form:#{@authorization_request.type.underscore}_#{@authorization_request.id}:current_build_step"
+    "demande_#{@authorization_request.id}_build_step"
   end
 
   def create_for_single_page_form

--- a/app/controllers/instruction/authorization_requests_controller.rb
+++ b/app/controllers/instruction/authorization_requests_controller.rb
@@ -59,8 +59,16 @@ class Instruction::AuthorizationRequestsController < Instruction::AbstractAuthor
   end
 
   def save_or_load_search_params
-    session[search_key] = params[:search_query] if params[:search_query].present?
-    params[:search_query] = session[search_key] if params[:search_query].blank?
+    save_search_params
+    load_search_params
+  end
+
+  def save_search_params
+    cookies[search_key] = { value: params[:search_query].to_json, expires: 1.month.from_now } if params[:search_query].present?
+  end
+
+  def load_search_params
+    params[:search_query] = JSON.parse(cookies[search_key] || '{}') if params[:search_query].blank?
   end
 
   def main_search_input_key


### PR DESCRIPTION
Move non-important data within standalone cookies with expiration. Will break wizard and saved search params for production, not a big deal if it's deployed in off hours.