### PR TITLE
Formulaires API Entreprise - Données des cas d'usages [API-5061]

### DIFF
--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -154,9 +154,6 @@ api-entreprise-portail-gru-instruction:
   scopes_config:
     disabled:
       - beneficiaires_effectifs_inpi
-      - bilans_bdf
-      - liasses_fiscales_dgfip
-      - liens_capitalistiques_dgfip
   data:
     intitule: "Démarches liées au portail de gestion relation usagers"
     description: "Accès aux données ouvertes permettant aux usagers de pré-remplir les informations liées à leurs entreprises, ainsi qu'aux données protégées permettant l'instruction de demandes par des agents habilités"

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -29,23 +29,30 @@ api-entreprise-marches-publics:
     - name: "legal"
     - name: "scopes"
     - name: "contacts"
+  scopes_config:
+    disabled:
+      - beneficiaires_effectifs_inpi
+      - liasses_fiscales_dgfip
+      - 
   data:
     cadre_juridique_nature: "R2143-13 Code de la commande publique"
     cadre_juridique_url: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589"
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
-      - effectifs_urssaf
-      - mandataires_sociaux_infogreffe
+      # - effectifs_urssaf
+      # - mandataires_sociaux_infogreffe
       - chiffre_affaires_dgfip
-      - bilans_bdf
-      - liasses_fiscales_dgfip
+      # - bilans_bdf
+      # - beneficiaires_effectifs_inpi
+      # - liasses_fiscales_dgfip
+      # - liens_capitalistiques_dgfip
       - attestation_fiscale_dgfip
       - attestation_sociale_urssaf
       - cotisations_msa
-      - cotisations_probtp
-      - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
-      - certifications_qualiopi_france_competences
+      # - cotisations_probtp
+      # - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
+      # - certifications_qualiopi_france_competences
 
 api-entreprise-aides-publiques:
   name: "Aides publiques"

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -90,19 +90,26 @@ api-entreprise-subventions-associations:
     - name: "contacts"
   scopes_config:
     disabled:
-      - unites_legales_etablissements_insee
-      - associations_djepva
-    displayed:
-      - unites_legales_etablissements_insee
-      - associations_djepva
-      - effectifs_urssaf
-      - certifications_qualiopi_france_competences
+      - attestation_fiscale_dgfip
+      - attestation_sociale_urssaf
+    hide:
+      - open_data_extrait_rcs_infogreffe
+      - beneficiaires_effectifs_inpi
+      - open_data_actes_bilans_inpi
+      - mandataires_sociaux_infogreffe
+      - open_data_numero_tva_commission_europeenne
+      - open_data_immatriculation_eori_douanes
+      - chiffre_affaires_dgfip
+      - bilans_bdf
+      - liasses_fiscales_dgfip
+      - cotisations_msa
+      - cotisations_probtp
+      - open_data_carte_pro_travaux_publics_fntp
+      - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
   data:
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
-      - effectifs_urssaf
-      - certifications_qualiopi_france_competences
 
 api-entreprise-portail-gru-preremplissage:
   name: "Portail GRU - Préremplissage uniquement"

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -62,25 +62,17 @@ api-entreprise-aides-publiques:
   scopes_config:
     disabled:
       - beneficiaires_effectifs_inpi
-      - liasses_fiscales_dgfip
-      - bilans_bdf
   data:
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
-      # - effectifs_urssaf
       - mandataires_sociaux_infogreffe
       - chiffre_affaires_dgfip
-      # - bilans_bdf
-      # - liasses_fiscales_dgfip
-      # - beneficiaires_effectifs_inpi
-      # - liens_capitalistiques_dgfip
+      - liasses_fiscales_dgfip
+      - liens_capitalistiques_dgfip
       - attestation_fiscale_dgfip
       - attestation_sociale_urssaf
       - cotisations_msa
-      # - cotisations_probtp
-      # - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
-      # - certifications_qualiopi_france_competences
 api-entreprise-subventions-associations:
   name: "Subventions des associations"
   description: "Simplifier la dépôt et l'instruction des demandes de subventions des associations."

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -32,7 +32,6 @@ api-entreprise-marches-publics:
   scopes_config:
     disabled:
       - beneficiaires_effectifs_inpi
