### PR TITLE
Raise an activerecord not found error on invalid authorization definition id start

### DIFF
--- a/app/controllers/authorization_requests_controller.rb
+++ b/app/controllers/authorization_requests_controller.rb
@@ -45,6 +45,8 @@ class AuthorizationRequestsController < AuthenticatedUserController
 
   def find_authorization_definition
     @authorization_definition = AuthorizationDefinition.find(id_sanitized)
+  rescue StaticApplicationRecord::EntryNotFound
+    raise ActiveRecord::RecordNotFound, "AuthorizationDefinition with id '#{id_sanitized}' not found"
   end
 
   def set_facade

--- a/spec/controllers/authorization_requests_controller_spec.rb
+++ b/spec/controllers/authorization_requests_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe AuthorizationRequestsController do
+  describe 'GET #new' do
+    subject(:new_authorization_request) { get :new, params: { definition_id: authorization_definition_id } }
+
+    describe 'when authorization definition exists' do
+      let(:authorization_definition_id) { AuthorizationDefinition.all.first.id }
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    describe 'when authorization definition does not exist' do
+      let(:authorization_definition_id) { 'non_existent_id' }
+
+      it 'raises an ActiveRecord::RecordNotFound error' do
+        expect { new_authorization_request }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://errors.data.gouv.fr/organizations/sentry/issues/264699/