### PR TITLE
Ajout scopes formulaire Kolis - QF et FT

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -1469,7 +1469,10 @@ api-particulier-keolis:
     displayed:
       - cnaf_quotient_familial
       - cnaf_adresse
+      - cnaf_allocataires
+      - cnaf_enfants
       - pole_emploi_identite
+      - pole_emploi_adresse
       - mesri_identite
       - mesri_admissions
       - mesri_admission_inscrit


### PR DESCRIPTION
Ajout scopes 
QF : 

- identités allocataires 
- identité enfants

France Travail : 

- adresse 