### PR TITLE
use the numeric id of authorizations in paths instead of the FriendlyId.

### DIFF
--- a/app/controllers/authorizations_controller.rb
+++ b/app/controllers/authorizations_controller.rb
@@ -3,6 +3,7 @@ class AuthorizationsController < AuthenticatedUserController
 
   before_action :set_context, only: :index
   before_action :set_authorization, only: :show
+  before_action :redirect_to_canonical, only: :show
   decorates_assigned :authorization, :authorizations, :authorization_request
 
   def index
@@ -23,7 +24,7 @@ class AuthorizationsController < AuthenticatedUserController
 
   def set_context
     if params[:authorization_id].present?
-      @authorization = Authorization.friendly.find(params[:authorization_id])
+      @authorization = Authorization.find(params[:authorization_id])
       @authorization_request = @authorization.request
     else
       @authorization_request = AuthorizationRequest.find(params[:authorization_request_id])
@@ -31,7 +32,13 @@ class AuthorizationsController < AuthenticatedUserController
   end
 
   def set_authorization
-    @authorization = Authorization.friendly.find(params[:id])
+    @authorization = Authorization.find(params[:id])
+  end
+
+  def redirect_to_canonical
+    return unless params[:id] != @authorization.id.to_s
+
+    redirect_to authorization_path(@authorization), status: :moved_permanently
   end
 
   def authorization_or_request

--- a/app/controllers/authorizations_controller.rb
+++ b/app/controllers/authorizations_controller.rb
@@ -36,7 +36,7 @@ class AuthorizationsController < AuthenticatedUserController
   end
 
   def redirect_to_canonical
-    return unless params[:id] != @authorization.id.to_s
+    return unless params[:id] == @authorization.slug.to_s
 
     redirect_to authorization_path(@authorization), status: :moved_permanently
   end

--- a/app/controllers/concerns/authorization_or_request_context.rb
+++ b/app/controllers/concerns/authorization_or_request_context.rb
@@ -12,7 +12,7 @@ module AuthorizationOrRequestContext
 
   def extract_authorization_or_request
     if params[:authorization_id].present?
-      @authorization = Authorization.friendly.find(params[:authorization_id])
+      @authorization = Authorization.find(params[:authorization_id])
       @authorization_request = @authorization.request
     else
       @authorization_request = AuthorizationRequest.find(params[:authorization_request_id])

--- a/app/controllers/instruction/revoke_authorizations_controller.rb
+++ b/app/controllers/instruction/revoke_authorizations_controller.rb
@@ -33,7 +33,7 @@ class Instruction::RevokeAuthorizationsController < InstructionController
   private
 
   def extract_authorization
-    @authorization = Authorization.friendly.find(params[:authorization_id])
+    @authorization = Authorization.find(params[:authorization_id])
   end
 
   def revocation_of_authorization_params

--- a/app/controllers/redirect_from_v1_controller.rb
+++ b/app/controllers/redirect_from_v1_controller.rb
@@ -1,6 +1,6 @@
 class RedirectFromV1Controller < ApplicationController
   def show
-    redirect_to authorization_path(Authorization.find(params[:id]).slug),
+    redirect_to authorization_path(Authorization.find(params[:id])),
       status: :moved_permanently
   rescue ActiveRecord::RecordNotFound
     redirect_to authorization_request_path(AuthorizationRequest.find(params[:id])),

--- a/app/controllers/reopen_authorizations_controller.rb
+++ b/app/controllers/reopen_authorizations_controller.rb
@@ -32,7 +32,7 @@ class ReopenAuthorizationsController < AuthenticatedUserController
 
   def extract_authorization
     authorization_request = AuthorizationRequest.find(params[:authorization_request_id])
-    @authorization = authorization_request.authorizations.friendly.find(params[:authorization_id])
+    @authorization = authorization_request.authorizations.find(params[:authorization_id])
   end
 
   def authorize_authorization_reopening

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,8 +1,5 @@
 class Authorization < ApplicationRecord
