### PR TITLE
Ajoute des droits utilisateur de niveau FD (DP-1612)

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -13,9 +13,7 @@ class APIController < ActionController::API
   private
 
   def current_user_authorization_request_types
-    current_user.developer_roles.map do |role|
-      "AuthorizationRequest::#{role.split(':')[0].classify}"
-    end
+    current_user.authorization_request_types_for(:developer)
   end
 
   def set_authorization_request

--- a/app/controllers/instruction/instructor_draft_requests_controller.rb
+++ b/app/controllers/instruction/instructor_draft_requests_controller.rb
@@ -98,12 +98,8 @@ class Instruction::InstructorDraftRequestsController < InstructionController
   private
 
   def extract_available_definitions
-    @definitions = current_user.instructor_roles.map do |scope|
-      authorization_definition_id = scope.split(':').first
-      AuthorizationDefinition.find(authorization_definition_id)
-    end
-
-    @definitions.select! { |definition| definition.feature?('instructor_drafts', default: false) }
+    @definitions = current_user.authorization_definition_roles_as(:instructor)
+      .select { |definition| definition.feature?('instructor_drafts', default: false) }
   end
 
   def instructor_draft_request_params

--- a/app/controllers/instruction/message_templates_controller.rb
+++ b/app/controllers/instruction/message_templates_controller.rb
@@ -61,7 +61,7 @@ class Instruction::MessageTemplatesController < InstructionController
   end
 
   def managed_authorization_definition_uids
-    current_user.manager_roles.map { |role| role.split(':').first }
+    current_user.definition_ids_for(:manager)
   end
 
   def managed_authorization_definitions

--- a/app/interactors/admin/remove_habilitation_type_roles.rb
+++ b/app/interactors/admin/remove_habilitation_type_roles.rb
@@ -1,14 +1,12 @@
 class Admin::RemoveHabilitationTypeRoles < ApplicationInteractor
   def call
     uid = context.habilitation_type.uid
+    fd_slug = context.habilitation_type.data_provider.slug
 
-    User::ROLES.each do |role_type|
-      role = "#{uid}:#{role_type}"
-
-      User.where('? = ANY(roles)', role).find_each do |user|
-        user.roles.delete(role)
-        user.save!
-      end
+    exact_roles = User::ROLES.map { |role_type| "#{fd_slug}:#{uid}:#{role_type}" }
+    User.with_role_matching(exact_roles).find_each do |user|
+      user.roles.reject! { |r| ParsedRole.parse(r).definition_id == uid }
+      user.save!
     end
   end
 end

--- a/app/interactors/admin/update_user_roles_attribute.rb
+++ b/app/interactors/admin/update_user_roles_attribute.rb
@@ -8,27 +8,7 @@ class Admin::UpdateUserRolesAttribute < ApplicationInteractor
   private
 
   def valid_roles
-    context.roles.select do |role|
-      admin_role?(role) ||
-        valid_role_for_authorization_request_type?(role)
-    end
-  end
-
-  def admin_role?(role)
-    role == 'admin'
-  end
-
-  def valid_role_for_authorization_request_type?(role)
-    authorization_request_type, role_type = role.split(':')
-
-    return false unless authorization_request_types.include?(authorization_request_type)
-    return false unless User::ROLES.include?(role_type)
-
-    true
-  end
-
-  def authorization_request_types
-    AuthorizationDefinition.all.map(&:id)
+    context.roles.select { |role| ParsedRole.valid?(role) }
   end
 
   def user

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -176,7 +176,7 @@ class Seeds
       external_id: '4',
       job_title: 'Responsable des instructions',
       phone_number: '0423456789',
-      roles: ['api_entreprise:instructor', 'api_entreprise:developer']
+      roles: ['dinum:api_entreprise:instructor', 'dinum:api_entreprise:developer']
     )
   end
 
@@ -188,40 +188,30 @@ class Seeds
       external_id: '12',
       job_title: 'Responsable des reporteurs',
       phone_number: '0423456789',
-      roles: ['api_entreprise:reporter']
+      roles: ['dinum:api_entreprise:reporter']
     )
   end
 
   def data_pass_admin
     @data_pass_admin ||= User.create!(
       email: 'datapass@yopmail.com',
-      roles: ['admin'] + all_authorization_definition_manager_roles + ['api_entreprise:developer', 'api_particulier:developer'],
+      roles: ['admin'] + all_authorization_definition_manager_roles + ['dinum:api_entreprise:developer', 'dinum:api_particulier:developer'],
     )
   end
 
   def dgfip_instructor_developer
     @dgfip_instructor_developer ||= User.create!(
       email: 'dgfip@yopmail.com',
-      roles: all_dgfip_instructor_roles + all_dgfip_developer_roles
+      roles: %w[dgfip:*:instructor dgfip:*:developer]
     )
   end
 
   def all_authorization_definition_manager_roles
-    AuthorizationDefinition.all.map { |definition| "#{definition.id}:manager" }
-  end
+    AuthorizationDefinition.all.filter_map do |definition|
+      next unless definition.provider_slug
 
-  def all_dgfip_authorizations_definitions
-    AuthorizationDefinition
-      .all
-      .select { |definition| definition.provider&.id == 'dgfip' }
-  end
-
-  def all_dgfip_developer_roles
-    all_dgfip_authorizations_definitions.map { |definition| "#{definition.id}:developer" }
-  end
-
-  def all_dgfip_instructor_roles
-    all_dgfip_authorizations_definitions.map { |definition| "#{definition.id}:instructor" }
+      "#{definition.provider_slug}:#{definition.id}:manager"
+    end
   end
 
   def clamart_organization

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -66,19 +66,6 @@ class DataProvider < ApplicationRecord
   end
 
   def users_for_roles(roles)
-    User.where(
-      "EXISTS (
-        SELECT 1
-        FROM unnest(roles) AS role
-        WHERE role in (?)
-      )",
-      roles.map { |role| build_user_role_query_param(role) }.flatten,
-    )
-  end
-
-  def build_user_role_query_param(role)
-    authorization_definitions.map do |authorization_definition|
-      "#{authorization_definition.id}:#{role}"
-    end
+    User.with_role_for_provider(slug, roles)
   end
 end

--- a/app/models/parsed_role.rb
+++ b/app/models/parsed_role.rb
@@ -1,0 +1,43 @@
+ParsedRole = Data.define(:provider_slug, :definition_id, :role) do
+  def self.parse(role_string)
+    return new(provider_slug: nil, definition_id: nil, role: 'admin') if role_string == 'admin'
+
+    parts = role_string.split(':')
+    return self::NULL unless parts.length == 3
+
+    new(provider_slug: parts[0], definition_id: parts[1], role: parts[2])
+  end
+
+  def self.valid?(role_string)
+    parsed = parse(role_string)
+    return false unless parsed.role
+    return true if parsed.admin?
+    return false unless User::ROLES.include?(parsed.role)
+
+    parsed.valid_definition?
+  end
+
+  def self.resolve_provider_slug(definition_id)
+    AuthorizationDefinition.find_by(id: definition_id)&.provider_slug
+  end
+
+  def fd_level?
+    definition_id == '*'
+  end
+
+  def admin?
+    role == 'admin'
+  end
+
+  def valid_definition?
+    if fd_level?
+      AuthorizationDefinition.all.any? { |ad| ad.provider_slug == provider_slug }
+    else
+      self.class.resolve_provider_slug(definition_id) == provider_slug
+    end
+  end
+end
+
+ParsedRole::NULL = ParsedRole.new(provider_slug: nil, definition_id: nil, role: nil)
+
+class ParsedRole::UnknownDefinitionError < StandardError; end

--- a/app/models/role_hierarchy.rb
+++ b/app/models/role_hierarchy.rb
@@ -1,0 +1,15 @@
+module RoleHierarchy
+  IMPLIES = {
+    manager: %i[instructor reporter],
+    instructor: %i[reporter],
+    developer: %i[reporter],
+    reporter: [],
+  }.freeze
+
+  def self.qualifying_roles(kind)
+    kind = kind.to_sym
+    result = [kind]
+    IMPLIES.each { |role, implied| result << role if implied.include?(kind) }
+    result.map(&:to_s)
+  end
+end

--- a/app/models/role_set.rb
+++ b/app/models/role_set.rb
@@ -1,22 +1,34 @@
 class RoleSet
   def initialize(roles_array, kind)
     qualifying = RoleHierarchy.qualifying_roles(kind)
-    @matching_roles = roles_array.select do |r|
-      parts = r.split(':')
-      parts.length == 2 && qualifying.include?(parts[1])
+    @roles = roles_array.filter_map do |r|
+      parsed = ParsedRole.parse(r)
+      parsed if qualifying.include?(parsed.role)
     end
   end
 
   def covers?(definition_id = nil)
-    return @matching_roles.any? unless definition_id
+    return @roles.any? unless definition_id
 
-    @matching_roles.any? { |r| r.start_with?("#{definition_id}:") }
+    fd_slug = ParsedRole.resolve_provider_slug(definition_id)
+
+    @roles.any? do |parsed|
+      parsed.definition_id == definition_id || (parsed.fd_level? && parsed.provider_slug == fd_slug)
+    end
   end
 
-  delegate :any?, to: :@matching_roles
+  delegate :any?, to: :@roles
 
   def definition_ids
