### PR TITLE
Gère les cas personne physique et organisation étrangère dans Organization#name

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -31,11 +31,18 @@ class Organization < ApplicationRecord
   end
 
   def name
+    return "L'organisation #{legal_entity_id} (issu de #{legal_entity_registry})" if foreign?
+    return "#{nom} #{prenom}".strip if personne_physique?
+
     denomination || "l'organisation #{legal_entity_id} (nom inconnu)"
   end
 
   def denomination
-    insee_payload.dig('etablissement', 'uniteLegale', 'denominationUniteLegale')
+    unite_legale['denominationUniteLegale']
+  end
+
+  def personne_physique?
+    unite_legale['categorieJuridiqueUniteLegale'] == '1000'
   end
 
   def insee_payload
@@ -83,6 +90,18 @@ class Organization < ApplicationRecord
   end
 
   private
+
+  def unite_legale
+    insee_payload.dig('etablissement', 'uniteLegale') || {}
+  end
+
+  def nom
+    unite_legale['nomUniteLegale'].to_s
+  end
+
+  def prenom
+    unite_legale['prenom1UniteLegale'].to_s
+  end
 
   def insee_latest_etablissement_period
     return unless insee_payload['etablissement']

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -4,6 +4,47 @@ RSpec.describe Organization do
     expect(build(:organization, identity_federator: 'proconnect')).to be_valid
   end
 
+  describe '#name' do
+    subject { organization.name }
+
+    context 'when organization is foreign' do
+      let(:organization) { build(:organization, :foreign) }
+
+      it { is_expected.to eq("L'organisation #{organization.legal_entity_id} (issu de isni)") }
+    end
+
+    context 'when insee_payload is blank' do
+      let(:organization) { build(:organization, siret: '41040946000756') }
+
+      it { is_expected.to eq("l'organisation #{organization.legal_entity_id} (nom inconnu)") }
+    end
+
+    context 'when organization is a personne physique' do
+      let(:organization) do
+        build(:organization,
+          legal_entity_registry: 'insee_sirene',
+          legal_entity_id: '12345678900010',
+          insee_payload: {
+            'etablissement' => {
+              'uniteLegale' => {
+                'categorieJuridiqueUniteLegale' => '1000',
+                'nomUniteLegale' => 'DUPONT',
+                'prenom1UniteLegale' => 'Jean'
+              }
+            }
+          })
+      end
+
+      it { is_expected.to eq('DUPONT Jean') }
+    end
+
+    context 'when organization is a personne morale' do
+      let(:organization) { build(:organization, siret: '21920023500014') }
+
+      it { is_expected.to eq('COMMUNE DE CLAMART') }
+    end
+  end
+
   describe '#closed?' do
     subject { organization }
 


### PR DESCRIPTION
Jusqu'ici Organization#name se contentait de retourner la denomination INSEE ou un fallback « nom inconnu », ce qui masquait :
- les personnes physiques (entrepreneurs individuels, categorieJuridique 1000), pour lesquelles l'INSEE n'expose pas de denomination mais un nomUniteLegale et un prenom1UniteLegale ;
- les organisations issues d'un registre autre que insee_sirene (ex. isni), qui n'ont pas de payload INSEE et affichaient donc systématiquement « nom inconnu » sans indiquer leur provenance réelle.

La méthode distingue désormais quatre cas :
1. organisation étrangère → « L'organisation <id> (issu de <registry>) »
2. personne physique → « NOM Prénom »
3. personne morale → denomination
4. payload INSEE absent → « l'organisation <id> (nom inconnu) »