-      - bilans_bdf
   data:
     cadre_juridique_nature: "R2143-13 Code de la commande publique"
     cadre_juridique_url: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589"

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -198,6 +198,7 @@ api-entreprise-detection-fraude:
       - cotisations_probtp
       - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
       - certifications_qualiopi_france_competences
+      - liens_capitalistiques_dgfip
 
 api-entreprise-editeur:
   name: "Formulaire spécifique aux éditeurs de logiciels"

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -33,7 +33,7 @@ api-entreprise-marches-publics:
     disabled:
       - beneficiaires_effectifs_inpi
       - liasses_fiscales_dgfip
-      - 
+      - bilans_bdf
   data:
     cadre_juridique_nature: "R2143-13 Code de la commande publique"
     cadre_juridique_url: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589"
@@ -106,13 +106,20 @@ api-entreprise-subventions-associations:
     - name: "legal"
     - name: "scopes"
     - name: "contacts"
+  scopes_config:
+    disabled:
+      - unites_legales_etablissements_insee
+      - associations_djepva
+    displayed:
+      - unites_legales_etablissements_insee
+      - associations_djepva
+      - effectifs_urssaf
+      - certifications_qualiopi_france_competences
   data:
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
       - effectifs_urssaf
-      # - attestation_fiscale_dgfip
-      # - attestation_sociale_urssaf
       - certifications_qualiopi_france_competences
 
 api-entreprise-portail-gru-preremplissage:

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -88,9 +88,6 @@ api-entreprise-subventions-associations:
     - name: "scopes"
     - name: "contacts"
   scopes_config:
-    disabled:
-      - attestation_fiscale_dgfip
-      - attestation_sociale_urssaf
     hide:
       - open_data_extrait_rcs_infogreffe
       - beneficiaires_effectifs_inpi
@@ -99,8 +96,6 @@ api-entreprise-subventions-associations:
       - open_data_numero_tva_commission_europeenne
       - open_data_immatriculation_eori_douanes
       - chiffre_affaires_dgfip
-      - bilans_bdf
-      - liasses_fiscales_dgfip
       - cotisations_msa
       - cotisations_probtp
       - open_data_carte_pro_travaux_publics_fntp
@@ -109,6 +104,11 @@ api-entreprise-subventions-associations:
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
+      - attestation_fiscale_dgfip
+      - attestation_sociale_urssaf
+      - bilans_bdf
+      - liasses_fiscales_dgfip
+      - liens_capitalistiques_dgfip
 
 api-entreprise-portail-gru-preremplissage:
   name: "Portail GRU - Préremplissage uniquement"

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -32,7 +32,6 @@ api-entreprise-marches-publics:
   scopes_config:
     disabled:
       - beneficiaires_effectifs_inpi
-      - liasses_fiscales_dgfip
       - bilans_bdf
   data:
     cadre_juridique_nature: "R2143-13 Code de la commande publique"
@@ -40,19 +39,10 @@ api-entreprise-marches-publics:
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
-      # - effectifs_urssaf
-      # - mandataires_sociaux_infogreffe
       - chiffre_affaires_dgfip
-      # - bilans_bdf
-      # - beneficiaires_effectifs_inpi
-      # - liasses_fiscales_dgfip
-      # - liens_capitalistiques_dgfip
       - attestation_fiscale_dgfip
       - attestation_sociale_urssaf
       - cotisations_msa
-      # - cotisations_probtp
-      # - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
-      # - certifications_qualiopi_france_competences
 
 api-entreprise-aides-publiques:
   name: "Aides publiques"

--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -152,6 +152,12 @@ api-entreprise-portail-gru-instruction:
     - name: "legal"
     - name: "scopes"
     - name: "contacts"
+  scopes_config:
+    disabled:
+      - beneficiaires_effectifs_inpi
+      - bilans_bdf
+      - liasses_fiscales_dgfip
+      - liens_capitalistiques_dgfip
   data:
     intitule: "Démarches liées au portail de gestion relation usagers"
     description: "Accès aux données ouvertes permettant aux usagers de pré-remplir les informations liées à leurs entreprises, ainsi qu'aux données protégées permettant l'instruction de demandes par des agents habilités"
