### PR TITLE
Improve accessibility

### DIFF
--- a/app/helpers/dsfr/pictogram.rb
+++ b/app/helpers/dsfr/pictogram.rb
@@ -9,7 +9,7 @@ module DSFR::Pictogram
 
   def dsfr_custom_pictogram(image_name)
     content_tag(:div, class: 'fr-custom-artwork') do
-      image_tag(image_name)
+      image_tag(image_name, alt: '', aria: { hidden: true })
     end
   end
 end


### PR DESCRIPTION
  - Add an aria-hidden true to pictogram Alt: "", helps to indicate to screen reader that this pictogram is decorative only.