-    @definition_ids ||= @matching_roles.map { |r| r.split(':').first }.uniq
+    @definition_ids ||= @roles.flat_map { |parsed|
+      if parsed.fd_level?
+        AuthorizationDefinition.all
+          .select { |ad| ad.provider_slug == parsed.provider_slug }
+          .map(&:id)
+      else
+        [parsed.definition_id]
+      end
+    }.uniq
   end
 
   def authorization_request_types

--- a/app/models/role_set.rb
+++ b/app/models/role_set.rb
@@ -1,0 +1,29 @@
+class RoleSet
+  def initialize(roles_array, kind)
+    qualifying = RoleHierarchy.qualifying_roles(kind)
+    @matching_roles = roles_array.select do |r|
+      parts = r.split(':')
+      parts.length == 2 && qualifying.include?(parts[1])
+    end
+  end
+
+  def covers?(definition_id = nil)
+    return @matching_roles.any? unless definition_id
+
+    @matching_roles.any? { |r| r.start_with?("#{definition_id}:") }
+  end
+
+  delegate :any?, to: :@matching_roles
+
+  def definition_ids
+    @definition_ids ||= @matching_roles.map { |r| r.split(':').first }.uniq
+  end
+
+  def authorization_request_types
+    definition_ids.map { |id| "AuthorizationRequest::#{id.classify}" }
+  end
+
+  def authorization_definitions
+    definition_ids.filter_map { |id| AuthorizationDefinition.find_by(id: id) }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,35 +58,32 @@ class User < ApplicationRecord
   scope :with_roles, -> { where("roles <> '{}'") }
   scope :banned, -> { where.not(banned_at: nil) }
 
-  scope :instructor_for, lambda { |authorization_request_type|
-    qualifying = RoleHierarchy.qualifying_roles(:instructor)
+  scope :with_role_matching, lambda { |role_strings|
     where(
-      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role IN (?))',
-      qualifying.map { |q| "#{authorization_request_type.underscore}:#{q}" }
+      'EXISTS (SELECT 1 FROM unnest(roles) AS r WHERE r IN (?))',
+      role_strings
     )
   }
 
-  scope :developer_for, lambda { |authorization_request_type|
-    where(
-      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role = ?)',
-      "#{authorization_request_type.underscore}:developer"
+  scope :with_role_for_definition, lambda { |definition_id, kind|
+    fd_slug = ParsedRole.resolve_provider_slug(definition_id)
+    qualifying = RoleHierarchy.qualifying_roles(kind)
+
+    with_role_matching(
+      qualifying.flat_map { |role_type| ["#{fd_slug}:#{definition_id}:#{role_type}", "#{fd_slug}:*:#{role_type}"] }
     )
   }
 
-  scope :manager_for, lambda { |authorization_request_type|
+  scope :with_role_for_provider, lambda { |provider_slug, roles|
     where(
-      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role = ?)',
-      "#{authorization_request_type.underscore}:manager"
+      'EXISTS (SELECT 1 FROM unnest(roles) AS r WHERE r LIKE ANY(ARRAY[?]))',
+      roles.map { |role| "#{provider_slug}:%:#{role}" }
     )
   }
 
-  scope :reporter_for, lambda { |authorization_request_type|
-    qualifying = RoleHierarchy.qualifying_roles(:reporter)
-    where(
-      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role IN (?))',
-      qualifying.map { |q| "#{authorization_request_type.underscore}:#{q}" }
-    )
-  }
+  %i[instructor developer manager reporter].each do |role|
+    scope :"#{role}_for", ->(type) { with_role_for_definition(type.underscore, role) }
+  end
 
   scope :admin, lambda {
     where("'admin' = ANY(roles)")
@@ -153,6 +150,32 @@ class User < ApplicationRecord
     roles_for(kind).authorization_request_types
   end
 
+  def grant_role(kind, definition_id)
+    fd = ParsedRole.resolve_provider_slug(definition_id)
+    raise ParsedRole::UnknownDefinitionError, "Unknown definition: #{definition_id}" unless fd
+
+    roles << "#{fd}:#{definition_id}:#{kind}"
+    roles.uniq!
+    @role_sets = nil
+  end
+
+  def grant_fd_role(kind, provider_slug)
+    roles << "#{provider_slug}:*:#{kind}"
+    roles.uniq!
+    @role_sets = nil
+  end
+
+  def grant_admin_role
+    roles << 'admin'
+    roles.uniq!
+    @role_sets = nil
+  end
+
+  def revoke_all_roles
+    self.roles = []
+    @role_sets = nil
+  end
+
   def admin?
     roles.include?('admin') ||
       bug_bounty_users_within_staging_env?
@@ -183,17 +206,38 @@ class User < ApplicationRecord
   end
 
   ransacker :api_role do |_parent|
-    Arel.sql <<~SQL.squish
+    Arel.sql(api_role_ransacker_sql)
+  end
+
+  def self.api_role_ransacker_sql
+    <<~SQL.squish
       COALESCE(
-        array_to_string(
-          ARRAY(
-            SELECT split_part(elem, ':', 1)
-            FROM unnest(users.roles) AS elem
-          ),
-          ','
-        ),
+        (SELECT string_agg(DISTINCT def_id, ',') FROM (
+          SELECT split_part(elem, ':', 2) AS def_id
+          FROM unnest(users.roles) AS elem
+          WHERE elem ~ '^[^:]+:[^:]+:[^:]+$' AND split_part(elem, ':', 2) <> '*'
+          #{api_role_fd_expansion_sql}
+        ) expanded),
         ''
       )
+    SQL
+  end
+
+  def self.api_role_fd_expansion_sql
+    all_definitions = AuthorizationDefinition.all.select(&:provider_slug)
+    values = all_definitions.map { |ad|
+      "(#{connection.quote(ad.id)}, #{connection.quote(ad.provider_slug)})"
+    }.join(', ')
+
+    return '' if values.blank?
+
+    <<~SQL.squish
+      UNION
+      SELECT ad_map.def_id
+      FROM unnest(users.roles) AS elem
+      JOIN (VALUES #{values}) AS ad_map(def_id, provider_slug)
+        ON ad_map.provider_slug = split_part(elem, ':', 1)
+      WHERE split_part(elem, ':', 2) = '*'
     SQL
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,60 +59,37 @@ class User < ApplicationRecord
   scope :banned, -> { where.not(banned_at: nil) }
 
   scope :instructor_for, lambda { |authorization_request_type|
-    where("
-      EXISTS (
-        SELECT 1
-        FROM unnest(roles) AS role
-        WHERE role = ?
-      )
-    ", "#{authorization_request_type.underscore}:instructor")
+    qualifying = RoleHierarchy.qualifying_roles(:instructor)
+    where(
+      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role IN (?))',
+      qualifying.map { |q| "#{authorization_request_type.underscore}:#{q}" }
+    )
   }
 
   scope :developer_for, lambda { |authorization_request_type|
-    where("
-      EXISTS (
-        SELECT 1
-        FROM unnest(roles) AS role
-        WHERE role = ?
-      )
-    ", "#{authorization_request_type.underscore}:developer")
+    where(
+      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role = ?)',
+      "#{authorization_request_type.underscore}:developer"
+    )
   }
 
   scope :manager_for, lambda { |authorization_request_type|
-    where("
-      EXISTS (
-        SELECT 1
-        FROM unnest(roles) AS role
-        WHERE role = ?
-      )
-    ", "#{authorization_request_type.underscore}:manager")
+    where(
+      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role = ?)',
+      "#{authorization_request_type.underscore}:manager"
+    )
   }
 
   scope :reporter_for, lambda { |authorization_request_type|
+    qualifying = RoleHierarchy.qualifying_roles(:reporter)
     where(
-      "EXISTS (
-        SELECT 1
-        FROM unnest(roles) AS role
-        WHERE role in (?)
-      )",
-      [
-        "#{authorization_request_type.underscore}:instructor",
-        "#{authorization_request_type.underscore}:manager",
-        "#{authorization_request_type.underscore}:developer",
-        "#{authorization_request_type.underscore}:reporter",
-      ]
+      'EXISTS (SELECT 1 FROM unnest(roles) AS role WHERE role IN (?))',
+      qualifying.map { |q| "#{authorization_request_type.underscore}:#{q}" }
     )
   }
 
   scope :admin, lambda {
-    where(
-      "EXISTS (
-        SELECT 1
-        FROM unnest(roles) AS role
-        WHERE role in (?)
-      )",
-      ['admin']
-    )
+    where("'admin' = ANY(roles)")
   }
 
   add_instruction_boolean_settings :submit_notifications, :messages_notifications
@@ -145,57 +122,35 @@ class User < ApplicationRecord
     "#{family_name.upcase} #{formatted_given_name}"
   end
 
-  def instructor?(authorization_request_type = nil)
-    return true if manager?(authorization_request_type)
-
-    if authorization_request_type
-      roles.include?("#{authorization_request_type}:instructor")
-    else
-      roles.any? { |role| role.end_with?(':instructor') }
-    end
+  def roles_for(kind)
+    @role_sets ||= {}
+    @role_sets[kind] ||= RoleSet.new(roles, kind)
   end
 
-  def manager?(authorization_request_type = nil)
-    if authorization_request_type
-      roles.include?("#{authorization_request_type}:manager")
-    else
-      roles.any? { |role| role.end_with?(':manager') }
-    end
+  def instructor?(definition_id = nil)
+    roles_for(:instructor).covers?(definition_id)
   end
 
