### PR TITLE
message_for_authorization_request fallbacks to classic key if reopening does not exist

### DIFF
--- a/app/controllers/concerns/authorization_requests_flashes.rb
+++ b/app/controllers/concerns/authorization_requests_flashes.rb
@@ -13,7 +13,7 @@ module AuthorizationRequestsFlashes
     reopening_prefix = authorization_request.reopening? ? 'reopening_' : ''
 
     options = {
-      title: I18n.t!("#{key}.#{reopening_prefix}#{type}.title", name: authorization_request.name),
+      title: t("#{key}.#{reopening_prefix}#{type}.title", name: authorization_request.name, default: t("#{key}.#{type}.title", name: authorization_request.name)),
     }
 
     if type == :error && include_model_errors


### PR DESCRIPTION
No need to raise error here, not a big issue tbh

Closes https://errors.data.gouv.fr/organizations/sentry/issues/261099/