### PR TITLE
remove doublons from authorization_definition_roles_as

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,9 +156,9 @@ class User < ApplicationRecord
   end
 
   def authorization_definition_roles_as(kind)
-    public_send(:"#{kind}_roles").map do |role|
-      AuthorizationDefinition.find(role.split(':').first)
-    end
+    public_send(:"#{kind}_roles")
+      .map { |role| AuthorizationDefinition.find(role.split(':').first) }
+      .uniq(&:id)
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -179,6 +179,19 @@ RSpec.describe User do
 
       it { is_expected.to contain_exactly('api_entreprise', 'api_particulier') }
     end
+
+    context 'when the user is reporter and developer for the same authorization definition' do
+      let(:kind) { 'reporter' }
+
+      let(:user) { build(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+
+      before do
+        user.roles << 'api_entreprise:developer'
+        user.save
+      end
+
+      it { is_expected.to contain_exactly('api_entreprise') }
+    end
   end
 
   describe '#settings on instruction_submit_notifications' do


### PR DESCRIPTION
The same definition appeared twice in the select list of definitions if I was instructor and developer for it.

Closes https://linear.app/pole-api/issue/DAT-1143/ne-pas-afficher-les-api-sur-lesquelles-le-droit-developer-est-donne