@@ -160,17 +166,9 @@ api-entreprise-portail-gru-instruction:
     scopes:
       - unites_legales_etablissements_insee
       - associations_djepva
-      - effectifs_urssaf
-      - mandataires_sociaux_infogreffe
-      - chiffre_affaires_dgfip
-      # - bilans_bdf
-      # - liasses_fiscales_dgfip
       - attestation_fiscale_dgfip
       - attestation_sociale_urssaf
       - cotisations_msa
-      - cotisations_probtp
-      - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
-      - certifications_qualiopi_france_competences
 
 api-entreprise-detection-fraude:
   name: "Détection de la fraude"


### PR DESCRIPTION
Mise à jour de tous les formulaires cas d'usages d'API Entreprise pour les uniformiser avec les données indiquées dans les cas d'usages : https://entreprise.api.gouv.fr/cas_usages/

@Charlottecho j'ai résumé les changements ci-dessous, j'ai besoin de ta revue avant de merger. Notamment concernant les points avec le "⚠️"


### Marchés publics 

- bilans BDF et liasses fiscales sont visibles et interdits
- liens capitalistiques peut être demandé (serait donc cochable mais pas coché par défaut)
- cochés par défaut : opendata, non-diffusibles, asso djepva, chiffres d'affaires, attestations fiscale et sociale, cotis msa

@Charlottecho  ⚠️ Vérifier si BDF et liasses fiscales sont autorisées. Si elles sont autorisées, dire si on les coche par défaut (coché par défaut = utile dans tous les cas de figure)

### Subventions associations : 

Fait dans ce commit https://github.com/etalab/data_pass/pull/928/commits/ab6aa8e435311702042fa8e3680ff286b2e0dbff

- cache les données qui ne contiennent pas d'infos associations
- pré-coche par défaut les non-diffusibles et les données associations
- Interdit les attestations fiscales et de vigilance, mais les laisse visible sur le formulaire (car elles ont des données asso)

@Charlottecho  
💡 Ici utilisation du fait que le formulaire peut ne pas montrer des données pour décider de ne montrer que les données contenant des données asso.

⚠️ Vérifier si les liasses fiscales et les liens capitalistiques contiennent des infos associations. 
- Si elles contiennent des données asso, déterminer si elles sont autorisées
- Si elles sont autorisées, dire si on les coche par défaut (coché par défaut = utile dans tous les cas de figure)


### Portail GRU

**Préremplissage :** rien à faire, pas de données à cocher vu qu'on donne que l'opendata

**Instruction :** 
Fait dans ce comit https://github.com/etalab/data_pass/pull/928/commits/f7f9b29ba3040e1e4dcb1875e520e9b2cc341417
- Interdit : BE, bilans bdf, liasses fiscales et liens capitalistiques
- pré-coche par défaut : non-diffusibles, djepva, attestations fiscale et sociale, cotis msa
- retire le précochage de chiffre d'affaires, effectif, qualiopi, etc, mais laisse la possibilité de les cocher

@Charlottecho  ⚠️ Vérifier si BDF et liasses fiscales sont autorisées. Si elles sont autorisées, dire si on les coche par défaut (coché par défaut = utile dans tous les cas de figure)


### Détection de la fraude 

Fait dans ce commit https://github.com/etalab/data_pass/pull/928/commits/7e6b8e7e56da06a86d87497398bb9e36d4646b92
- ajoute donnée manquante car récente : liens capitalistiques @skelz0r ici un cas intéressant où on aurait envie de dire dans `initialize_with` > `scopes` : `"tout est précoché par défaut sauf :" `
- finalement il y a que les BE, où l'usager doit cocher

@Charlottecho  ⚠️ Confirmer que pour le cas d'usage détection de la fraude : tout est pré-coché par défaut, SAUF Bénéficiaires effectifs, qui est cochable mais ne l'est pas par défaut. ça permettra de vérifier qu'il y a eut demande à l'inpi ?


## Modifications dans admin_api_entreprise

à faire en conséquence et commencé ici => https://github.com/etalab/admin_api_entreprise/pull/1904