### PR TITLE
Fix N+1 queries on dashboard associations

### DIFF
--- a/app/services/authorization_requests_search_engine_builder.rb
+++ b/app/services/authorization_requests_search_engine_builder.rb
@@ -1,7 +1,6 @@
 class AuthorizationRequestsSearchEngineBuilder < AbstractSearchEngineBuilder
   def build_relation(policy_scope)
     base_items = policy_scope
-      .includes(:applicant, :organization, authorizations: %i[organization])
       .not_archived
       .order(created_at: :desc)
 
@@ -12,7 +11,7 @@ class AuthorizationRequestsSearchEngineBuilder < AbstractSearchEngineBuilder
     base_items = base_items.or(mentions_items)
     base_items = base_items.where(type: subdomain_types) if subdomain_types.present?
 
-    build_search_engine(base_items)
+    build_search_engine(base_items).preload(:applicant, :organization, :authorizations)
   end
 
   private

--- a/app/services/authorizations_search_engine_builder.rb
+++ b/app/services/authorizations_search_engine_builder.rb
@@ -1,7 +1,6 @@
 class AuthorizationsSearchEngineBuilder < AbstractSearchEngineBuilder
   def build_relation(policy_scope)
     base_items = policy_scope
-      .includes(:request, :applicant, :organization, request: %i[organization])
       .order(created_at: :desc)
 
     mentions_items = AuthorizationsMentionsQuery
@@ -11,7 +10,7 @@ class AuthorizationsSearchEngineBuilder < AbstractSearchEngineBuilder
     base_items = base_items.or(mentions_items)
     base_items = base_items.where(authorization_request_class: subdomain_types) if subdomain_types.present?
 
-    build_search_engine(base_items)
+    build_search_engine(base_items).preload(:request, :applicant, :organization)
   end
 
   private

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -12,4 +12,40 @@ RSpec.describe 'Dashboard' do
       expect(response).to redirect_to(dashboard_show_path(id: 'demandes'))
     end
   end
+
+  describe 'GET show habilitations' do
+    let(:organization) { user.current_organization }
+    let(:other_user) { create(:user, skip_organization_creation: true) }
+    let(:request_user) { create(:authorization_request, :api_entreprise, :validated, organization:, applicant: user) }
+    let(:request_other) { create(:authorization_request, :api_entreprise, :validated, organization:, applicant: other_user) }
+
+    before do
+      other_user.add_to_organization(organization, verified: true)
+      create(:authorization, request: request_user)
+      create(:authorization, request: request_other)
+    end
+
+    it 'does not trigger N+1 queries on associations' do
+      get dashboard_show_path(id: 'habilitations')
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET show demandes' do
+    let(:organization) { user.current_organization }
+    let(:other_user) { create(:user, skip_organization_creation: true) }
+
+    before do
+      other_user.add_to_organization(organization, verified: true)
+      create(:authorization_request, :api_entreprise, organization:, applicant: user, state: :draft)
+      create(:authorization_request, :api_entreprise, organization:, applicant: other_user, state: :submitted)
+    end
+
+    it 'does not trigger N+1 queries on associations' do
+      get dashboard_show_path(id: 'demandes')
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
includes() on authorization_requests and authorizations was silently dropped in the .or() + Ransack pipeline, triggering individual SQL queries for applicant, organization and authorizations on each record.

Replace with preload() applied after build_search_engine so it survives Ransack processing. Also add regression tests via Bullet.