### PR TITLE
Formulaires API Entreprise : vérification des données cochées par défaut

### DIFF
--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -62,23 +62,28 @@ api-entreprise-aides-publiques:
     - name: "legal"
     - name: "scopes"
     - name: "contacts"
+  scopes_config:
+    disabled:
+      - beneficiaires_effectifs_inpi
+      - liasses_fiscales_dgfip
+      - bilans_bdf
   data:
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
-      - effectifs_urssaf
+      # - effectifs_urssaf
       - mandataires_sociaux_infogreffe
       - chiffre_affaires_dgfip
-      - bilans_bdf
+      # - bilans_bdf
       # - liasses_fiscales_dgfip
-      - liens_capitalistiques_dgfip
+      # - beneficiaires_effectifs_inpi
+      # - liens_capitalistiques_dgfip
       - attestation_fiscale_dgfip
       - attestation_sociale_urssaf
       - cotisations_msa
-      - cotisations_probtp
-      - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
-      - certifications_qualiopi_france_competences
-
+      # - cotisations_probtp
+      # - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
+      # - certifications_qualiopi_france_competences
 api-entreprise-subventions-associations:
   name: "Subventions des associations"
   description: "Simplifier la dépôt et l'instruction des demandes de subventions des associations."


### PR DESCRIPTION
Cette PR vise à uniformiser les données entre les formulaires API Entreprise et la doc des cas d'usages : 
https://entreprise.api.gouv.fr/cas_usages/


Ce que fait cette PR pour aides publiques : 
- Décocher et rendre non cochables les BE, les liasses et les bilans BDF
- Décocher Effectifs, liens capitalistiques, cotisations probtp, cnetp et qualiopi, MAIS les laisser cochables