### PR TITLE
Fix flaky features

### DIFF
--- a/.github/workflows/test.env
+++ b/.github/workflows/test.env
@@ -1,3 +1,4 @@
 DATABASE_URL=postgres://postgres:dummy@localhost:5432/test
 RAILS_ENV=test
 CHROME_URL=ws://localhost:3333/chromium
+CAPYBARA_WAIT_TIME=8

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -23,7 +23,7 @@ Quand("je clique sur {string} pour l'utilisateur {string}") do |link, email|
 end
 
 Quand("je remplis {string} avec l'ID de la demande") do |label|
-  fill_in label, with: AuthorizationRequest.last.id
+  fill_in label, with: last_authorization_request.id
 end
 
 Soit("l'utilisateur {string}") do |email|

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -85,7 +85,7 @@ Quand('je remplis les informations du contact {string} avec :') do |string, tabl
 end
 
 Quand('cette demande a été modifiée avec les informations suivantes :') do |table|
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
 
   params = table.hashes.to_h do |hash|
     [hash['champ'], hash['nouvelle valeur']]
@@ -95,7 +95,7 @@ Quand('cette demande a été modifiée avec les informations suivantes :') do |t
 end
 
 Quand('cette demande possède les informations potentiellement non intègres suivantes :') do |table|
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
 
   data = authorization_request.data || {}
 
@@ -133,7 +133,7 @@ Alors("il n'y a pas de formulaire en mode résumé") do
 end
 
 Quand('je me rends sur cette demande d\'habilitation') do
-  authorization_request = @authorization_request || AuthorizationRequest.last
+  authorization_request = last_authorization_request
 
   if current_user!.instructor?
     visit instruction_authorization_request_path(authorization_request)
@@ -143,7 +143,7 @@ Quand('je me rends sur cette demande d\'habilitation') do
 end
 
 Quand('je me rends sur la page demandeur de cette demande') do
-  authorization_request = @authorization_request || AuthorizationRequest.last
+  authorization_request = last_authorization_request
   visit authorization_request_path(authorization_request)
 end
 
@@ -173,9 +173,9 @@ Quand(/(j'ai|il y a|mon organisation a) (\d+) demandes? d'habilitation "([^"]+)"
 end
 
 Quand("cette dernière demande d'habilitation s'appelait {string}") do |intitule|
-  last_authorization_request = AuthorizationRequest.last
-  last_authorization_request.intitule = intitule
-  last_authorization_request.save
+  ar = last_authorization_request
+  ar.intitule = intitule
+  ar.save
 end
 
 Quand('je change d\'organisation courante pour mon organisation initiale') do
@@ -208,7 +208,7 @@ Quand(/je suis mentionné dans (\d+) demandes? d'habilitation "([^"]+)" en tant 
   role = role_humanized.parameterize.underscore
   foreign_user = create(:user)
   options = {
-    "#{role}_email": current_user.email,
+    "#{role}_email": current_user!.email,
     applicant: foreign_user,
     organization: foreign_user.current_organization,
   }
@@ -241,7 +241,7 @@ Alors("l'utilisateur {string} possède une demande d'habilitation {string}") do 
 end
 
 Quand("un instructeur a révoqué la demande d'habilitation") do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   instructor = create_instructor(authorization_request.definition.name)
 
   using_user_session(instructor) do
@@ -256,14 +256,14 @@ Quand("un instructeur a révoqué la demande d'habilitation") do
 end
 
 Quand("un instructeur a validé la demande d'habilitation") do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   instructor = create_instructor(authorization_request.definition.id)
   instructor.update!(roles: AuthorizationDefinition.all.map { |definition| "#{definition.id}:instructor" })
   ApproveAuthorizationRequest.call(authorization_request: authorization_request, user: instructor)
 end
 
 Quand('cette demande a été {string}') do |status|
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   user = User.last
 
   case extract_state_from_french_status(status)
@@ -283,7 +283,7 @@ Quand('cette demande a été {string}') do |status|
 end
 
 Quand('cette demande a été {string} avec le message {string}') do |status, message|
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   user = User.last
 
   organizer = case extract_state_from_french_status(status)
@@ -325,17 +325,17 @@ Quand('je joins 2 documents au cadre juridique du projet {string}') do |authoriz
 end
 
 Quand('cette habilitation a une pièce jointe {string}') do |safety_state|
-  attachment = AuthorizationRequest.last.maquette_projet.attach([Rails.root.join('spec/fixtures/dummy.pdf')]).first
+  attachment = last_authorization_request.maquette_projet.attach([Rails.root.join('spec/fixtures/dummy.pdf')]).first
 
   MalwareScan.create!(sha256: SecureRandom.hex(32), attachment:, safety_state:)
 end
 
 Quand('cette demande possède une maquette du projet {string}') do |filename|
-  AuthorizationRequest.last.maquette_projet.attach(io: Rails.root.join('spec/fixtures', filename).open, filename:)
+  last_authorization_request.maquette_projet.attach(io: Rails.root.join('spec/fixtures', filename).open, filename:)
 end
 
 Quand('cette demande possède un document d\'expression de besoin spécifique') do
-  AuthorizationRequest.last.specific_requirements_document.attach(io: Rails.root.join('spec/fixtures/dummy.csv').open, filename: 'dummy.csv')
+  last_authorization_request.specific_requirements_document.attach(io: Rails.root.join('spec/fixtures/dummy.csv').open, filename: 'dummy.csv')
 end
 
 Alors('un scan antivirus est lancé') do
@@ -357,8 +357,7 @@ Quand("j'adhère aux conditions générales d'utilisation") do
     Quand je coche "conditions générales"
   )
 
