### PR TITLE
Harden displays of errors for dirty from v1

### DIFF
--- a/app/decorators/authorization_request_decorator.rb
+++ b/app/decorators/authorization_request_decorator.rb
@@ -122,6 +122,13 @@ class AuthorizationRequestDecorator < ApplicationDecorator
     false
   end
 
+  def errors_linked_to_dirty
+    return [] unless object.dirty_from_v1?
+    return [] if object.valid?(:submit)
+
+    object.errors.reject { |e| e.type == :all_terms_not_accepted }
+  end
+
   private
 
   def lookup_i18n_key(subkey)

--- a/app/decorators/authorization_request_decorator.rb
+++ b/app/decorators/authorization_request_decorator.rb
@@ -122,7 +122,7 @@ class AuthorizationRequestDecorator < ApplicationDecorator
     false
   end
 
-  def errors_linked_to_dirty
+  def dirty_related_errors
     return [] unless object.dirty_from_v1?
     return [] if object.valid?(:submit)
 

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -61,13 +61,13 @@
             <%= t('authorization_requests.show.dirty_from_v1.description') %>
           </p>
 
-          <% if @authorization_request.errors_linked_to_dirty.any? %>
+          <% if @authorization_request.dirty_related_errors.any? %>
             <p class="fr-mt-2w">
               <%= t('authorization_requests.show.dirty_from_v1.errors_title') %>
             </p>
 
             <ul>
-              <% @authorization_request.errors_linked_to_dirty.full_messages.each do |message| %>
+              <% @authorization_request.dirty_related_errors.full_messages.each do |message| %>
                 <li>
                   <%= message %>
                 </li>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -61,7 +61,7 @@
             <%= t('authorization_requests.show.dirty_from_v1.description') %>
           </p>
 
-          <% unless @authorization_request.valid?(:submit) %>
+          <% if !@authorization_request.valid?(:submit) && @authorization_request.errors.any? { |e| e.type == :all_terms_not_accepted } %>
             <p class="fr-mt-2w">
               <%= t('authorization_requests.show.dirty_from_v1.errors_title') %>
             </p>

--- a/app/views/authorization_request_forms/summary.html.erb
+++ b/app/views/authorization_request_forms/summary.html.erb
@@ -61,13 +61,13 @@
             <%= t('authorization_requests.show.dirty_from_v1.description') %>
           </p>
 
-          <% if !@authorization_request.valid?(:submit) && @authorization_request.errors.any? { |e| e.type == :all_terms_not_accepted } %>
+          <% if @authorization_request.errors_linked_to_dirty.any? %>
             <p class="fr-mt-2w">
               <%= t('authorization_requests.show.dirty_from_v1.errors_title') %>
             </p>
 
             <ul>
-              <% @authorization_request.errors.full_messages.each do |message| %>
+              <% @authorization_request.errors_linked_to_dirty.full_messages.each do |message| %>
                 <li>
                   <%= message %>
                 </li>


### PR DESCRIPTION
In the case of an authorization linked to a production request in draft, checkboxes are switch to false in order to let the user check them on the summary page, so we have to exclude these errors for the display, because it is not an error linked to the dirtiness.