-  def reporter_roles
-    (roles.select { |role|
-      role.end_with?(':reporter')
-    } + instructor_roles + manager_roles + developer_roles).uniq
+  def manager?(definition_id = nil)
+    roles_for(:manager).covers?(definition_id)
   end
 
-  def instructor_roles
-    (roles.select { |role|
-      role.end_with?(':instructor')
-    } + manager_roles).uniq
-  end
-
-  def manager_roles
-    roles.select { |role| role.end_with?(':manager') }
-  end
-
-  def developer_roles
-    roles.select { |role| role.end_with?(':developer') }
-  end
-
-  def reporter?(authorization_request_type = nil)
+  def reporter?(definition_id = nil)
     return true if admin?
-    return true if instructor?(authorization_request_type)
 
-    if authorization_request_type
-      roles.include?("#{authorization_request_type}:reporter")
-    else
-      roles.any? { |role| role.end_with?(':reporter') }
-    end
+    roles_for(:reporter).covers?(definition_id)
   end
 
   def developer?
-    developer_roles.any?
+    roles_for(:developer).any?
+  end
+
+  def definition_ids_for(kind)
+    roles_for(kind).definition_ids
+  end
+
+  def authorization_request_types_for(kind)
+    roles_for(kind).authorization_request_types
   end
 
   def admin?
@@ -209,9 +164,7 @@ class User < ApplicationRecord
   end
 
   def authorization_definition_roles_as(kind)
-    public_send(:"#{kind}_roles")
-      .map { |role| AuthorizationDefinition.find(role.split(':').first) }
-      .uniq(&:id)
+    roles_for(kind).authorization_definitions
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/policies/concerns/developer_scoping.rb
+++ b/app/policies/concerns/developer_scoping.rb
@@ -6,12 +6,10 @@ module DeveloperScoping
   def user_is_developer_for_definition?(definition_id)
     return false if definition_id.blank?
 
-    user.authorization_definition_roles_as(:developer).any? do |definition|
-      definition.id == definition_id
-    end
+    user.roles_for(:developer).covers?(definition_id)
   end
 
   def developer_definition_ids
-    user.authorization_definition_roles_as(:developer).map(&:id)
+    user.definition_ids_for(:developer)
   end
 end

--- a/app/policies/instruction/authorization_policy.rb
+++ b/app/policies/instruction/authorization_policy.rb
@@ -36,17 +36,7 @@ class Instruction::AuthorizationPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(authorization_request_class: current_user_reporter_types)
-    end
-
-    def current_user_reporter_types
-      current_user_reporter_roles.map do |scope|
-        "AuthorizationRequest::#{scope.split(':').first.classify}"
-      end
-    end
-
-    def current_user_reporter_roles
-      user.reporter_roles
+      scope.where(authorization_request_class: user.authorization_request_types_for(:reporter))
     end
   end
 end

--- a/app/policies/instruction/authorization_request_policy.rb
+++ b/app/policies/instruction/authorization_request_policy.rb
@@ -93,17 +93,7 @@ class Instruction::AuthorizationRequestPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(type: current_user_reporter_types)
-    end
-
-    def current_user_reporter_types
-      current_user_reporter_roles.map do |scope|
-        "AuthorizationRequest::#{scope.split(':').first.classify}"
-      end
-    end
-
-    def current_user_reporter_roles
-      user.reporter_roles
+      scope.where(type: user.authorization_request_types_for(:reporter))
     end
   end
 end

--- a/app/policies/instruction/instructor_draft_request_policy.rb
+++ b/app/policies/instruction/instructor_draft_request_policy.rb
@@ -45,17 +45,7 @@ class Instruction::InstructorDraftRequestPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(authorization_request_class: current_user_instructor_types)
-    end
-
-    def current_user_instructor_types
-      current_user_instructor_roles.map do |scope|
-        "AuthorizationRequest::#{scope.split(':').first.classify}"
-      end
-    end
-
-    def current_user_instructor_roles
-      user.instructor_roles
+      scope.where(authorization_request_class: user.authorization_request_types_for(:instructor))
     end
   end
 end

--- a/app/policies/instruction/message_template_policy.rb
+++ b/app/policies/instruction/message_template_policy.rb
@@ -46,13 +46,7 @@ class Instruction::MessageTemplatePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(authorization_definition_uid: accessible_authorization_definition_uids)
-    end
-
-    private
-
-    def accessible_authorization_definition_uids
-      user.instructor_roles.map { |role| role.split(':').first }
+      scope.where(authorization_definition_uid: user.definition_ids_for(:instructor))
     end
   end
 end

--- a/app/views/admin/users_with_roles/new.html.erb
+++ b/app/views/admin/users_with_roles/new.html.erb
@@ -3,7 +3,7 @@
     <div class="fr-col-6">
       <%= form_with(model: @user, url: @user.persisted? ? admin_users_with_role_path(@user) : admin_users_with_roles_path) do |f| %>
         <%= f.dsfr_email_field :email, required: true, disabled: @user.persisted?, placeholder: t('.form.email.placeholder') %>
-        <%= f.dsfr_text_area :roles, value: @user.roles.split(',').join("\n"), required: false, placeholder: t('.form.roles.placeholder'), rows: 20 %>
+        <%= f.dsfr_text_area :roles, value: @user.roles.join("\n"), placeholder: t('.form.roles.placeholder'), rows: 20 %>
         <%= f.submit t('.cta'), class: %w[fr-btn fr-btn--sm] %>
       <% end %>
     </div>
@@ -12,12 +12,16 @@
       <h3>Instructions</h3>
 
       <p>
-        Dans le champ « Rôles » : mettre 1 rôle par ligne, de la forme <code>habilitation_code:role_code</code>.
+        Dans le champ « Rôles » : mettre 1 rôle par ligne, de la forme <code>fd_slug:definition_id:role_code</code>.
+      </p>
+
+      <p>
+        Pour donner accès à toutes les définitions d'un fournisseur : <code>fd_slug:*:role_code</code>
       </p>
 
       <hr />
 
-      <strong>Liste des rôles</strong>
+      <h4 class="fr-text--sm fr-mb-1w">Liste des rôles</h4>
 
       <ul>
         <li>Rapporteur (code: reporter)</li>
@@ -28,12 +32,22 @@
 
       <hr />
 
-      <strong>Liste des habilitations</strong>
+      <h4 class="fr-text--sm fr-mb-1w">Liste des fournisseurs de données</h4>
 
       <ul>
-        <% AuthorizationDefinition.all.each do |authorization_definition| %>
+        <% DataProvider.order(:name).each do |dp| %>
+          <li><%= dp.name %> (slug: <code><%= dp.slug %></code>)</li>
+        <% end %>
+      </ul>
+
+      <hr />
+
+      <h4 class="fr-text--sm fr-mb-1w">Liste des habilitations</h4>
+
+      <ul>
+        <% AuthorizationDefinition.all.sort_by { |ad| [ad.provider_slug.to_s, ad.id] }.each do |authorization_definition| %>
           <li>
-            <%= authorization_definition.name_with_stage %> (code: <%= authorization_definition.id %>)
+            <%= authorization_definition.name_with_stage %> (<code><%= authorization_definition.provider_slug %>:<%= authorization_definition.id %></code>)
           </li>
         <% end %>
       </ul>

--- a/app/views/developers/oauth_applications/index.html.erb
+++ b/app/views/developers/oauth_applications/index.html.erb
@@ -60,13 +60,13 @@
   </div>
 <% end %>
 
-<% if current_user.developer_roles.any? %>
+<% if current_user.developer? %>
   <div class="fr-mt-2w">
     <p class="fr-mt-2w fr-mb-1w">
       <strong><%= t('.list_of_habilitations_description') %></strong>
   </p>
   <ul>
-    <% current_user.developer_roles.map{ |role| role.split(':').first }.each do |authorization_definition_name| %>
+    <% current_user.definition_ids_for(:developer).each do |authorization_definition_name| %>
       <li>
         <%= authorization_definition_name %>
       </li>

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -68,7 +68,7 @@ fr:
             placeholder: user@gouv.fr
           roles:
             label: Rôles
-            placeholder: "api_entreprise:instructor\napi_particulier:reporter"
+            placeholder: "dinum:api_entreprise:instructor\ndinum:api_particulier:reporter"
         cta: Mettre à jour les rôles
       update: &admin_user_with_roles_create
         success: L'utilisateur %{user_email} a été mis à jour avec succès