-  extend FriendlyId
   include DemandesHabilitationsSearchable
-
-  friendly_id :slug_candidates, use: :slugged
 
   validates :data, presence: true
 
@@ -103,6 +100,8 @@ class Authorization < ApplicationRecord
 
   def self.find(id)
     super(id.to_s.sub(/\AH/i, ''))
+  rescue ActiveRecord::RecordNotFound => e
+    find_by(slug: id.to_s) || raise(e)
   end
 
   def self.ransackable_associations(_auth_object = nil)
@@ -221,18 +220,5 @@ class Authorization < ApplicationRecord
         request_as_validated.public_send(:"#{document.name}").attach(file.blob)
       end
     end
-  end
-
-  def slug_candidates
-    [
-      :authorization_request_id_with_date,
-      -> { "#{authorization_request_id_with_date}--1" },
-      -> { "#{authorization_request_id_with_date}--2" },
-      -> { "#{authorization_request_id_with_date}--3" },
-    ]
-  end
-
-  def authorization_request_id_with_date
-    "#{request.id}--#{(created_at || Date.current).strftime('%d-%m-%Y')}"
   end
 end

--- a/app/views/dgfip/apim_mailer/approve.text.erb
+++ b/app/views/dgfip/apim_mailer/approve.text.erb
@@ -1,9 +1,9 @@
 <%= t('mailer.shared.header.hello') %>
 
 <% if @reopening -%>
-<%= t('.reopening_description', formatted_id: @authorization_request.formatted_id, stage_label: @stage_label, slug: @authorization.slug, instruction_url: instruction_authorization_request_url(@authorization_request)) %>
+<%= t('.reopening_description', formatted_id: @authorization_request.formatted_id, stage_label: @stage_label, authorization_formatted_id: @authorization.formatted_id, instruction_url: instruction_authorization_request_url(@authorization_request)) %>
 <% else -%>
-<%= t('.description', formatted_id: @authorization_request.formatted_id, stage_label: @stage_label, slug: @authorization.slug, instruction_url: instruction_authorization_request_url(@authorization_request)) %>
+<%= t('.description', formatted_id: @authorization_request.formatted_id, stage_label: @stage_label, authorization_formatted_id: @authorization.formatted_id, instruction_url: instruction_authorization_request_url(@authorization_request)) %>
 <% end -%>
 
 Cordialement,

--- a/config/locales/mailer.fr.yml
+++ b/config/locales/mailer.fr.yml
@@ -207,11 +207,11 @@ fr:
       approve:
         description: >-
           Nous vous informons que la demande %{formatted_id} d'accès %{stage_label} a été validée,
-          elle a donné lieu à l'habilitation %{slug}. Les détails de cette habilitation sont
+          elle a donné lieu à l'habilitation %{authorization_formatted_id}. Les détails de cette habilitation sont
           disponibles via le lien suivant : %{instruction_url}
         reopening_description: >-
           Nous vous informons que la demande de mise à jour %{formatted_id} d'accès %{stage_label}
-          a été validée, elle a donné lieu à l'habilitation %{slug}. Les détails de cette
+          a été validée, elle a donné lieu à l'habilitation %{authorization_formatted_id}. Les détails de cette
           habilitation sont disponibles via le lien suivant : %{instruction_url}
   webhook_mailer:
     fail:

--- a/config/openapi/v1.yaml
+++ b/config/openapi/v1.yaml
@@ -246,6 +246,7 @@ components:
           description: Identifiant unique de l'habilitation
         slug:
           type: string
+          nullable: true
           example: "habilitation-123"
           description: Slug de l'habilitation
         revoked:
@@ -279,7 +280,6 @@ components:
           description: Identifiant de la définition d'habilitation associée à cette habilitation. Voir le endpoint `GET /definitions` pour la liste des définitions d'habilitations auxquelles vous avez accès.
       required:
         - id
