### PR TITLE
Ajoute le scope men_regime_pensionnat à API Particulier

### DIFF
--- a/config/authorization_definitions/api_particulier.yml
+++ b/config/authorization_definitions/api_particulier.yml
@@ -91,6 +91,9 @@ api_particulier:
     - name: "Module élémentaire formation"
       value: "men_statut_module_elementaire_formation"
       group: "API Statut élève scolarisé et boursier"
+    - name: "Régime de pensionnat"
+      value: "men_regime_pensionnat"
+      group: "API Statut élève scolarisé et boursier"
 
     - name: "Statut étudiant boursier"
       value: "cnous_statut_boursier"

--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -1536,6 +1536,7 @@ api-particulier-dialog:
       - men_statut_scolarite
       - men_statut_boursier
       - men_echelon_bourse
+      - men_regime_pensionnat
 
   initialize_with:
     intitule: Dématérialisation des dispositifs d'aides et de subventions
@@ -1584,6 +1585,7 @@ api-particulier-coexya:
       - men_statut_scolarite
       - men_statut_boursier
       - men_echelon_bourse
+      - men_regime_pensionnat
       - complementaire_sante_solidaire
 
   initialize_with:
@@ -2183,6 +2185,7 @@ api-particulier-tarification-cantines-lycees:
       - men_statut_scolarite
       - men_statut_boursier
       - men_echelon_bourse
+      - men_regime_pensionnat
   steps:
     - name: basic_infos
     - name: legal
@@ -2212,6 +2215,7 @@ api-particulier-tarification-cantines-colleges:
       - men_statut_scolarite
       - men_statut_boursier
       - men_echelon_bourse
+      - men_regime_pensionnat
   steps:
     - name: basic_infos
     - name: legal
@@ -2308,6 +2312,7 @@ api-particulier-tarification-transports:
       - men_statut_scolarite
       - men_statut_boursier
       - men_echelon_bourse
+      - men_regime_pensionnat
       - mesri_identite
       - mesri_admissions
       - mesri_admission_inscrit
@@ -2352,6 +2357,7 @@ api-particulier-gestion-rh-secteur-public:
       - men_statut_scolarite
       - men_statut_boursier
       - men_echelon_bourse
+      - men_regime_pensionnat
       - cnous_echelon_bourse
       - cnous_identite
       - cnous_email


### PR DESCRIPTION
- Ajout du scope `men_regime_pensionnat` (« Régime de pensionnat ») dans la définition API Particulier, groupe « API Statut élève scolarisé et boursier »
- Ajout du scope dans les 6 formulaires qui proposaient déjà le triplet `men_statut_scolarite` / `men_statut_boursier` / `men_echelon_bourse` :
  - Dématérialisation des dispositifs d'aides et de subventions
  - Tarification sociale et solidaires des transports
  - Tarification cantine des lycées
  - Tarification cantine des collèges
  - Bourses et aides sociales (displayed)
  - Bourses et aides sociales (disabled/pré-coché)
- Les formulaires ne listant que `men_statut_scolarite` (sans les scopes boursier/échelon) ne sont pas concernés car le régime de pensionnat est une donnée retournée par le même endpoint que les données de bourse.

Ref: https://linear.app/pole-api/issue/API-6590
Ref: https://github.com/datagouv/apistration/pull/13