### PR TITLE
Remove safety_certification block from infinoe form

### DIFF
--- a/config/authorization_definitions/dgfip.yml
+++ b/config/authorization_definitions/dgfip.yml
@@ -849,7 +849,6 @@ api_infinoe:
     - name: legal
     - name: contacts
     - name: operational_acceptance
-    - name: safety_certification
     - name: volumetrie
 
 api_infinoe_sandbox:


### PR DESCRIPTION
No safety_certification block needed

Fixes https://errors.data.gouv.fr/organizations/sentry/issues/257309/?project=28