### PR TITLE
Transfert works with production draft

### DIFF
--- a/app/policies/authorization_request_policy.rb
+++ b/app/policies/authorization_request_policy.rb
@@ -106,7 +106,13 @@ class AuthorizationRequestPolicy < ApplicationPolicy
   def common_transfer?
     record.persisted? &&
       same_current_organization? &&
-      (record.reopening? || record.state != 'draft')
+      (record.reopening? || record.state != 'draft' || production_draft?)
+  end
+
+  def production_draft?
+    record.multi_stage? &&
+      record.definition.stage.type == 'production' &&
+      record.draft?
   end
 
   def authorization_request_class

--- a/spec/policies/authorization_request_policy_spec.rb
+++ b/spec/policies/authorization_request_policy_spec.rb
@@ -98,4 +98,15 @@ RSpec.describe AuthorizationRequestPolicy do
       end
     end
   end
+
+  describe '#manual_transfer?' do
+    subject { instance.manual_transfer_from_instructor? }
+
+    context 'with a DGFIP draft production (non-regression test)' do
+      let(:authorization_request) { create(:authorization_request, :api_impot_particulier_production, :draft, applicant: user) }
+      let(:authorization_request_class) { authorization_request }
+
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
We don't want to allow transferts on draft not submitted, but a production draft is not really a draft, it has an historic with a sandbox stage.