--- a/db/migrate/20260421000000_migrate_roles_to_three_part_format.rb
+++ b/db/migrate/20260421000000_migrate_roles_to_three_part_format.rb
@@ -1,0 +1,202 @@
+class MigrateRolesToThreePartFormat < ActiveRecord::Migration[8.1]
+  def up
+    migrate_user_roles
+    migrate_admin_events
+  end
+
+  YAML_PROVIDER_MAP = {
+    'api_entreprise' => 'dinum',
+    'api_particulier' => 'dinum',
+    'formulaire_qf' => 'dinum',
+    'france_connect' => 'dinum',
+    'hubee_cert_dc' => 'dgs',
+    'hubee_dila' => 'dila',
+    'le_taxi' => 'dinum',
+    'pro_connect_service_provider' => 'dinum',
+    'pro_connect_identity_provider' => 'dinum',
+    'api_indicateurs_sociaux' => 'dinum',
+    'annuaire_des_entreprises' => 'dinum',
+    'api_impot_particulier' => 'dgfip',
+    'api_impot_particulier_sandbox' => 'dgfip',
+    'api_sfip' => 'dgfip',
+    'api_sfip_sandbox' => 'dgfip',
+    'api_hermes' => 'dgfip',
+    'api_hermes_sandbox' => 'dgfip',
+    'api_e_contacts' => 'dgfip',
+    'api_e_contacts_sandbox' => 'dgfip',
+    'api_opale' => 'dgfip',
+    'api_opale_sandbox' => 'dgfip',
+    'api_ocfi' => 'dgfip',
+    'api_ocfi_sandbox' => 'dgfip',
+    'api_e_pro' => 'dgfip',
+    'api_e_pro_sandbox' => 'dgfip',
+    'api_robf' => 'dgfip',
+    'api_robf_sandbox' => 'dgfip',
+    'api_cpr_pro_adelie' => 'dgfip',
+    'api_cpr_pro_adelie_sandbox' => 'dgfip',
+    'api_imprimfip' => 'dgfip',
+    'api_imprimfip_sandbox' => 'dgfip',
+    'api_satelit' => 'dgfip',
+    'api_satelit_sandbox' => 'dgfip',
+    'api_mire' => 'dgfip',
+    'api_mire_sandbox' => 'dgfip',
+    'api_ensu_documents' => 'dgfip',
+    'api_ensu_documents_sandbox' => 'dgfip',
+    'api_rial' => 'dgfip',
+    'api_rial_sandbox' => 'dgfip',
+    'api_infinoe' => 'dgfip',
+    'api_infinoe_sandbox' => 'dgfip',
+    'api_ficoba' => 'dgfip',
+    'api_ficoba_sandbox' => 'dgfip',
+    'api_r2p' => 'dgfip',
+    'api_r2p_sandbox' => 'dgfip',
+    'api_sfip_r2p' => 'dgfip',
+    'api_sfip_r2p_sandbox' => 'dgfip',
+    'api_droits_cnam' => 'cnam',
+    'api_indemnites_journalieres_cnam' => 'cnam',
+    'api_scolarite' => 'menj',
+    'api_gfe_echange_collectivites' => 'menj',
+    'api_gfe_echange_editeurs_restauration' => 'menj',
+    'api_inser_jeunes_sup' => 'menj',
+    'api_mobilic' => 'mtes',
+    'api_gunenv' => 'mtes',
+    'api_ingres' => 'cisirh',
+    'services_cisirh' => 'cisirh',
+    'api_declaration_auto_entrepreneur' => 'urssaf',
+    'api_declaration_cesu' => 'urssaf',
+    'api_captchetat' => 'aife',
+    'api_pro_sante_connect' => 'ans',
+  }.freeze
+
+  def down
+    revert_user_roles
+    revert_admin_events
+  end
+
+  private
+
+  def migrate_user_roles
+    execute(<<~SQL.squish).each do |row|
+      SELECT id, roles FROM users WHERE roles <> '{}'
+    SQL
+      user_id = row['id']
+      old_roles = parse_pg_array(row['roles'])
+
+      new_roles = old_roles.map { |role_string| convert_role(role_string) }
+
+      escaped = new_roles.map { |r| quote(r) }.join(',')
+      sql_array = new_roles.any? ? "ARRAY[#{escaped}]" : 'ARRAY[]::varchar[]'
+      execute("UPDATE users SET roles = #{sql_array} WHERE id = #{user_id}")
+    end
+  end
+
+  def migrate_admin_events
+    execute(<<~SQL.squish).each do |row|
+      SELECT id, before_attributes, after_attributes
+      FROM admin_events
+      WHERE name = 'user_roles_changed' AND before_attributes::jsonb ? 'roles'
+    SQL
+      convert_admin_event(row)
+    end
+  end
+
+  def convert_admin_event(row)
+    new_before = convert_roles_json(row['before_attributes'])
+    new_after = convert_roles_json(row['after_attributes'])
+
+    execute(<<~SQL.squish)
+      UPDATE admin_events
+      SET before_attributes = jsonb_set(before_attributes::jsonb, '{roles}', #{quote(new_before)}::jsonb)::json,
+          after_attributes = jsonb_set(after_attributes::jsonb, '{roles}', #{quote(new_after)}::jsonb)::json
+      WHERE id = #{row['id']}
+    SQL
+  end
+
+  def convert_roles_json(json_string)
+    roles = JSON.parse(json_string)['roles'] || []
+    roles.map { |r| convert_role(r) }.to_json
+  end
+
+  def convert_role(role_string)
+    role_string = role_string.strip
+    return 'admin' if role_string == 'admin'
+
+    parts = role_string.split(':')
+    return role_string if parts.length == 3
+
+    raise "Unexpected role format: #{role_string.inspect}" unless parts.length == 2
+
+    def_id, role_type = parts
+    provider_slug = find_provider_slug(def_id)
+
+    raise "Cannot resolve provider for definition #{def_id.inspect} in role #{role_string.inspect}. Add it to YAML_PROVIDER_MAP." unless provider_slug
+
+    "#{provider_slug}:#{def_id}:#{role_type}"
+  end
+
+  def find_provider_slug(definition_id)
+    result = execute(<<~SQL.squish).first
+      SELECT dp.slug FROM habilitation_types ht
+      JOIN data_providers dp ON dp.id = ht.data_provider_id
+      WHERE LOWER(REPLACE(ht.slug, '-', '_')) = #{quote(definition_id)}
+    SQL
+    return result['slug'] if result
+
+    YAML_PROVIDER_MAP[definition_id]
+  end
+
+  def parse_pg_array(pg_string)
+    pg_string.delete('{}').split(',').map(&:strip).compact_blank
+  end
+
+  def revert_user_roles
+    execute(<<~SQL.squish).each do |row|
+      SELECT id, roles FROM users WHERE roles <> '{}'
+    SQL
+      user_id = row['id']
+      old_roles = parse_pg_array(row['roles'])
+
+      new_roles = old_roles.map { |r| revert_role(r) }
+
+      escaped = new_roles.map { |r| quote(r) }.join(',')
+      sql_array = new_roles.any? ? "ARRAY[#{escaped}]" : 'ARRAY[]::varchar[]'
+      execute("UPDATE users SET roles = #{sql_array} WHERE id = #{user_id}")
+    end
+  end
+
+  def revert_admin_events
+    execute(<<~SQL.squish).each do |row|
+      SELECT id, before_attributes, after_attributes
+      FROM admin_events
+      WHERE name = 'user_roles_changed' AND before_attributes::jsonb ? 'roles'
+    SQL
+      revert_admin_event(row)
+    end
+  end
+
+  def revert_admin_event(row)
+    new_before = revert_roles_json(row['before_attributes'])
+    new_after = revert_roles_json(row['after_attributes'])
+
+    execute(<<~SQL.squish)
+      UPDATE admin_events
+      SET before_attributes = jsonb_set(before_attributes::jsonb, '{roles}', #{quote(new_before)}::jsonb)::json,
+          after_attributes = jsonb_set(after_attributes::jsonb, '{roles}', #{quote(new_after)}::jsonb)::json
+      WHERE id = #{row['id']}
+    SQL
+  end
+
+  def revert_roles_json(json_string)
+    roles = JSON.parse(json_string)['roles'] || []
+    roles.map { |r| revert_role(r) }.to_json
+  end
+
+  def revert_role(role_string)
+    return 'admin' if role_string == 'admin'
+
+    parts = role_string.split(':')
+    return role_string unless parts.length == 3
+
+    "#{parts[1]}:#{parts[2]}"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_154456) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"

--- a/features/admin/utilisateurs_avec_roles.feature
+++ b/features/admin/utilisateurs_avec_roles.feature
@@ -47,11 +47,11 @@ Fonctionnalité: Espace admin: utilisateurs avec rôles
     Quand il y a l'utilisateur "api-entreprise@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
     Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
     Et que je clique sur "Éditer" pour l'utilisateur "api-entreprise@gouv.fr"
-    Et que je remplis "Role" avec "api_entreprise:reporter"
+    Et que je remplis "Role" avec "dinum:api_entreprise:reporter"
     Et que je clique sur "Mettre à jour"
     Alors il y a un message de succès contenant "mis à jour"
-    Et la page contient "api_entreprise:reporter"
-    Et la page ne contient pas "api_entreprise:instructor"
+    Et la page contient "dinum:api_entreprise:reporter"
+    Et la page ne contient pas "dinum:api_entreprise:instructor"
 
   Scénario: Je peux retirer tous les rôles d'un utilisateur
     Quand il y a l'utilisateur "api-entreprise@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
@@ -67,17 +67,17 @@ Fonctionnalité: Espace admin: utilisateurs avec rôles
     Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
     Et que je clique sur "Ajouter des rôles à un utilisateur"
     Et que je remplis "Email" avec "api-entreprise@gouv.fr"
-    Et que je remplis "Role" avec "api_entreprise:reporter"
+    Et que je remplis "Role" avec "dinum:api_entreprise:reporter"
     Et que je clique sur "Mettre à jour"
     Alors il y a un message de succès contenant "mis à jour"
-    Et la page contient "api_entreprise:reporter"
+    Et la page contient "dinum:api_entreprise:reporter"
 
   Scénario: Je veux ajouter des rôles à un utilisateur qui n'existe pas
     Quand il y a l'utilisateur "api-entreprise@gouv.fr" sans rôle
     Et que je me rends sur le module "Utilisateurs avec rôles" de l'espace administrateur
     Et que je clique sur "Ajouter des rôles à un utilisateur"
     Et que je remplis "Email" avec "inconnu@gouv.fr"
-    Et que je remplis "Role" avec "api_entreprise:reporter"
+    Et que je remplis "Role" avec "dinum:api_entreprise:reporter"
     Et que je clique sur "Mettre à jour"
     Alors il y a un message d'erreur contenant "n'existe pas"
 

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -262,8 +262,11 @@ end
 
 Quand("un instructeur a validé la demande d'habilitation") do
   authorization_request = AuthorizationRequest.last
-  instructor = create_instructor(authorization_request.definition.id)
-  instructor.update!(roles: AuthorizationDefinition.all.map { |definition| "#{definition.id}:instructor" })
+  definition = authorization_request.definition
+  instructor = create_instructor(definition.name)
+  instructor.revoke_all_roles
+  instructor.grant_role(:instructor, definition.id)
+  instructor.save!
   ApproveAuthorizationRequest.call(authorization_request: authorization_request, user: instructor)
 end
 

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -101,19 +101,16 @@ Sachantque('je suis un instructeur {string}') do |kind|
   end
 
   if @current_user_email != user.email
-    current_user.roles << "#{find_factory_trait_from_name(kind)}:instructor"
-    current_user.roles.uniq!
+    current_user.grant_role(:instructor, find_factory_trait_from_name(kind))
     current_user.save!
   end
 end
 
 Sachantque('je suis un instructeur avec plusieurs types d\'autorisation') do
   user = create_instructor('API Entreprise')
-  # Add API Particulier instructor role, plus reporter roles for both types
-  user.roles << 'api_particulier:instructor'
-  user.roles << 'api_entreprise:reporter'
-  user.roles << 'api_particulier:reporter'
-  user.roles.uniq!
+  user.grant_role(:instructor, 'api_particulier')
+  user.grant_role(:reporter, 'api_entreprise')
+  user.grant_role(:reporter, 'api_particulier')
   user.save!
 
   if @current_user_email.blank?
@@ -131,8 +128,7 @@ Sachantque('je suis un rapporteur {string}') do |kind|
   end
 
   if @current_user_email != user.email
-    current_user.roles << "#{find_factory_trait_from_name(kind)}:reporter"
-    current_user.roles.uniq!
+    current_user.grant_role(:reporter, find_factory_trait_from_name(kind))
     current_user.save!
   end
 end
@@ -146,8 +142,7 @@ Sachantque('je suis un manager {string}') do |kind|
   end
 
   if @current_user_email != user.email
-    current_user.roles << "#{find_factory_trait_from_name(kind)}:manager"
-    current_user.roles.uniq!
+    current_user.grant_role(:manager, find_factory_trait_from_name(kind))
     current_user.save!
   end
 end
@@ -160,9 +155,9 @@ Sachantque('je suis un développeur {string}') do |kind|
     mock_identity_federators(user)
   end
 
-  current_user.roles << "#{find_factory_trait_from_name(kind)}:reporter" if @current_user_email != user.email
-  current_user.roles << "#{find_factory_trait_from_name(kind)}:developer"
-  current_user.roles.uniq!
+  def_id = find_factory_trait_from_name(kind)
+  current_user.grant_role(:reporter, def_id) if @current_user_email != user.email
+  current_user.grant_role(:developer, def_id)
   current_user.save!
 
   Doorkeeper::Application.create!(
@@ -182,8 +177,7 @@ Sachantque('je suis un administrateur') do
   end
 
   if @current_user_email != user.email
-    current_user.roles << 'admin'
-    current_user.roles.uniq!
+    current_user.grant_admin_role
     current_user.save!
   end
 end

--- a/features/step_definitions/users_roles_steps.rb
+++ b/features/step_definitions/users_roles_steps.rb
@@ -3,33 +3,32 @@ Quand("il y a l'utilisateur {string} avec le rôle {string} pour {string}") do |
 
   case humanized_role.downcase
   when 'instructeur'
-    role = 'instructor'
+    role = :instructor
   when 'rapporteur'
-    role = 'reporter'
+    role = :reporter
   when 'manager'
-    role = 'manager'
+    role = :manager
   when 'développeur'
-    role = 'developer'
+    role = :developer
   else
     raise "Unknown role #{humanized_role}"
   end
 
-  user.roles << "#{find_factory_trait_from_name(authorization_definition_name)}:#{role}"
-  user.roles.uniq!
+  def_id = find_factory_trait_from_name(authorization_definition_name)
+  user.grant_role(role, def_id)
   user.save!
 end
 
 Quand("il y a l'utilisateur {string} avec le rôle d'administrateur") do |email|
   user = User.find_by(email:) || FactoryBot.create(:user, email: email)
 
-  user.roles << 'admin'
-  user.roles.uniq!
+  user.grant_admin_role
   user.save!
 end
 
 Quand("il y a l'utilisateur {string} sans rôle") do |email|
   user = User.find_by(email:) || FactoryBot.create(:user, email: email)
 
-  user.roles = []
+  user.revoke_all_roles
   user.save!
 end

--- a/features/support/sessions.rb
+++ b/features/support/sessions.rb
@@ -26,12 +26,12 @@ def create_admin
   user = User.find_by(email:)
 
   if user
-    user.roles = []
+    user.revoke_all_roles
   else
     user = FactoryBot.create(:user, email:)
   end
 
-  user.roles << 'admin'
+  user.grant_admin_role
   user.save!
 
   user
@@ -54,12 +54,13 @@ def create_user_with_role(role, kind)
   user = User.find_by(email:)
 
   if user
-    user.roles = []
+    user.revoke_all_roles
   else
     user = FactoryBot.create(:user, email:)
   end
 
-  user.roles << "#{find_factory_trait_from_name(kind)}:#{role}"
+  def_id = find_factory_trait_from_name(kind)
+  user.grant_role(role, def_id)
   user.save!
 
   user

--- a/spec/controllers/dgfip/export_controller_spec.rb
+++ b/spec/controllers/dgfip/export_controller_spec.rb
@@ -10,26 +10,26 @@ RSpec.describe DGFIP::ExportController do
 
     describe 'access' do
       context 'when admin' do
-        let(:user) { create(:user, roles: %w[admin]) }
+        let(:user) { create(:user, :admin) }
 
         it { is_expected.to have_http_status(:ok) }
       end
 
       context 'when dgfip reporter' do
-        let(:user) { create(:user, roles: %w[api_impot_particulier:reporter]) }
+        let(:user) { create(:user, :reporter, authorization_request_types: %w[api_impot_particulier]) }
 
         it { is_expected.to have_http_status(:ok) }
       end
 
       context 'when another reporter' do
-        let(:user) { create(:user, roles: %w[api_whatever:reporter]) }
+        let(:user) { create(:user, :reporter, authorization_request_types: %w[api_entreprise]) }
 
         it { is_expected.to have_http_status(:forbidden) }
       end
     end
 
     describe 'response body' do
-      let(:user) { create(:user, roles: %w[api_impot_particulier:reporter]) }
+      let(:user) { create(:user, :reporter, authorization_request_types: %w[api_impot_particulier]) }
 
       it 'is expected to be a spreadsheet' do
         get_spreadsheet

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,8 @@ FactoryBot.define do
 
     transient do
       skip_organization_creation { false }
+      authorization_request_types { %w[hubee_cert_dc api_entreprise] }
+      data_provider_slugs { %w[dgfip] }
     end
 
     after(:build) do |user, evaluator|
@@ -24,66 +26,28 @@ FactoryBot.define do
       )
     end
 
-    trait :reporter do
-      transient do
-        authorization_request_types do
-          %w[hubee_cert_dc api_entreprise]
+    %i[reporter instructor developer manager].each do |role|
+      trait role do
+        after(:build) do |user, evaluator|
+          evaluator.authorization_request_types.each do |art|
+            user.grant_role(role, art.to_s)
+          rescue ParsedRole::UnknownDefinitionError
+            user.roles << "unknown:#{art}:#{role}"
+          end
         end
       end
 
-      after(:build) do |user, evaluator|
-        evaluator.authorization_request_types.each do |authorization_request_type|
-          user.roles << "#{authorization_request_type}:reporter"
-        end
-      end
-    end
-
-    trait :instructor do
-      transient do
-        authorization_request_types do
-          %w[hubee_cert_dc api_entreprise]
-        end
-      end
-
-      after(:build) do |user, evaluator|
-        evaluator.authorization_request_types.each do |authorization_request_type|
-          user.roles << "#{authorization_request_type}:instructor"
-        end
-      end
-    end
-
-    trait :developer do
-      transient do
-        authorization_request_types do
-          %w[hubee_cert_dc api_entreprise]
-        end
-      end
-
-      after(:build) do |user, evaluator|
-        evaluator.authorization_request_types.each do |authorization_request_type|
-          user.roles << "#{authorization_request_type}:developer"
-        end
-      end
-    end
-
-    trait :manager do
-      transient do
-        authorization_request_types do
-          %w[hubee_cert_dc api_entreprise]
-        end
-      end
-
-      after(:build) do |user, evaluator|
-        evaluator.authorization_request_types.each do |authorization_request_type|
-          user.roles << "#{authorization_request_type}:manager"
+      trait :"fd_#{role}" do
+        after(:build) do |user, evaluator|
+          evaluator.data_provider_slugs.each do |slug|
+            user.grant_fd_role(role, slug)
+          end
         end
       end
     end
 
     trait :admin do
-      after(:build) do |user|
-        user.roles << 'admin'
-      end
+      after(:build, &:grant_admin_role)
     end
   end
 end

--- a/spec/interactors/admin/remove_habilitation_type_roles_spec.rb
+++ b/spec/interactors/admin/remove_habilitation_type_roles_spec.rb
@@ -6,28 +6,29 @@ RSpec.describe Admin::RemoveHabilitationTypeRoles, type: :interactor do
 
     let(:habilitation_type) { create(:habilitation_type) }
     let(:uid) { habilitation_type.uid }
+    let(:fd_slug) { habilitation_type.data_provider.slug }
 
     context 'when users have roles linked to the habilitation type' do
-      let!(:instructor) { create(:user, roles: ["#{uid}:instructor", 'other_type:instructor']) }
-      let!(:manager) { create(:user, roles: ["#{uid}:manager"]) }
+      let!(:instructor) { create(:user, roles: ["#{fd_slug}:#{uid}:instructor", 'dinum:api_entreprise:instructor']) }
+      let!(:manager) { create(:user, roles: ["#{fd_slug}:#{uid}:manager"]) }
 
       it { is_expected.to be_success }
 
       it 'removes roles linked to the habilitation type' do
         result
 
-        expect(instructor.reload.roles).to eq(['other_type:instructor'])
+        expect(instructor.reload.roles).to eq(['dinum:api_entreprise:instructor'])
         expect(manager.reload.roles).to be_empty
       end
     end
 
     context 'when users have roles from other habilitation types only' do
-      let!(:other_user) { create(:user, roles: ['other_type:instructor']) }
+      let!(:other_user) { create(:user, roles: ['dinum:api_entreprise:instructor']) }
 
       it 'does not affect other roles' do
         result
 
-        expect(other_user.reload.roles).to eq(['other_type:instructor'])
+        expect(other_user.reload.roles).to eq(['dinum:api_entreprise:instructor'])
       end
     end
   end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe AdminMailer do
   describe '#notify_user_roles_change' do
-    let(:mail) { described_class.with(user:, old_roles: %w[api_entreprise:reporter]).notify_user_roles_change }
+    let(:mail) { described_class.with(user:, old_roles: %w[dinum:api_entreprise:reporter]).notify_user_roles_change }
 
-    let(:user) { create(:user, roles: %w[api_entreprise:instructeur]) }
+    let(:user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
     let!(:admins) { create_list(:user, 2, :admin) }
 
     it 'sends emails to admins in bcc' do
@@ -13,8 +13,8 @@ RSpec.describe AdminMailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to include(user.email)
-      expect(mail.body.encoded).to include('api_entreprise:instructeur')
-      expect(mail.body.encoded).to include('api_entreprise:reporter')
+      expect(mail.body.encoded).to include('dinum:api_entreprise:instructor')
+      expect(mail.body.encoded).to include('dinum:api_entreprise:reporter')
     end
   end
 end

--- a/spec/mailers/webhook_mailer_spec.rb
+++ b/spec/mailers/webhook_mailer_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe WebhookMailer do
     end
 
     let(:webhook) { create(:webhook, authorization_definition_id: 'api_entreprise', url: webhook_url) }
-    let!(:api_entreprise_developer) { create(:user, roles: ['api_entreprise:developer']) }
-    let!(:foreign_developer) { create(:user, roles: ['api_particulier:developer']) }
+    let!(:api_entreprise_developer) { create(:user, :developer, authorization_request_types: %w[api_entreprise]) }
+    let!(:foreign_developer) { create(:user, :developer, authorization_request_types: %w[api_particulier]) }
     let(:webhook_url) { 'https://service.api.gouv.fr/webhook' }
 
     it 'sends email to definition developers, from datapass@api.gouv.fr' do

--- a/spec/models/instructor_draft_request_spec.rb
+++ b/spec/models/instructor_draft_request_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe InstructorDraftRequest do
     end
 
     context 'with another instructor' do
-      let(:authorization_request_types) { %w[whatever] }
+      let(:authorization_request_types) { %w[api_particulier] }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/models/parsed_role_spec.rb
+++ b/spec/models/parsed_role_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe ParsedRole do
+  describe '.parse' do
+    it 'parses a 3-part role string' do
+      parsed = described_class.parse('dinum:api_entreprise:instructor')
+
+      expect(parsed.provider_slug).to eq('dinum')
+      expect(parsed.definition_id).to eq('api_entreprise')
+      expect(parsed.role).to eq('instructor')
+    end
+
+    it 'parses admin role' do
+      parsed = described_class.parse('admin')
+
+      expect(parsed.admin?).to be true
+      expect(parsed.provider_slug).to be_nil
+    end
+
+    it 'parses FD-level wildcard' do
+      parsed = described_class.parse('dgfip:*:instructor')
+
+      expect(parsed.fd_level?).to be true
+      expect(parsed.provider_slug).to eq('dgfip')
+      expect(parsed.role).to eq('instructor')
+    end
+
+    it 'returns null object for invalid format' do
+      parsed = described_class.parse('bad_format')
+
+      expect(parsed.role).to be_nil
+      expect(parsed.definition_id).to be_nil
+      expect(parsed.fd_level?).to be false
+      expect(parsed.admin?).to be false
+    end
+  end
+
+  describe '.valid?' do
+    it 'accepts admin' do
+      expect(described_class.valid?('admin')).to be true
+    end
+
+    it 'accepts valid 3-part role' do
+      expect(described_class.valid?('dinum:api_entreprise:instructor')).to be true
+    end
+
+    it 'accepts FD-level wildcard' do
+      expect(described_class.valid?('dinum:*:instructor')).to be true
+    end
+
+    it 'rejects invalid role type' do
+      expect(described_class.valid?('dinum:api_entreprise:invalid')).to be false
+    end
+
+    it 'rejects unknown provider' do
+      expect(described_class.valid?('unknown_provider:api_entreprise:instructor')).to be false
+    end
+
+    it 'rejects unknown definition' do
+      expect(described_class.valid?('dinum:unknown_def:instructor')).to be false
+    end
+
+    it 'rejects definition with wrong provider' do
+      expect(described_class.valid?('dgfip:api_entreprise:instructor')).to be false
+    end
+
+    it 'rejects 2-part format' do
+      expect(described_class.valid?('api_entreprise:instructor')).to be false
+    end
+  end
+
+  describe '.resolve_provider_slug' do
+    it 'returns provider slug for known definition' do
+      expect(described_class.resolve_provider_slug('api_entreprise')).to eq('dinum')
+    end
+
+    it 'returns nil for unknown definition' do
+      expect(described_class.resolve_provider_slug('unknown')).to be_nil
+    end
+  end
+
+  describe '#valid_definition?' do
+    it 'returns true for valid definition-level role' do
+      parsed = described_class.parse('dinum:api_entreprise:instructor')
+
+      expect(parsed.valid_definition?).to be true
+    end
+
+    it 'returns false for wrong provider' do
+      parsed = described_class.parse('dgfip:api_entreprise:instructor')
+
+      expect(parsed.valid_definition?).to be false
+    end
+
+    it 'returns true for FD-level wildcard with known provider' do
+      parsed = described_class.parse('dinum:*:instructor')
+
+      expect(parsed.valid_definition?).to be true
+    end
+
+    it 'returns false for FD-level wildcard with unknown provider' do
+      parsed = described_class.parse('unknown:*:instructor')
+
+      expect(parsed.valid_definition?).to be false
+    end
+  end
+end

--- a/spec/models/role_hierarchy_spec.rb
+++ b/spec/models/role_hierarchy_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe RoleHierarchy do
+  describe '.qualifying_roles' do
+    it 'returns reporter plus all roles that imply reporter' do
+      expect(described_class.qualifying_roles(:reporter)).to match_array(%w[reporter manager instructor developer])
+    end
+
+    it 'returns instructor plus manager' do
+      expect(described_class.qualifying_roles(:instructor)).to match_array(%w[instructor manager])
+    end
+
+    it 'returns only manager for manager' do
+      expect(described_class.qualifying_roles(:manager)).to eq(%w[manager])
+    end
+
+    it 'returns only developer for developer' do
+      expect(described_class.qualifying_roles(:developer)).to eq(%w[developer])
+    end
+
+    it 'accepts string arguments' do
+      expect(described_class.qualifying_roles('instructor')).to match_array(%w[instructor manager])
+    end
+  end
+end

--- a/spec/models/role_set_spec.rb
+++ b/spec/models/role_set_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe RoleSet do
+  describe '#covers?' do
+    it 'returns true when user has the exact role for the definition' do
+      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+
+      expect(role_set.covers?('api_entreprise')).to be true
+    end
+
+    it 'returns false when user does not have the role for the definition' do
+      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+
+      expect(role_set.covers?('api_particulier')).to be false
+    end
+
+    it 'returns true when user has a qualifying role via hierarchy' do
+      role_set = described_class.new(%w[api_entreprise:manager], :instructor)
+
+      expect(role_set.covers?('api_entreprise')).to be true
+    end
+
+    it 'returns false when role does not qualify via hierarchy' do
+      role_set = described_class.new(%w[api_entreprise:reporter], :instructor)
+
+      expect(role_set.covers?('api_entreprise')).to be false
+    end
+
+    context 'without definition_id' do
+      it 'returns true when user has any qualifying role' do
+        role_set = described_class.new(%w[api_entreprise:manager], :instructor)
+
+        expect(role_set.covers?).to be true
+      end
+
+      it 'returns false when user has no qualifying role' do
+        role_set = described_class.new(%w[api_entreprise:reporter], :instructor)
+
+        expect(role_set.covers?).to be false
+      end
+    end
+  end
+
+  describe '#any?' do
+    it 'returns true when matching roles exist' do
+      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+
+      expect(role_set.any?).to be true
+    end
+
+    it 'returns false when no matching roles exist' do
+      role_set = described_class.new(%w[], :instructor)
+
+      expect(role_set.any?).to be false
+    end
+  end
+
+  describe '#definition_ids' do
+    it 'returns unique definition ids for matching roles' do
+      role_set = described_class.new(
+        %w[api_entreprise:instructor api_particulier:manager api_entreprise:manager],
+        :instructor,
+      )
+
+      expect(role_set.definition_ids).to match_array(%w[api_entreprise api_particulier])
+    end
+
+    it 'includes roles from hierarchy' do
+      role_set = described_class.new(
+        %w[api_entreprise:reporter api_particulier:instructor api_entreprise:manager],
+        :reporter,
+      )
+
+      expect(role_set.definition_ids).to match_array(%w[api_entreprise api_particulier])
+    end
+  end
+
+  describe '#authorization_request_types' do
+    it 'returns classified authorization request types' do
+      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+
+      expect(role_set.authorization_request_types).to eq(["AuthorizationRequest::#{'api_entreprise'.classify}"])
+    end
+  end
+
+  describe '#authorization_definitions' do
+    it 'returns authorization definitions for matching roles' do
+      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+
+      result = role_set.authorization_definitions
+
+      expect(result.map(&:id)).to include('api_entreprise')
+    end
+
+    it 'skips unknown definitions' do
+      role_set = described_class.new(%w[unknown_definition:instructor], :instructor)
+
+      expect(role_set.authorization_definitions).to be_empty
+    end
+  end
+
+  it 'ignores admin role' do
+    role_set = described_class.new(%w[admin api_entreprise:instructor], :instructor)
+
+    expect(role_set.definition_ids).to eq(%w[api_entreprise])
+  end
+
+  it 'ignores malformed roles' do
+    role_set = described_class.new(%w[bad_format api_entreprise:instructor:extra], :instructor)
+
+    expect(role_set.definition_ids).to eq([])
+  end
+end

--- a/spec/models/role_set_spec.rb
+++ b/spec/models/role_set_spec.rb
@@ -3,38 +3,50 @@ require 'rails_helper'
 RSpec.describe RoleSet do
   describe '#covers?' do
     it 'returns true when user has the exact role for the definition' do
-      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
 
       expect(role_set.covers?('api_entreprise')).to be true
     end
 
     it 'returns false when user does not have the role for the definition' do
-      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
 
       expect(role_set.covers?('api_particulier')).to be false
     end
 
     it 'returns true when user has a qualifying role via hierarchy' do
-      role_set = described_class.new(%w[api_entreprise:manager], :instructor)
+      role_set = described_class.new(%w[dinum:api_entreprise:manager], :instructor)
 
       expect(role_set.covers?('api_entreprise')).to be true
     end
 
     it 'returns false when role does not qualify via hierarchy' do
-      role_set = described_class.new(%w[api_entreprise:reporter], :instructor)
+      role_set = described_class.new(%w[dinum:api_entreprise:reporter], :instructor)
+
+      expect(role_set.covers?('api_entreprise')).to be false
+    end
+
+    it 'returns true with FD-level wildcard covering the definition' do
+      role_set = described_class.new(%w[dinum:*:instructor], :instructor)
+
+      expect(role_set.covers?('api_entreprise')).to be true
+    end
+
+    it 'returns false with FD-level wildcard for wrong provider' do
+      role_set = described_class.new(%w[dgfip:*:instructor], :instructor)
 
       expect(role_set.covers?('api_entreprise')).to be false
     end
 
     context 'without definition_id' do
       it 'returns true when user has any qualifying role' do
-        role_set = described_class.new(%w[api_entreprise:manager], :instructor)
+        role_set = described_class.new(%w[dinum:api_entreprise:manager], :instructor)
 
         expect(role_set.covers?).to be true
       end
 
       it 'returns false when user has no qualifying role' do
-        role_set = described_class.new(%w[api_entreprise:reporter], :instructor)
+        role_set = described_class.new(%w[dinum:api_entreprise:reporter], :instructor)
 
         expect(role_set.covers?).to be false
       end
@@ -43,7 +55,7 @@ RSpec.describe RoleSet do
 
   describe '#any?' do
     it 'returns true when matching roles exist' do
-      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
 
       expect(role_set.any?).to be true
     end
@@ -58,7 +70,7 @@ RSpec.describe RoleSet do
   describe '#definition_ids' do
     it 'returns unique definition ids for matching roles' do
       role_set = described_class.new(
-        %w[api_entreprise:instructor api_particulier:manager api_entreprise:manager],
+        %w[dinum:api_entreprise:instructor dinum:api_particulier:manager dinum:api_entreprise:manager],
         :instructor,
       )
 
@@ -67,17 +79,27 @@ RSpec.describe RoleSet do
 
     it 'includes roles from hierarchy' do
       role_set = described_class.new(
-        %w[api_entreprise:reporter api_particulier:instructor api_entreprise:manager],
+        %w[dinum:api_entreprise:reporter dinum:api_particulier:instructor dinum:api_entreprise:manager],
         :reporter,
       )
 
       expect(role_set.definition_ids).to match_array(%w[api_entreprise api_particulier])
     end
+
+    it 'expands FD-level wildcard to all definitions under the provider' do
+      role_set = described_class.new(%w[dinum:*:instructor], :instructor)
+
+      dinum_definition_ids = AuthorizationDefinition.all
+        .select { |ad| ad.provider_slug == 'dinum' }
+        .map(&:id)
+
+      expect(role_set.definition_ids).to match_array(dinum_definition_ids)
+    end
   end
 
   describe '#authorization_request_types' do
     it 'returns classified authorization request types' do
-      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
 
       expect(role_set.authorization_request_types).to eq(["AuthorizationRequest::#{'api_entreprise'.classify}"])
     end
@@ -85,7 +107,7 @@ RSpec.describe RoleSet do
 
   describe '#authorization_definitions' do
     it 'returns authorization definitions for matching roles' do
-      role_set = described_class.new(%w[api_entreprise:instructor], :instructor)
+      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
 
       result = role_set.authorization_definitions
 
@@ -93,20 +115,20 @@ RSpec.describe RoleSet do
     end
 
     it 'skips unknown definitions' do
-      role_set = described_class.new(%w[unknown_definition:instructor], :instructor)
+      role_set = described_class.new(%w[dinum:unknown_definition:instructor], :instructor)
 
       expect(role_set.authorization_definitions).to be_empty
     end
   end
 
   it 'ignores admin role' do
-    role_set = described_class.new(%w[admin api_entreprise:instructor], :instructor)
+    role_set = described_class.new(%w[admin dinum:api_entreprise:instructor], :instructor)
 
     expect(role_set.definition_ids).to eq(%w[api_entreprise])
   end
 
   it 'ignores malformed roles' do
-    role_set = described_class.new(%w[bad_format api_entreprise:instructor:extra], :instructor)
+    role_set = described_class.new(%w[bad_format api_entreprise:instructor], :instructor)
 
     expect(role_set.definition_ids).to eq([])
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe User do
     let!(:valid_instructor_with_multiple_authorization_type) { create(:user, :instructor, authorization_request_types: %i[api_entreprise api_particulier]) }
     let!(:invalid_instructor) { create(:user, :instructor, authorization_request_types: %i[api_particulier]) }
     let!(:valid_reporter) { create(:user, :reporter, authorization_request_types: %i[api_entreprise]) }
+    let!(:valid_manager) { create(:user, :manager, authorization_request_types: %i[api_entreprise]) }
 
-    it { is_expected.to contain_exactly(valid_instructor, valid_instructor_with_multiple_authorization_type) }
+    it { is_expected.to contain_exactly(valid_instructor, valid_instructor_with_multiple_authorization_type, valid_manager) }
   end
 
   describe '.developer_for' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe User do
       let(:user) { build(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
       before do
-        user.roles << 'api_entreprise:developer'
+        user.grant_role(:developer, 'api_entreprise')
         user.save
       end
 

--- a/spec/organizers/admin/ban_user_spec.rb
+++ b/spec/organizers/admin/ban_user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::BanUser do
         admin:,
       }
     end
-    let(:admin) { create(:user, roles: ['admin']) }
+    let(:admin) { create(:user, :admin) }
     let(:target_user) { create(:user) }
     let(:user_email) { target_user.email }
     let(:ban_reason) { 'Compte compromis (CSIRT)' }

--- a/spec/organizers/admin/destroy_habilitation_type_spec.rb
+++ b/spec/organizers/admin/destroy_habilitation_type_spec.rb
@@ -19,12 +19,13 @@ RSpec.describe Admin::DestroyHabilitationType, type: :organizer do
     end
 
     context 'when users have roles linked to the habilitation type' do
-      let!(:instructor) { create(:user, roles: ["#{habilitation_type.uid}:instructor", 'other_type:manager']) }
+      let(:fd_slug) { habilitation_type.data_provider.slug }
+      let!(:instructor) { create(:user, roles: ["#{fd_slug}:#{habilitation_type.uid}:instructor", 'dinum:api_entreprise:manager']) }
 
       it 'removes roles linked to the habilitation type' do
         organizer
 
-        expect(instructor.reload.roles).to eq(['other_type:manager'])
+        expect(instructor.reload.roles).to eq(['dinum:api_entreprise:manager'])
       end
     end
 

--- a/spec/organizers/admin/start_impersonation_spec.rb
+++ b/spec/organizers/admin/start_impersonation_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Admin::StartImpersonation do
         }
       }
     end
-    let(:admin) { create(:user, roles: ['admin']) }
+    let(:admin) { create(:user, :admin) }
     let(:user_email) { create(:user).email }
     let(:reason) { 'Testing purposes' }
 

--- a/spec/organizers/admin/stop_impersonation_spec.rb
+++ b/spec/organizers/admin/stop_impersonation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Admin::StopImpersonation do
         impersonation:
       }
     end
-    let(:admin) { create(:user, roles: ['admin']) }
+    let(:admin) { create(:user, :admin) }
     let(:impersonation) { create(:impersonation, admin:) }
 
     context 'when all conditions are met' do

--- a/spec/organizers/admin/unban_user_spec.rb
+++ b/spec/organizers/admin/unban_user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Admin::UnbanUser do
         admin:,
       }
     end
-    let(:admin) { create(:user, roles: ['admin']) }
+    let(:admin) { create(:user, :admin) }
     let(:target_user) { create(:user, banned_at: Time.zone.now, ban_reason: 'Compte compromis') }
 
     context 'when all conditions are met' do

--- a/spec/organizers/admin/update_user_roles_spec.rb
+++ b/spec/organizers/admin/update_user_roles_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
     subject(:update_user_roles) { described_class.call(admin:, user:, roles:) }
 
     let(:admin) { create(:user, :admin) }
-    let(:user) { create(:user, roles: %w[api_entreprise:reporter]) }
-    let(:roles) { %w[api_particulier:instructor admin] }
+    let(:user) { create(:user, roles: %w[dinum:api_entreprise:reporter]) }
+    let(:roles) { %w[dinum:api_particulier:instructor admin] }
 
     before do
       ActiveJob::Base.queue_adapter = :inline
@@ -26,14 +26,14 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
       expect(admin_event.name).to eq('user_roles_changed')
       expect(admin_event.admin).to eq(admin)
       expect(admin_event.entity).to eq(user)
-      expect(admin_event.before_attributes).to eq('roles' => %w[api_entreprise:reporter])
-      expect(admin_event.after_attributes).to eq('roles' => %w[api_particulier:instructor admin])
+      expect(admin_event.before_attributes).to eq('roles' => %w[dinum:api_entreprise:reporter])
+      expect(admin_event.after_attributes).to eq('roles' => %w[dinum:api_particulier:instructor admin])
     end
 
     it 'updates the user roles' do
       expect {
         update_user_roles
-      }.to change { user.reload.roles }.from(%w[api_entreprise:reporter]).to(%w[api_particulier:instructor admin])
+      }.to change { user.reload.roles }.from(%w[dinum:api_entreprise:reporter]).to(%w[dinum:api_particulier:instructor admin])
     end
 
     it 'notifies admins for roles update' do
