### PR TITLE
display search results count in turbo frame

### DIFF
--- a/app/assets/stylesheets/components/search_results.css
+++ b/app/assets/stylesheets/components/search_results.css
@@ -1,0 +1,10 @@
+.search-results-container {
+  position: relative;
+}
+
+.search-results-container .results-count {
+  position: absolute;
+  top: -3.5rem;
+  left: 0;
+  padding: 0.5rem 1rem;
+}

--- a/app/views/instruction/authorization_requests/index.html.erb
+++ b/app/views/instruction/authorization_requests/index.html.erb
@@ -29,7 +29,11 @@
   </div>
 <% end %>
 
-<turbo-frame id="authorization_requests_table">
+<turbo-frame id="authorization_requests_table" class="search-results-container">
+  <div class="results-count">
+    <%= t('.search.results_count', count: @authorization_requests.total_count) %>
+  </div>
+
   <div class="fr-table fr-table--bordered">
     <table>
       <thead>

--- a/config/locales/instruction.fr.yml
+++ b/config/locales/instruction.fr.yml
@@ -7,6 +7,7 @@ fr:
             label: Rechercher dans toutes les habilitations
             placeholder: id, numéro de siret, intitulé...
           btn: Rechercher
+          results_count: "%{count} résultat(s)"
         table:
           caption: Liste des demandes en cours
           header:

--- a/features/instructeurs/liste_des_habilitations.feature
+++ b/features/instructeurs/liste_des_habilitations.feature
@@ -13,6 +13,7 @@ Fonctionnalité: Instruction: liste des habilitations
     Et qu'il y a 1 demande d'habilitation "Démarche Certificats de Décès Électroniques Dématérialisés (CertDc)" en attente
     Et que je vais sur la page instruction
     Alors je vois 2 demandes d'habilitation
+    Et la page contient "2 résultat(s)"
 
   Scénario: Je vois les badges des habilitations en réouvertures
     Sachant qu'il y a 1 demande d'habilitation "API Entreprise" réouverte
@@ -47,4 +48,10 @@ Fonctionnalité: Instruction: liste des habilitations
     Et que je vais sur la page instruction
     Et que je clique sur "Statut"
     Alors je vois 1 demande d'habilitation
+  
+  Scénario: La pagination limite le nombre de résultats mais compte bien le nombre total de résultats
+    Sachant qu'il y a 26 demandes d'habilitation "API Entreprise" en attente
+    Et que je vais sur la page instruction
+    Alors je vois 25 demandes d'habilitation
+    Et la page contient "26 résultat(s)"
 


### PR DESCRIPTION
Pour éviter que Lauren de France Connect ne compte à la main ses résultats pour savoir combien d'instructions en cours elle a à faire :D

![image](https://github.com/user-attachments/assets/60e4c1a5-e4d2-40a4-8b26-9917918d3905)
