### PR TITLE
Harden FindOrCreateUserThroughMonComptePro when email changed on MCP

### DIFF
--- a/app/interactors/find_or_create_user_through_mon_compte_pro.rb
+++ b/app/interactors/find_or_create_user_through_mon_compte_pro.rb
@@ -10,6 +10,17 @@ class FindOrCreateUserThroughMonComptePro < ApplicationInteractor
   private
 
   def find_or_initialize_user
+    find_user_by_external_id ||
+      find_or_initialize_user_by_email
+  end
+
+  def find_user_by_external_id
+    User.where(
+      external_id: info_payload['sub'],
+    ).first
+  end
+
+  def find_or_initialize_user_by_email
     User.where(
       email: info_payload['email'],
     ).first_or_initialize
@@ -17,6 +28,7 @@ class FindOrCreateUserThroughMonComptePro < ApplicationInteractor
 
   def user_attributes
     info_payload.slice(
+      'email',
       'family_name',
       'given_name',
       'email_verified',

--- a/spec/organizers/authenticate_user_through_mon_compte_pro_spec.rb
+++ b/spec/organizers/authenticate_user_through_mon_compte_pro_spec.rb
@@ -39,5 +39,17 @@ RSpec.describe AuthenticateUserThroughMonComptePro do
         expect(user.current_organization).to eq(authenticate_user.organization)
       end
     end
+
+    context 'when user already exists with same external ID but another email' do
+      let!(:another_user) do
+        create(:user, external_id: mon_compte_pro_omniauth_payload['info']['sub'], email: generate(:email))
+      end
+
+      it 'does not create a new user and updated the existing one' do
+        expect { authenticate_user }.not_to change(User, :count)
+
+        expect(another_user.reload.email).to eq(mon_compte_pro_omniauth_payload['info']['email'])
+      end
+    end
   end
 end


### PR DESCRIPTION
Users can change their email on MCP (ProConnect identity), which does not change the external_id and use to cause an error on an unpersisted record. We now try to find the user with the external_id and fallback on the old behaviour if it's not found.

Closes https://errors.data.gouv.fr/organizations/sentry/issues/262564