@@ -50,7 +50,7 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
       it 'removes all roles from the user' do
         expect {
           update_user_roles
-        }.to change { user.reload.roles }.from(%w[api_entreprise:reporter]).to([])
+        }.to change { user.reload.roles }.from(%w[dinum:api_entreprise:reporter]).to([])
       end
 
       it 'creates an admin event' do
@@ -60,7 +60,7 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
 
         admin_event = AdminEvent.last
 
-        expect(admin_event.before_attributes).to eq('roles' => %w[api_entreprise:reporter])
+        expect(admin_event.before_attributes).to eq('roles' => %w[dinum:api_entreprise:reporter])
         expect(admin_event.after_attributes).to eq('roles' => [])
       end
 
@@ -72,8 +72,8 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
     end
 
     describe 'with invalid roles' do
-      context 'when it is an invalid authorization request type' do
-        let(:roles) { user.roles + %w[invalid_role:instructor] }
+      context 'when it is an invalid provider' do
+        let(:roles) { user.roles + %w[unknown:api_entreprise:instructor] }
 
         it 'does not update with this role' do
           expect {
@@ -82,14 +82,34 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
         end
       end
 
-      context 'when it is an invalid role' do
-        let(:roles) { user.roles + %w[api_particulier:invalid_role] }
+      context 'when it is an invalid role type' do
+        let(:roles) { user.roles + %w[dinum:api_particulier:invalid_role] }
 
         it 'does not update with this role' do
           expect {
             update_user_roles
           }.not_to change { user.reload.roles }
         end
+      end
+
+      context 'when it is a 2-part legacy format' do
+        let(:roles) { user.roles + %w[api_particulier:instructor] }
+
+        it 'does not update with this role' do
+          expect {
+            update_user_roles
+          }.not_to change { user.reload.roles }
+        end
+      end
+    end
+
+    describe 'with FD-level wildcard' do
+      let(:roles) { %w[dinum:*:instructor] }
+
+      it 'accepts FD-level wildcard' do
+        expect {
+          update_user_roles
+        }.to change { user.reload.roles }.to(%w[dinum:*:instructor])
       end
     end
   end


### PR DESCRIPTION
## Refonte du système de rôles — Support des droits FD-level (DP-1612)

### Contexte

La gestion des droits par définition d'autorisation est fastidieuse quand un FD a beaucoup de définitions (ex: DGFIP en a ~36). Cette PR introduit les droits au niveau Fournisseur de Données : un rôle `dgfip:*:instructor` donne accès à toutes les définitions sous DGFIP, actuelles et futures.

### Ce qui change

**Format des rôles** : `"def_id:role"` → `"fd_slug:def_id:role"` (ex: `"dinum:api_entreprise:instructor"`). Le wildcard `"dgfip:*:instructor"` couvre toutes les définitions du FD.

**3 nouveaux modèles** :

| Modèle | Rôle |
|---|---|
| `RoleHierarchy` | Centralise la hiérarchie (manager → instructor → reporter ← developer) en un seul endroit |
| `ParsedRole` | Value object (`Data.define`) qui parse/valide une string de rôle. NullObject pour les formats invalides |
| `RoleSet` | Collection filtrée de rôles pour un kind donné. Gère l'expansion des wildcards FD-level |

**API User** :

```ruby
user.roles_for(:instructor)                    # → RoleSet
user.roles_for(:instructor).covers?('api_x')   # → true/false (inclut wildcard FD)
user.roles_for(:instructor).definition_ids     # → ['api_x', 'api_y', ...]

user.grant_role(:instructor, 'api_entreprise') # encapsule le format de stockage
user.grant_fd_role(:instructor, 'dgfip')       # rôle FD-level
user.grant_admin_role
user.revoke_all_roles
```

**Corrections** :
- Fix P4 : `User.instructor_for` inclut désormais les managers (cohérent avec `user.instructor?`)
- Les queries SQL sur les rôles (`unnest`, `split_part`, `LIKE`) sont centralisées dans `User` (scopes `with_role_matching`, `with_role_for_definition`, `with_role_for_provider`)

### Comment reviewer

Les commits sont organisés ainsi :

1. **`Ajoute les nouveaux PORO`** (5 fichiers) — `RoleHierarchy`, `RoleSet`, réécriture de `User` : scopes, `roles_for`, suppression des `*_roles`
2. **`Tout le monde utilise les nouveaux POROs`** (13 fichiers) — Migration des consommateurs : policies, controllers, vues, `DeveloperScoping`. Beaucoup de suppressions (code simplifié)
3. **`Ajoute le nouveau rôle au niveau FD`** (26 fichiers) — Le cœur de la feature : `ParsedRole`, format 3 segments, wildcard, migration de données, admin UI, factories/seeds/cucumber
4. **Commits suivants** — DRY des scopes, extraction `ParsedRole` depuis `RoleSet`, découplage tests/format de stockage via `grant_role`

A terme tout sera fixup dans 1-2 commits. Il est intéressant de lire les 2 premiers pour comprendre le concept des nouveaux POROs puis la review peut être faite sur les changements globaux (car les POROs ont pas mal évolué)

### Migration

La migration `20260421000000_migrate_roles_to_three_part_format` convertit les rôles existants et les AdminEvents. Elle est réversible. Elle **échoue explicitement** (fail fast) si un rôle ne peut pas être converti (provider introuvable dans la table `habilitation_types` ni dans le `YAML_PROVIDER_MAP`). Cela garantit qu'aucune permission n'est silencieusement perdue — un mapping manquant doit être corrigé avant de pouvoir migrer.

### Tests

Les tests n'utilisent plus de strings de rôles hardcodées (sauf dans les specs qui testent spécifiquement le fonctionnement des rôles).

### La suite

Cette PR est une étape qui sert à simplifier la gestion de droits via des interfaces plus claires tout en permettant un accès rapide à la fonctionnalité de droits niveau FD. Elle sera follow up par une PR pour modifier le stockage des rôles en tables dédiées.