### PR TITLE
use docker's redis on local, instead of local redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ DOCKER-COMPOSE = docker compose
 DOCKER-RUN = $(DOCKER-COMPOSE) run --rm --entrypoint=""
 BUNDLE-EXEC = bundle exec
 
-STOP-SERVICES = which systemctl > /dev/null && sudo systemctl stop postgresql redis || true
-
 build:
 	$(DOCKER-COMPOSE) build
 	$(DOCKER-RUN) web bundle exec rails db:create RAILS_ENV=test
@@ -42,17 +40,20 @@ fix-yaml-lint:
 security:
 	$(DOCKER-RUN) web $(BUNDLE-EXEC) ./bin/brakeman
 
+# You can run this before running tests, to avoid conflicts with the local
+# redis and postgres services you might have running
+stop-services:
+	which systemctl > /dev/null && sudo systemctl stop postgresql redis || true
+
 guard:
 	$(DOCKER-COMPOSE) up -d chrome
 	$(DOCKER-RUN) web $(BUNDLE-EXEC) guard
 
 tests:
-	$(STOP-SERVICES)
 	$(DOCKER-COMPOSE) up -d chrome
 	$(DOCKER-RUN) web $(BUNDLE-EXEC) rspec $(filter-out $@,$(MAKECMDGOALS))
 
 e2e:
-	$(STOP-SERVICES)
 	$(DOCKER-COMPOSE) up -d chrome
 	$(DOCKER-RUN) web $(BUNDLE-EXEC) cucumber $(filter-out $@,$(MAKECMDGOALS))
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
 
 test:
   adapter: test

--- a/spec/queries/processing_time_query_spec.rb
+++ b/spec/queries/processing_time_query_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ProcessingTimeQuery, type: :query do
     subject(:average_days) { described_class.new(authorization_request_class).perform }
 
     let(:authorization_request_class) { nil }
-    let(:initial_datetime) { DateTime.new(2025, 3, 1) }
+    let(:initial_datetime) { DateTime.current }
 
     before do
       api_entreprise_request = create(:authorization_request, :api_entreprise)


### PR DESCRIPTION
Quand j'suis reparti d'un PC neuf, j'ai eu une erreur redis à la consultation du site.

Il essayait d'utiliser l'adresse de redis en dehors du docker si j'ai bien compris. Avec cette config, il utilise le redis du docker et tout va mieux.