### PR TITLE
Harden AuthorizationDefinition#unique attribute

### DIFF
--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -11,11 +11,11 @@ class AuthorizationDefinition < StaticApplicationRecord
     :scopes,
     :blocks,
     :features,
-    :stage,
-    :unique
+    :stage
 
   attr_writer :startable_by_applicant,
-    :public
+    :public,
+    :unique
 
   def self.all
     AuthorizationDefinitionConfigurations.instance.all.map do |uid, hash|
@@ -100,6 +100,10 @@ class AuthorizationDefinition < StaticApplicationRecord
 
   def public
     value_or_default(@public, true)
+  end
+
+  def unique
+    value_or_default(@unique, false)
   end
 
   def startable_by_applicant


### PR DESCRIPTION
If not defined is nil, so on an `unless unique` it returns invalid false instead of true, which has side effect behaviour on forms new, which displays a unicity callout if there is any other request exists.