### PR TITLE
Admin::StopImpersonation use latest unfinished impersonation

### DIFF
--- a/app/interactors/admin/finish_impersonation_record.rb
+++ b/app/interactors/admin/finish_impersonation_record.rb
@@ -1,7 +1,26 @@
 class Admin::FinishImpersonationRecord < ApplicationInteractor
   def call
-    return if context.impersonation.finished_at.present?
+    context.fail! if impersonation.nil?
 
-    context.impersonation.finish!
+    return if impersonation.finished_at.present?
+
+    impersonation.finish!
+  end
+
+  private
+
+  def impersonation
+    context.impersonation = latest_unfinished_impersonation if context.impersonation.nil?
+
+    context.impersonation
+  end
+
+  def latest_unfinished_impersonation
+    @latest_unfinished_impersonation ||= Impersonation.where(
+      admin: context.admin,
+      finished_at: nil
+    )
+      .order(created_at: :desc)
+      .first
   end
 end

--- a/spec/organizers/admin/stop_impersonation_spec.rb
+++ b/spec/organizers/admin/stop_impersonation_spec.rb
@@ -56,5 +56,16 @@ RSpec.describe Admin::StopImpersonation do
         }.to change(AdminEvent, :count).by(1)
       end
     end
+
+    context 'when impersonation is nil' do
+      let(:impersonation) { nil }
+      let(:other_unfinished_impersonation) { create(:impersonation, admin:) }
+
+      it 'marks the other impersonation as finished' do
+        expect {
+          stop_impersonation
+        }.to change { other_unfinished_impersonation.reload.finished_at }
+      end
+    end
   end
 end


### PR DESCRIPTION
Can be nil within the controller, but if an admin perform the action there is at least one unfinised.

Closes https://errors.data.gouv.fr/organizations/sentry/issues/261392/