### PR TITLE
Améliore le mailer FranceConnect new scopes

### DIFF
--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -58,6 +58,9 @@ class Seeds
 
     create_validated_authorization_request(:api_impot_particulier_sandbox, attributes: { intitule: 'Demande de retraite progressive en ligne', applicant: demandeur })
 
+    france_connect_authorization_request_for_dgfip = create_validated_authorization_request(:france_connect, attributes: { intitule: 'Connexion FranceConnect ImpotPart', applicant: demandeur })
+    create_validated_authorization_request(:api_impot_particulier_sandbox, attributes: { modalities: ['with_france_connect'], france_connect_authorization_id: france_connect_authorization_request_for_dgfip.latest_authorization.id, intitule: 'Demande de retraite progressive en ligne', applicant: demandeur })
+
     create_fully_approved_api_impot_particulier_authorization_request
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/models/authorization_request/api_droits_cnam.rb
+++ b/app/models/authorization_request/api_droits_cnam.rb
@@ -11,4 +11,8 @@ class AuthorizationRequest::APIDroitsCNAM < AuthorizationRequest
     :volumetrie_approximative
 
   contact :contact_technique, validation_condition: ->(record) { record.need_complete_validation?(:contacts) }
+
+  def scopes
+    ['droits_assurance_maladie']
+  end
 end

--- a/app/models/authorization_request/api_indemnites_journalieres_cnam.rb
+++ b/app/models/authorization_request/api_indemnites_journalieres_cnam.rb
@@ -11,4 +11,8 @@ class AuthorizationRequest::APIIndemnitesJournalieresCNAM < AuthorizationRequest
     :volumetrie_approximative
 
   contact :contact_technique, validation_condition: ->(record) { record.need_complete_validation?(:contacts) }
+
+  def scopes
+    ['cnam_paiements_ij']
+  end
 end

--- a/app/views/france_connect_mailer/new_scopes.text.erb
+++ b/app/views/france_connect_mailer/new_scopes.text.erb
@@ -2,12 +2,10 @@ Bonjour,
 
 Une <%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> <%= @authorization_request.definition.name %><%= " (#{t("authorization_request.stage.#{@authorization_request.definition.stage.type}")})" if @authorization_request.definition.stage.type %> pour le FS <%= @authorization_request.organization.name %> (identifiant DataPass de <%= @authorization_request.reopening? ? 'la mise à jour' : "l'habilitation" %> FranceConnect associée : <%= @france_connect_authorization_request.id %>) vient d’être validée.
 
-<% if @authorization_request.respond_to?(:scopes) %>
 En conséquence, merci d’autoriser les scopes suivant pour le sus-mentionné FS :
 
 <% @authorization_request.scopes.each do |scope| %>
 - <%= scope %>
-<% end %>
 <% end %>
 
 Pour consulter cette <%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %>, veuillez cliquer sur le lien suivant <%= authorization_request_url(@authorization_request) %> .

--- a/app/views/france_connect_mailer/new_scopes.text.erb
+++ b/app/views/france_connect_mailer/new_scopes.text.erb
@@ -1,11 +1,13 @@
 Bonjour,
 
-Une <%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> <%= @authorization_request.definition.name %> pour le FS <%= @authorization_request.organization.name %> (identifiant DataPass de l’<%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> FranceConnect associée : <%= @france_connect_authorization_request.id %>) vient d’être validée.
+Une <%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %> <%= @authorization_request.definition.name %><%= " (#{t("authorization_request.stage.#{@authorization_request.definition.stage.type}")})" if @authorization_request.definition.stage.type %> pour le FS <%= @authorization_request.organization.name %> (identifiant DataPass de <%= @authorization_request.reopening? ? 'la mise à jour' : "l'habilitation" %> FranceConnect associée : <%= @france_connect_authorization_request.id %>) vient d’être validée.
 
+<% if @authorization_request.respond_to?(:scopes) %>
 En conséquence, merci d’autoriser les scopes suivant pour le sus-mentionné FS :
 
-<% @france_connect_authorization_request.scopes.each do |scope| %>
+<% @authorization_request.scopes.each do |scope| %>
 - <%= scope %>
+<% end %>
 <% end %>
 
 Pour consulter cette <%= @authorization_request.reopening? ? 'mise à jour' : 'habilitation' %>, veuillez cliquer sur le lien suivant <%= authorization_request_url(@authorization_request) %> .

--- a/spec/mailers/france_connect_mailer_spec.rb
+++ b/spec/mailers/france_connect_mailer_spec.rb
@@ -13,5 +13,13 @@ RSpec.describe FranceConnectMailer do
     it 'renders the body' do
       expect(mail.body.encoded).to match('FranceConnect associée')
     end
+
+    context 'when the request has a stage' do
+      let(:authorization_request) { create(:authorization_request, :api_impot_particulier_sandbox, :with_france_connect, :validated, modalities: %w[with_france_connect]) }
+
+      it 'includes the stage in the body' do
+        expect(mail.body.encoded).to match('Bac à sable')
+      end
+    end
   end
 end

--- a/spec/mailers/previews/france_connect_mailer_preview.rb
+++ b/spec/mailers/previews/france_connect_mailer_preview.rb
@@ -6,6 +6,6 @@ class FranceConnectMailerPreview < ActionMailer::Preview
   private
 
   def authorization_request
-    AuthorizationRequest::APIDroitsCNAM.where(state: 'validated').first
+    AuthorizationRequest::APIImpotParticulierSandbox.where(state: :validated).last
   end
 end


### PR DESCRIPTION
Affiche le palier sur les habilitations multi paliers Affiche les scopes de l'habilitation principale (quand elles existent) au lieu des scopes de l'habilitation FranceConnect

<img width="882" height="381" alt="Capture d’écran du 2025-08-20 16-54-24" src="https://github.com/user-attachments/assets/604ce7b2-90ed-4a7c-acf5-f4f963c27923" />
