### PR TITLE
Fix silent 422 on authorization request submit from summary page

### DIFF
--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -263,8 +263,8 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
       redirect_to dashboard_path
     else
       error_message_for_authorization_request(@authorization_request, key: 'authorization_request_forms.submit', include_model_errors: true)
-
-      render 'summary', status: :unprocessable_content
+      @force_render_summary_tab = @authorization_request.state != 'draft'
+      render 'summary', status: :unprocessable_content, layout: layout_name # Forces turbo to render the whole body
     end
   end
 
@@ -332,6 +332,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
   end
 
   def show_tabs?
+    return true if @force_render_summary_tab
     return false unless action_name == 'summary'
     return false if @authorization_request.nil?
     return false if @authorization_request.new_record?

--- a/app/views/layouts/authorization_request_with_tabs.html.erb
+++ b/app/views/layouts/authorization_request_with_tabs.html.erb
@@ -94,7 +94,7 @@
       <% authorization_request_tabs(authorization_request).each do |id, path| %>
         <turbo-frame id="tab-<%= id %>-panel" class="fr-tabs__panel fr-tabs__panel--selected fr-bg-white" role="tabpanel" aria-labelledby="tab-<%= id %>" tabindex="0" data-turbo-action="advance">
           <div class="fr-container">
-            <% if current_page?(path) %>
+            <% if current_page?(path) || (@force_render_summary_tab && id == :authorization_request ) %>
               <%= render partial: 'shared/alerts' %>
               <div data-auto-height-target="source">
                 <%= yield %>

--- a/features/soumission_depuis_resume_demande_modifications.feature
+++ b/features/soumission_depuis_resume_demande_modifications.feature
@@ -1,0 +1,30 @@
+# language: fr
+
+Fonctionnalité: Soumission depuis la page de résumé d'une demande en attente de modification
+  Quand un demandeur soumet une demande en attente de modification depuis la page de
+  résumé et que la soumission échoue, le message d'erreur doit être affiché.
+  Ce comportement est critique car la page de résumé d'une demande en attente de
+  modification utilise des onglets (turbo-frames), ce qui peut rendre le message
+  d'erreur invisible si la réponse n'est pas gérée correctement.
+
+  Contexte:
+    Sachant que je suis un demandeur
+    Et que je me connecte
+
+  @javascript
+  Scénario: L'erreur d'email non joignable est affichée ainsi que les onglets lors de la soumission depuis la page de résumé d'une demande à modifier
+    Quand j'ai 1 demande d'habilitation "API Entreprise" en attente de modification
+    Et qu'il y a l'email "jean.dupont.contact_technique@gouv.fr" marqué en tant que "non délivrable"
+    Et que je me rends sur cette demande d'habilitation
+    Et que je clique sur "Soumettre la demande d'habilitation"
+    Alors il y a un message d'erreur contenant "Nous n’avons pas pu transmettre votre demande"
+    Et je vois l'onglet "Demande"
+
+  @javascript
+  Scénario: L'erreur d'email non joignable est affichée ainsi que les onglets lors de la soumission depuis la page de résumé d'un draft
+    Quand j'ai 1 demande d'habilitation "API Entreprise" en brouillon et rempli
+    Et qu'il y a l'email "jean.dupont.contact_technique@gouv.fr" marqué en tant que "non délivrable"
+    Et que je me rends sur la page résumé de cette demande
+    Et que je clique sur "Soumettre la demande d'habilitation"
+    Alors il y a un message d'erreur contenant "Nous n’avons pas pu transmettre votre demande"
+    Et je ne vois pas l'onglet "Demande"

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -142,6 +142,11 @@ Quand('je me rends sur cette demande d\'habilitation') do
   end
 end
 
+Quand('je me rends sur la page résumé de cette demande') do
+  authorization_request = @authorization_request || AuthorizationRequest.last
+  visit summary_authorization_request_form_path(form_uid: authorization_request.form.uid, id: authorization_request.id)
+end
+
 Quand('je me rends sur la page demandeur de cette demande') do
   authorization_request = @authorization_request || AuthorizationRequest.last
   visit authorization_request_path(authorization_request)


### PR DESCRIPTION
When a user submits a \`change_requested\` authorization request from the summary page and validation fails (e.g. an unverifiable contact email), two things went wrong simultaneously:

1. **The flash error was silently swallowed** — it never appeared on screen.
2. **The page lost its CSS** — the entire tab layout collapsed, leaving a blank unstyled page.

## Root cause

The summary form submits via PATCH to the authorization request form path (e.g. \`/demande/api-r2p-production/65790\`). On failure, the controller rendered \`summary\` with the \`authorization_request_with_tabs\` layout. That layout renders each tab's content inside a \`<turbo-frame>\`, guarded by \`current_page?(path)\` where \`path\` is the summary URL (\`/demande/api-r2p-production/65790/résumé\`).

Since the PATCH request URL differs from the summary URL, \`current_page?\` returns false for all tabs. Every turbo-frame renders as an empty placeholder. Turbo finds the summary frame in the response, swaps in the empty placeholder, and:
- the flash error disappears (it was inside the now-empty frame)
- the tab chrome (header, navigation, DSFR styles) is gone — only the empty frame content is swapped in, stripping the surrounding layout from view

## Fix

- Introduced \`@force_render_summary_tab\` to bypass the \`current_page?\` guard and render the summary tab content regardless of the request URL.
- Explicitly pass the correct layout to \`render\` on failure: \`authorization_request_with_tabs\` for \`change_requested\` requests (which have tabs), \`authorization_request\` for drafts (which don't).