-        - slug
         - revoked
         - state
         - created_at

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -586,8 +586,7 @@ Quand(%r{je me rends sur l'habilitation validée(?: du (\d{1,2}/\d{2}/\d{4}))?})
 
   if date_string.present?
     date = Date.parse(date_string)
-    authorization = authorization_request.authorizations.friendly.find(date.strftime('%d-%m-%Y'))
-    raise "Authorization not found for #{date}" if authorization.nil?
+    authorization = authorization_request.authorizations.find_by!(created_at: date.all_day)
   else
     authorization = authorization_request.latest_authorization
   end

--- a/features/step_definitions/authorization_steps.rb
+++ b/features/step_definitions/authorization_steps.rb
@@ -82,7 +82,7 @@ Quand("j'ai une habilitation {string} liée à une demande d'habilitation ayant 
 end
 
 Alors('il y a un formulaire en mode résumé non modifiable') do
-  expect(page).to have_current_path(%r{/habilitations/#{@authorization.slug}})
+  expect(page).to have_current_path(%r{/habilitations/#{@authorization.id}})
 
   # Verify the form is not editable by checking if inputs are disabled or read-only
   expect(page).to have_css('input[disabled]') if page.has_css?('input')

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe AuthorizationsController do
+  describe 'GET #show' do
+    subject(:show_authorization) { get :show, params: { id: } }
+
+    let(:user) { create(:user) }
+    let(:authorization) { create(:authorization, applicant: user, slug: 'some slug') }
+
+    before do
+      sign_in(user)
+    end
+
+    context 'when the id param is a slug' do
+      let(:id) { authorization.slug }
+
+      it 'redirects permanently to the numeric ID URL' do
+        expect(show_authorization).to redirect_to(authorization_path(authorization))
+        expect(show_authorization).to have_http_status(:moved_permanently)
+      end
+    end
+
+    context 'when the id param is the numeric ID' do
+      let(:id) { authorization.id }
+
+      it 'renders the show page' do
+        expect(show_authorization).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/controllers/redirect_from_v1_controller_spec.rb
+++ b/spec/controllers/redirect_from_v1_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RedirectFromV1Controller do
       let(:id) { authorization.id }
 
       it 'redirects to the authorization path' do
-        expect(redirect_from_v1).to redirect_to(authorization_path(authorization.slug))
+        expect(redirect_from_v1).to redirect_to(authorization_path(authorization))
       end
     end
 

--- a/spec/mailers/dgfip_apim_mailer_spec.rb
+++ b/spec/mailers/dgfip_apim_mailer_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe DGFIP::APIMMailer do
         )
       end
 
-      it 'includes the authorization request id in the body' do
-        expect(mail.body.encoded).to include(authorization_request.id.to_s)
+      it 'includes the authorization_request\'s formatted_id in the body' do
+        expect(mail.body.encoded).to include(authorization_request.formatted_id)
       end
 
-      it 'includes the authorization slug in the body' do
-        expect(mail.body.encoded).to include(authorization.slug)
+      it 'includes the authorization\'s formatted id in the body' do
+        expect(mail.body.encoded).to include(authorization.formatted_id)
       end
 
       it 'includes BAS for sandbox stage' do

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Authorization do
   end
 
   describe '.find' do
-    let!(:authorization) { create(:authorization) }
+    let!(:authorization) { create(:authorization, slug: 'old-slug-backward-compat') }
 
     it 'finds by numeric ID' do
       expect(described_class.find(authorization.id)).to eq(authorization)
@@ -51,6 +51,10 @@ RSpec.describe Authorization do
 
     it 'finds by lowercase prefixed ID (h123)' do
       expect(described_class.find("h#{authorization.id}")).to eq(authorization)
+    end
+
+    it 'finds by slug for backward compatibility' do
+      expect(described_class.find('old-slug-backward-compat')).to eq(authorization)
     end
   end
 


### PR DESCRIPTION
Keep FriendlyId functionnal so that all previous urls sent by email still work.

ref https://linear.app/pole-api/issue/DP-1537/privilegier-les-liens-avec-lid-explicite-de-lhabilitation