### PR TITLE
Gère l'erreur à la soumission d'une demande avec turbo-stream

### DIFF
--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -263,8 +263,11 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
       redirect_to dashboard_path
     else
       error_message_for_authorization_request(@authorization_request, key: 'authorization_request_forms.submit', include_model_errors: true)
-      @force_render_summary_tab = @authorization_request.state != 'draft'
-      render 'summary', status: :unprocessable_content, layout: layout_name # Forces turbo to render the whole body
+
+      respond_to do |format|
+        format.turbo_stream { render 'authorization_request_forms/submit' }
+        format.html { render 'summary', status: :unprocessable_content }
+      end
     end
   end
 

--- a/app/javascript/controllers/scroll_into_view_controller.js
+++ b/app/javascript/controllers/scroll_into_view_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect () {
+    this.element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+}

--- a/app/views/authorization_request_forms/_form.html.erb
+++ b/app/views/authorization_request_forms/_form.html.erb
@@ -16,7 +16,9 @@
 
 <div class="fr-container fr-container--with-tiny-alert">
   <% unless show_authorization_request_tabs?(@authorization_request) %>
-    <%= render partial: 'shared/alerts' %>
+    <div id="flash-alerts">
+      <%= render partial: 'shared/alerts' %>
+    </div>
   <% end %>
 
   <% if within_wizard? %>

--- a/app/views/authorization_request_forms/submit.turbo_stream.erb
+++ b/app/views/authorization_request_forms/submit.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace 'flash-alerts' do %>
+  <div id="flash-alerts" data-controller="scroll-into-view">
+    <%= render partial: 'shared/alerts' %>
+  </div>
+<% end %>

--- a/app/views/layouts/authorization_request_with_tabs.html.erb
+++ b/app/views/layouts/authorization_request_with_tabs.html.erb
@@ -94,8 +94,10 @@
       <% authorization_request_tabs(authorization_request).each do |id, path| %>
         <turbo-frame id="tab-<%= id %>-panel" class="fr-tabs__panel fr-tabs__panel--selected fr-bg-white" role="tabpanel" aria-labelledby="tab-<%= id %>" tabindex="0" data-turbo-action="advance">
           <div class="fr-container">
-            <% if current_page?(path) || (@force_render_summary_tab && id == :authorization_request ) %>
-              <%= render partial: 'shared/alerts' %>
+            <% if current_page?(path) %>
+              <div id="flash-alerts">
+                <%= render partial: 'shared/alerts' %>
+              </div>
               <div data-auto-height-target="source">
                 <%= yield %>
               </div>


### PR DESCRIPTION
C'est donc la technique officielle pour les soumissions de formulaire qui donnent une erreur.
Follow-up de https://github.com/etalab/data_pass/pull/1505