-  authorization_request = @authorization_request || AuthorizationRequest.last
-  raise 'No authorization request found' unless authorization_request
+  authorization_request = last_authorization_request
 
   unless authorization_request.skip_data_protection_officer_informed_check_box?
     steps %(
@@ -484,7 +483,7 @@ Quand("j'enregistre et continue vers le résumé") do
 end
 
 Quand('il existe un instructeur pour cette demande d\'habilitation') do
-  definition = AuthorizationRequest.last.definition
+  definition = last_authorization_request.definition
 
   create_instructor(definition.name) unless definition.instructors.any?
 end
@@ -518,11 +517,11 @@ Quand(/je me rends sur une demande d'habilitation "([^"]+)"(?: de l'organisation
 end
 
 Quand('je me rends sur la dernière demande à instruire') do
-  visit instruction_authorization_request_path(AuthorizationRequest.last)
+  visit instruction_authorization_request_path(last_authorization_request)
 end
 
 Quand('je me rends sur la dernière demande') do
-  visit authorization_request_path(AuthorizationRequest.last)
+  visit authorization_request_path(last_authorization_request)
 end
 
 Quand('je me rends sur la dernière demande {string}') do |kind|
@@ -548,7 +547,7 @@ Alors(/je vois (\d+) habilitation(?: "([^"]+)")?(?:(?: en)? (.+))?/) do |count, 
 end
 
 Quand('je visite sa page publique') do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
 
   visit public_authorization_request_path(authorization_request.public_id)
 end
@@ -571,7 +570,7 @@ end
 
 Quand(%r{cette demande a déjà été validée le (\d{1,2}/\d{2}/\d{4})}) do |date_string|
   date = Date.parse(date_string)
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
 
   organizer = ApproveAuthorizationRequest.call(authorization_request:, user: User.first)
 
@@ -582,7 +581,7 @@ Quand(%r{cette demande a déjà été validée le (\d{1,2}/\d{2}/\d{4})}) do |da
 end
 
 Quand(%r{je me rends sur l'habilitation validée(?: du (\d{1,2}/\d{2}/\d{4}))?}) do |date_string|
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
 
   if date_string.present?
     date = Date.parse(date_string)
@@ -598,7 +597,7 @@ end
 Quand("une mise à jour globale a été effectuée sur les demandes d'habilitations {string}") do |authorization_definition_name|
   definition = find_authorization_definition_from_name(authorization_definition_name)
 
-  AuthorizationRequest.last.update!(created_at: 2.days.ago)
+  last_authorization_request.update!(created_at: 2.days.ago)
 
   BulkAuthorizationRequestUpdate.create!(
     authorization_definition_uid: definition.id,

--- a/features/step_definitions/authorization_steps.rb
+++ b/features/step_definitions/authorization_steps.rb
@@ -91,14 +91,14 @@ Alors('il y a un formulaire en mode résumé non modifiable') do
 end
 
 Quand('je me rends sur la première habilitation validée') do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   first_authorization = authorization_request.authorizations.first
 
   visit authorization_path(first_authorization)
 end
 
 Sachant('une seconde habilitation active existe sur la même demande') do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   @sister_authorization = FactoryBot.create(:authorization,
     request: authorization_request,
     applicant: authorization_request.applicant,
@@ -106,7 +106,7 @@ Sachant('une seconde habilitation active existe sur la même demande') do
 end
 
 Alors('la première habilitation de la demande est révoquée') do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   first_authorization = authorization_request.authorizations.order(:id).first
   expect(first_authorization.reload.state).to eq('revoked')
 end
@@ -116,12 +116,12 @@ Alors('la seconde habilitation de la demande est active') do
 end
 
 Alors('la demande est toujours validée') do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   expect(authorization_request.reload.state).to eq('validated')
 end
 
 Alors('la demande est révoquée') do
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   expect(authorization_request.reload.state).to eq('revoked')
 end
 

--- a/features/step_definitions/integrity_stepts.rb
+++ b/features/step_definitions/integrity_stepts.rb
@@ -1,5 +1,5 @@
 Quand('cette demande est issue de la v1 et non intègre') do
-  AuthorizationRequest.last.update!(
+  last_authorization_request.update!(
     dirty_from_v1: true,
   )
 end

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -193,6 +193,7 @@ Sachantque('je me connecte') do
     Quand je me rends sur la page d'accueil
     Et que je clique sur "S’identifier avec ProConnect"
   )
+  raise "Login failed — still on homepage (@current_user_email=#{@current_user_email.inspect})" if page.has_content?(%(S\u2019identifier avec ProConnect), wait: 0)
 end
 
 Sachantque("je me connecte via ProConnect avec l'identité {string}") do |identity_provider_name|

--- a/features/step_definitions/messages_steps.rb
+++ b/features/step_definitions/messages_steps.rb
@@ -3,7 +3,7 @@ Quand('je clique sur la bulle de messagerie') do
 end
 
 Quand(/cette habilitation a un message (?:de l'|du )([^\s+]*) avec comme corps "([^"]*)"$/) do |entity_kind, message|
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
 
   case entity_kind
   when 'demandeur'

--- a/features/step_definitions/organizations_steps.rb
+++ b/features/step_definitions/organizations_steps.rb
@@ -25,7 +25,7 @@ Alors("l'organisation associée est marquée comme {string}") do |kind|
 end
 
 Quand("le lien entre le demandeur et l'organisation est marqué comme {string}") do |kind|
-  authorization_request = AuthorizationRequest.last
+  authorization_request = last_authorization_request
   applicant = authorization_request.applicant
   organization = authorization_request.organization
 

--- a/features/support/applicant_authorization_request_helpers.rb
+++ b/features/support/applicant_authorization_request_helpers.rb
@@ -26,5 +26,5 @@ def using_user_session(user, &)
 end
 
 def using_last_applicant_session(&)
-  using_user_session(AuthorizationRequest.last.applicant, &)
+  using_user_session(last_authorization_request.applicant, &)
 end

--- a/features/support/authorization_request_helpers.rb
+++ b/features/support/authorization_request_helpers.rb
@@ -101,3 +101,8 @@ def create_authorization_requests_with_status(type, status = nil, count = 1, sta
   end
 end
 # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
+
+def last_authorization_request
+  @authorization_request || AuthorizationRequest.order(:created_at).last ||
+    raise('No authorization request found')
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,9 +26,7 @@ require 'cucumber/rails'
 ActionController::Base.allow_rescue = false
 
 DatabaseCleaner.allow_remote_database_url = true
-DatabaseCleaner.strategy = :transaction
 
-Cucumber::Rails::Database.javascript_strategy = :truncation
 Cucumber::Rails::Database.autorun_database_cleaner = false
 
 World(FactoryBot::Syntax::Methods)
@@ -36,14 +34,11 @@ World(FactoryBot::Syntax::Methods)
 Seeds.new.flushdb
 
 Before('@javascript') do
-  DatabaseCleaner.strategy = :truncation
-end
-
-Before('not @javascript') do
-  DatabaseCleaner.strategy = :transaction
+  ActiveRecord::Base.connection_pool.pin_connection!(true)
 end
 
 Before do
+  DatabaseCleaner.strategy = :transaction
   DatabaseCleaner.clean
   DatabaseCleaner.start
   Kredis.redis.flushdb
@@ -52,6 +47,7 @@ end
 After do
   Capybara.reset_sessions!
   DatabaseCleaner.clean
+  ActiveRecord::Base.connection_pool.unpin_connection! if javascript?
   AuthorizationDefinition.reset!
   AuthorizationRequestForm.reset!
 end

--- a/spec/support/configure_javascript_driver.rb
+++ b/spec/support/configure_javascript_driver.rb
@@ -52,4 +52,4 @@ Capybara.server = :puma, { Silent: true }
 Capybara.server_host = '0.0.0.0'
 Capybara.always_include_port = true
 Capybara.app_host = "http://#{ENV.fetch('APP_HOST', `hostname`.strip&.downcase || '0.0.0.0')}" if remote_chrome
-Capybara.default_max_wait_time = 5
+Capybara.default_max_wait_time = Integer(ENV.fetch('CAPYBARA_WAIT_TIME', 5))


### PR DESCRIPTION
### Problème

~30% des runs CI sur develop échouaient à cause de tests Cucumber flaky : à chaque
run, 1 scénario aléatoire sur ~533 échouait, obligeant à relancer manuellement. Ces
échecs tombaient dans 5 catégories, toutes liées à la même cause racine.

### Cause racine

Les scénarios `@javascript` utilisaient la stratégie `DatabaseCleaner :truncation`
pour partager les données entre le thread de test et le serveur Puma (qui tourne dans
un thread séparé). Le problème : entre deux scénarios, le `TRUNCATE TABLE` pouvait
s'exécuter pendant que Puma traitait encore une requête résiduelle. Résultat :
des tables tronquées en plein milieu d'un traitement, des records fantômes, des
sessions perdues, des `nil` inexpliqués.

### Solution principale : `pin_connection!(true)`

**Fichier clé : `features/support/env.rb`**

On remplace la stratégie `truncation` par `pin_connection!(true)` (API Rails 8.1,
utilisée en interne par les system tests Rails). Ce mécanisme force le pool de
connexions à retourner **la même connexion DB** au thread de test et au thread Puma.
Un mutex garantit qu'un seul thread utilise la connexion à la fois.

Conséquence : tous les scénarios (JS ou non) utilisent maintenant la stratégie
`:transaction`. Le cleanup se fait par `ROLLBACK` — atomique, instantané, sans race
condition. La truncation est complètement éliminée.

```ruby
# Avant : truncation pour @javascript → race condition
Before('@javascript') do
  DatabaseCleaner.strategy = :truncation
end

# Après : connexion partagée + transaction pour tous
Before('@javascript') do
  ActiveRecord::Base.connection_pool.pin_connection!(true)
end
```

### Autres corrections

**Helper `last_authorization_request`** — Les 30 occurrences de
`AuthorizationRequest.last` éparpillées dans les step definitions sont remplacées par
un helper centralisé qui : (1) retourne `@authorization_request` si défini, (2) fait
un `.order(:created_at).last` sinon, (3) raise un message explicite si nil. Avant,
un `.last` retournant nil produisait un `NoMethodError` cryptique plusieurs lignes
plus loin.

**Guard `current_user!`** — Un appel `current_user.email` non gardé (ligne 211 de
`authorization_requests_steps.rb`) pouvait crasher avec `NoMethodError` quand
`current_user` était nil. Remplacé par `current_user!.email` qui donne un message
clair.

**Vérification post-login** — Le step `je me connecte` vérifie maintenant que le
login a réussi. Si la page affiche encore « S'identifier avec ProConnect » après le
clic, un `raise` explicite est levé immédiatement, au lieu de laisser le scénario
continuer avec une session invalide et produire une erreur incompréhensible plus tard.

**`CAPYBARA_WAIT_TIME` configurable** — Le `default_max_wait_time` de Capybara est
maintenant configurable via variable d'environnement. Valeur par défaut : 5s. Sur la
CI (`.github/workflows/test.env`) : 8s, pour absorber la latence sous charge.

### Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `features/support/env.rb` | `pin_connection!(true)`, suppression truncation |
| `features/support/authorization_request_helpers.rb` | Helper `last_authorization_request` |
| `features/step_definitions/authorization_requests_steps.rb` | 20× `.last` → helper, `current_user!` |
| `features/step_definitions/authorization_steps.rb` | 5× `.last` → helper |
| `features/step_definitions/messages_steps.rb` | 1× `.last` → helper |
| `features/step_definitions/organizations_steps.rb` | 1× `.last` → helper |
| `features/step_definitions/admin_steps.rb` | 1× `.last` → helper |
| `features/step_definitions/integrity_stepts.rb` | 1× `.last` → helper |
| `features/step_definitions/login_steps.rb` | Vérification post-login |
| `features/support/applicant_authorization_request_helpers.rb` | 1× `.last` → helper |
| `spec/support/configure_javascript_driver.rb` | `CAPYBARA_WAIT_TIME` configurable |
| `.github/workflows/test.env` | `CAPYBARA_WAIT_TIME=8` |

### Points d'attention pour la review

- `pin_connection!` est une API `:nodoc:` de Rails (non documentée publiquement),
  mais stable et utilisée par `ActiveRecord::TestFixtures` depuis Rails 7.1. Si
  l'API change dans une future version de Rails, l'erreur sera explicite (méthode
  non trouvée) et facile à corriger.
- Le helper `last_authorization_request` est un refactoring mécanique : chaque
  remplacement est identique. Le diff est volumineux mais le changement est simple.
- Aucun changement de comportement applicatif. Seul le code de test est modifié.

### Résultats

**Avant :** ~30% des runs CI échouaient (6/20), nécessitant des relances manuelles.

**Après :** 5 runs CI consécutifs, tous verts (0/5 en échec).