### PR TITLE
CancelAuthorizationReopening no longer validates authorization request

### DIFF
--- a/app/interactors/assign_params_to_authorization_request.rb
+++ b/app/interactors/assign_params_to_authorization_request.rb
@@ -4,7 +4,7 @@ class AssignParamsToAuthorizationRequest < ApplicationInteractor
       valid_authorization_request_params
     )
 
-    return if context.authorization_request.valid?(context.save_context)
+    return if context.authorization_request.valid?(context.save_context) || context.skip_validation
 
     context.fail!
   end

--- a/app/interactors/restore_authorization_request_to_latest_authorization.rb
+++ b/app/interactors/restore_authorization_request_to_latest_authorization.rb
@@ -7,7 +7,7 @@ class RestoreAuthorizationRequestToLatestAuthorization < ApplicationInteractor
 
     fill_authorization_request_with_latest_authorization_data!
 
-    authorization_request.save
+    authorization_request.save(validate: false)
   end
 
   private
@@ -16,7 +16,7 @@ class RestoreAuthorizationRequestToLatestAuthorization < ApplicationInteractor
     interactor = AssignParamsToAuthorizationRequest.call(
       authorization_request:,
       authorization_request_params:,
-      save_context: :submit,
+      skip_validation: true,
     )
     authorization_request.type = latest_authorization.authorization_request_class
 

--- a/app/organizers/cancel_authorization_reopening.rb
+++ b/app/organizers/cancel_authorization_reopening.rb
@@ -5,6 +5,6 @@ class CancelAuthorizationReopening < ApplicationOrganizer
   end
 
   organize CreateAuthorizationRequestReopeningCancellation,
-    RestoreAuthorizationRequestToLatestAuthorization,
-    ExecuteAuthorizationRequestTransitionWithCallbacks
+    ExecuteAuthorizationRequestTransitionWithCallbacks,
+    RestoreAuthorizationRequestToLatestAuthorization
 end

--- a/spec/organizers/cancel_authorization_reopening_spec.rb
+++ b/spec/organizers/cancel_authorization_reopening_spec.rb
@@ -132,5 +132,26 @@ RSpec.describe CancelAuthorizationReopening, type: :organizer do
         end
       end
     end
+
+    describe 'when authorization is no longer valid in the request context, with dirty data (invalid format)' do
+      let(:user) { create(:user, :instructor, authorization_request_types: [authorization_request_kind]) }
+      let!(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :reopened) }
+
+      before do
+        latest_authorization = authorization_request.latest_authorization
+        latest_authorization.data['administrateur_metier_email'] = 'Non renseigné'
+        latest_authorization.save!
+
+        authorization_request.reload
+      end
+
+      it { is_expected.to be_success }
+
+      it 'restore the authorization request to the latest authorization: validation are bypassed' do
+        expect { cancel_authorization_reopening }.to change { authorization_request.reload.state }.from('draft').to('validated')
+
+        expect(authorization_request.administrateur_metier_email).to eq('Non renseigné')
+      end
+    end
   end
 end


### PR DESCRIPTION
An authorization is a snapshot of a previous authorization request, which can be dirty/invalid with actual context/validations rules.

It can happens in multiple scenarios:
1. Dirty data from migration: old authorization/requests were already dirty
2. Context changed: for example HubEE will validate phone number in the future, there is several authorizations without phone numbers.

We can reopen an authorization without errors, but the cancellation used to restore to the latest authorization, which used to cause strange errors. This commit fixes this behaviour.

For the context, we tried to mitigate the behaviour described in 1. with a `dirty_from_v1` boolean, which disabled reopening (and avoid the issue with the cancellation): we may revert this feature in the future, TBD.

In the case of a reopening without cancellation, the validations is not an issue because we want to have clean requests (and authorizations) in the current context.