### PR TITLE
Ajoute une section tutoriels dans l'espace développeurs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,10 @@ If the user is NOT using Docker, you can use these commands directly:
 - Be sure that tests you introduce pass before stopping your work.
 - Authorization should be done in the controller, not in the model/services.
 - Check docs/ for technical documentation if needed.
+- When touching the API (endpoints, payloads, événements webhooks, scopes,
+  politique de retry, etc.), iterate on the relevant files under `docs/` and on
+  the tutorials (`docs/developers/tutorials/` + `app/views/developers/tutorials/`)
+  so docs et tutos restent alignés avec le code.
 - For building forms use DSFRFormBuilder
 - Components are documented here
     https://www.systeme-de-design.gouv.fr/version-courante/fr/composants

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ If the user is NOT using Docker, you can use these commands directly:
 - When touching the API (endpoints, payloads, événements webhooks, scopes,
   politique de retry, etc.), iterate on the relevant files under `docs/` and on
   the tutorials (`docs/developers/tutorials/` + `app/views/developers/tutorials/`)
-  so docs et tutos restent alignés avec le code.
+  so docs et tutos remain consistent with the code.
 - For building forms use DSFRFormBuilder
 - Components are documented here
     https://www.systeme-de-design.gouv.fr/version-courante/fr/composants

--- a/app/controllers/developers/tutorials_controller.rb
+++ b/app/controllers/developers/tutorials_controller.rb
@@ -1,0 +1,17 @@
+class Developers::TutorialsController < DevelopersController
+  allow_unauthenticated_access
+
+  TUTORIALS = {
+    'lecture' => 'lecture.md',
+    'ecriture' => 'ecriture.md',
+    'webhooks' => 'webhooks.md'
+  }.freeze
+
+  def index; end
+
+  def show
+    filename = TUTORIALS.fetch(params[:slug]) { raise ActionController::RoutingError, 'Not Found' }
+    @slug = params[:slug]
+    @html_content = MarkdownRenderer.new(Rails.root.join('docs/developers/tutorials', filename).read).to_html
+  end
+end

--- a/app/services/skip_links_implemented_checker.rb
+++ b/app/services/skip_links_implemented_checker.rb
@@ -112,6 +112,8 @@ class SkipLinksImplementedChecker
 
     developers/open_api#show
     developers/oauth_applications#index
+    developers/tutorials#index
+    developers/tutorials#show
     pages#proconnect_connexion
     public/authorization_requests#show
 

--- a/app/services/skip_links_implemented_checker.rb
+++ b/app/services/skip_links_implemented_checker.rb
@@ -135,7 +135,21 @@ class SkipLinksImplementedChecker
     return true if whitelisted?
 
     current_route = "#{controller_name}##{action_name}"
-    raise SkipLinksNotDefinedError, "Accessibility Error: No skip links have been defined for the current page (#{current_route}). To ensure proper navigation for keyboard and screen reader users, add skip links by using `content_for(:skip_links)` in your view or defining them through a dedicated helper method."
+    raise SkipLinksNotDefinedError, <<~MSG.strip
+      Accessibility Error: No skip links have been defined for the current page (#{current_route}).
+
+      Two ways to fix this, depending on your use case:
+
+      1. Standard case (default skip links: Contenu / Menu / Pied de page):
+         Add `#{current_route}` to SkipLinksImplementedChecker::WHITELISTED_ROUTES.
+         The default skip links from `SkipLinks#default_skip_links` will be rendered.
+         To customize the « Aller au contenu » label, set `content_for(:content_skip_link_text)` in your view.
+
+      2. Specific case (custom anchors, tabs, business-specific navigation):
+         Define `content_for(:skip_links)` in your view with your own `skip_link(...)` calls.
+
+      Prefer option 1 unless you actually need custom anchors.
+    MSG
   end
 
   private

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -1,3 +1,4 @@
+<% set_title! t('page_titles.developers_home') %>
 
 <div class="fr-mt-4w fr-mb-2w">
   <div class="sub-header">
@@ -33,6 +34,19 @@
             <%= link_to t('.applications'), developers_oauth_applications_path %>
           </h3>
           <p class="fr-card__desc"><%= t('.applications_desc') %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="fr-col-12 fr-col-md-4">
+    <div class="fr-card fr-enlarge-link">
+      <div class="fr-card__body">
+        <div class="fr-card__content">
+          <h3 class="fr-card__title">
+            <%= link_to t('.tutorials'), developers_tutorials_path %>
+          </h3>
+          <p class="fr-card__desc"><%= t('.tutorials_desc') %></p>
         </div>
       </div>
     </div>

--- a/app/views/developers/tutorials/index.html.erb
+++ b/app/views/developers/tutorials/index.html.erb
@@ -1,0 +1,34 @@
+<% set_title! t('page_titles.developers_tutorials') %>
+
+<% content_for :content_skip_link_text do %>
+  <%= t('.title') %>
+<% end %>
+
+<div class="fr-mt-4w fr-mb-2w">
+  <div class="sub-header">
+    <div class="sub-header-content">
+      <h1><%= t('.title') %></h1>
+    </div>
+  </div>
+</div>
+
+<div class="fr-my-4w">
+  <p class="fr-text--lead"><%= t('.intro') %></p>
+
+  <div class="fr-grid-row fr-grid-row--gutters fr-mt-4w">
+    <% %w[lecture ecriture webhooks].each do |slug| %>
+      <div class="fr-col-12 fr-col-md-4">
+        <div class="fr-card fr-enlarge-link">
+          <div class="fr-card__body">
+            <div class="fr-card__content">
+              <h3 class="fr-card__title">
+                <%= link_to t(".#{slug}.title"), developers_tutorial_path(slug: slug) %>
+              </h3>
+              <p class="fr-card__desc"><%= t(".#{slug}.desc") %></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/developers/tutorials/show.html.erb
+++ b/app/views/developers/tutorials/show.html.erb
@@ -1,0 +1,15 @@
+<% set_title! t('page_titles.developers_tutorial', title: t("developers.tutorials.index.#{@slug}.title")) %>
+
+<% content_for :content_skip_link_text do %>
+  <%= t("developers.tutorials.index.#{@slug}.title") %>
+<% end %>
+
+<div class="fr-container fr-my-4w">
+  <p class="fr-mb-2w">
+    <%= link_to t('.back'), developers_tutorials_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon-left' %>
+  </p>
+
+  <div class="markdown-content">
+    <%= @html_content %>
+  </div>
+</div>

--- a/config/locales/developers.fr.yml
+++ b/config/locales/developers.fr.yml
@@ -21,6 +21,23 @@ fr:
       applications_desc: Créez et gérez vos applications OAuth pour accéder à l'API DataPass de manière sécurisée. Générez vos identifiants client et configurez vos URLs de redirection.
       webhooks: Webhooks
       webhooks_desc: Configurez des webhooks pour recevoir des notifications en temps réel lors des changements de statut de vos demandes d'autorisation. Suivez l'historique des appels et rejouez les webhooks en cas d'échec.
+      tutorials: Tutoriels
+      tutorials_desc: Guides pas-à-pas pour exploiter l'API DataPass — lecture, écriture, webhooks — avec exemples de code et cas d'usage (tableau de bord, intégration CRM, suivi de demandes).
+    tutorials:
+      index:
+        title: Tutoriels développeurs
+        intro: Guides pratiques pour intégrer DataPass dans vos systèmes — fournisseurs de données, intégrateurs CRM, créateurs de tableaux de bord. Chaque tutoriel suppose que vous avez au minimum le rôle « développeur » pour le type d'habilitation visé.
+        lecture:
+          title: Exploiter l'API en lecture
+          desc: Obtenir un jeton OAuth2, interroger les demandes et habilitations, construire un tableau de bord de pilotage.
+        ecriture:
+          title: Exploiter l'API en écriture
+          desc: Créer et mettre à jour des demandes depuis un formulaire ou un CRM. Comprendre la clé « data » spécifique à chaque type d'habilitation.
+        webhooks:
+          title: Suivre les demandes via webhooks
+          desc: Recevoir les événements de cycle de vie en temps réel, vérifier la signature, distinguer les actions initiées par l'API.
+      show:
+        back: Retour aux tutoriels
     webhooks:
       index:
         title: Mes webhooks

--- a/config/locales/page_titles.fr.yml
+++ b/config/locales/page_titles.fr.yml
@@ -10,6 +10,9 @@ fr:
     cgu_api_impot_particulier_production: CGU API Impôt Particulier - Production
     api_documentation: Documentation API
     webhooks_documentation: Documentation des webhooks
+    developers_home: Espace développeur
+    developers_tutorials: Tutoriels développeurs
+    developers_tutorial: "Tutoriel : %{title}"
 
     dashboard: Tableau de bord
     profile: Votre compte utilisateur

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,9 @@ Rails.application.routes.draw do
     resources :oauth_applications, only: :index, path: 'applications'
     get 'documentation', to: 'open_api#show'
 
+    get 'tutoriels', to: 'tutorials#index', as: :tutorials
+    get 'tutoriels/:slug', to: 'tutorials#show', as: :tutorial
+
     resources :webhooks, path: 'webhooks' do
       collection do
         get :documentation

--- a/docs/developers/tutorials/ecriture.md
+++ b/docs/developers/tutorials/ecriture.md
@@ -1,0 +1,282 @@
+# Tutoriel : exploiter l'API DataPass en écriture
+
+Ce tutoriel couvre la **création** et la **mise à jour** de demandes d'habilitation via l'API. Cas d'usage typiques : ouverture d'habilitation depuis un formulaire embarqué sur votre site, synchronisation CRM → DataPass, pré-remplissage à partir d'un back-office métier.
+
+## Prérequis
+
+- Avoir lu [le tutoriel lecture](/developpeurs/tutoriels/lecture) pour obtenir un token OAuth2.
+- Avoir le rôle **« développeur »** pour le type d'habilitation visé. Sans ce rôle, les endpoints d'écriture renvoient `403 Forbidden`.
+- Demander le scope `write_authorizations` lors de la requête `/oauth/token` (en plus de `read_authorizations` si vous souhaitez aussi lire).
+
+```ruby
+response = Net::HTTP.post(
+  URI('https://datapass.api.gouv.fr/api/v1/oauth/token'),
+  URI.encode_www_form(
+    grant_type: 'client_credentials',
+    client_id: ENV.fetch('DATAPASS_CLIENT_ID'),
+    client_secret: ENV.fetch('DATAPASS_CLIENT_SECRET'),
+    scope: 'read_authorizations write_authorizations'
+  )
+)
+```
+
+## Construire la clé `data` correctement
+
+C'est le point le plus délicat de l'API en écriture. Chaque définition d'habilitation expose la liste des clés `data` attendues via `GET /definitions/{id}`.
+
+### Étape 1 — récupérer les clés acceptées
+
+```python
+import requests
+
+definition = requests.get(
+    'https://datapass.api.gouv.fr/api/v1/definitions/api_entreprise',
+    headers={'Authorization': f'Bearer {access_token}'},
+).json()
+
+print(definition['data'])
+# ['intitule', 'description', 'destinataire_donnees_caractere_personnel',
+#  'duree_conservation_donnees_caractere_personnel',
+#  'duree_conservation_donnees_caractere_personnel_justification',
+#  'cadre_juridique_url', 'cadre_juridique_nature',
+#  'date_prevue_mise_en_production', 'volumetrie_approximative', 'scopes']
+```
+
+### Étape 2 — récupérer les scopes disponibles
+
+La clé `scopes` du payload `data` prend une liste de **valeurs techniques** issues du champ `scopes[].value` renvoyé par `GET /definitions/{id}`.
+
+```json
+{
+  "scopes": [
+    { "name": "Unités légales et établissements INSEE", "value": "unites_legales_etablissements_insee", "deprecated": false },
+    { "name": "Bilans BDF", "value": "bilans_bdf", "deprecated": true }
+  ]
+}
+```
+
+Ignorez les scopes dont `deprecated` est à `true`.
+
+### Étape 3 — construire le payload
+
+Seules les clés listées dans `definition.data` seront acceptées. Toute clé supplémentaire est ignorée silencieusement ou produit une erreur `422` selon la définition.
+
+## Cas d'usage : création depuis un formulaire / CRM
+
+Scénario : un agent saisit une demande dans votre CRM ; vous la poussez vers DataPass en `draft`, puis l'agent continue sur l'interface DataPass pour soumission.
+
+### En Node.js (depuis un backend de formulaire)
+
+```javascript
+const payload = {
+  demande: {
+    type: 'api_entreprise',
+    applicant: {
+      email: 'demandeur@mairie-exemple.fr',
+      given_name: 'Jean',
+      family_name: 'Dupont',
+      job_title: 'Responsable informatique',
+      phone_number: '0612345678'
+    },
+    organization: { siret: '13002526500013' },
+    data: {
+      intitule: 'Raccordement au référentiel INSEE',
+      description: 'Pré-remplissage des formulaires usagers',
+      destinataire_donnees_caractere_personnel: 'Service informatique',
+      duree_conservation_donnees_caractere_personnel: 12,
+      duree_conservation_donnees_caractere_personnel_justification: 'Durée légale de conservation',
+      cadre_juridique_url: 'https://example.gouv.fr/arrete-123',
+      cadre_juridique_nature: 'arrete',
+      date_prevue_mise_en_production: '2026-06-01',
+      volumetrie_approximative: 10000,
+      scopes: ['unites_legales_etablissements_insee']
+    }
+  }
+}
+
+const response = await fetch('https://datapass.api.gouv.fr/api/v1/demandes', {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify(payload)
+})
+
+const demande = await response.json()
+// demande.id, demande.public_id, demande.state === 'draft'
+```
+
+### En Python (synchronisation depuis un CRM)
+
+```python
+import requests
+
+payload = {
+    'demande': {
+        'type': 'api_entreprise',
+        'applicant': {
+            'email': contact['email'],
+            'given_name': contact['prenom'],
+            'family_name': contact['nom'],
+        },
+        'organization': {'siret': contact['siret']},
+        'data': {
+            'intitule': dossier['intitule'],
+            'description': dossier['description'],
+            'scopes': dossier['scopes_selectionnes'],
+            # ... autres clés dynamiquement récupérées via /definitions/{id}
+        },
+    }
+}
+
+response = requests.post(
+    'https://datapass.api.gouv.fr/api/v1/demandes',
+    headers={'Authorization': f'Bearer {access_token}'},
+    json=payload,
+)
+response.raise_for_status()
+demande = response.json()
+```
+
+### `type` ou `form_uid` ?
+
+Ces deux clés sont mutuellement exclusives :
+
+- **`type`** (recommandé par défaut) : identifiant du type d'habilitation, avec underscores (ex. `api_entreprise`, `api_impot_particulier`). Le formulaire par défaut du type est utilisé.
+- **`form_uid`** : identifiant d'un formulaire spécifique, avec tirets (ex. `api-entreprise-socle-de-base`). À utiliser uniquement si vous ciblez un cas d'usage précis avec un formulaire distinct du formulaire par défaut.
+
+La liste des `form_uid` existants est visible dans la [spec OpenAPI](/developpeurs/documentation) via `GET /definitions/{id}` (chaque définition expose ses formulaires).
+
+### Réponses possibles
+
+- `201 Created` — la demande est créée en état `draft`, la réponse contient la `Demande` complète.
+- `403 Forbidden` — vous n'avez pas le rôle développeur pour ce type, ou le scope `write_authorizations` manque.
+- `422 Unprocessable Content` — le payload ne respecte pas la définition.
+
+Le format des erreurs suit la convention JSON:API. Exemple de réponse `422` :
+
+```json
+{
+  "errors": [
+    {
+      "status": "422",
+      "title": "Clé de données invalide",
+      "detail": "La clé « scopes » contient une valeur non autorisée.",
+      "source": { "pointer": "/data/scopes" }
+    }
+  ]
+}
+```
+
+Le pointeur `source.pointer` cible le chemin de la clé fautive dans le payload, ce qui permet d'afficher l'erreur directement à côté du bon champ côté CRM.
+
+Voir la [spec OpenAPI de `POST /demandes`](/developpeurs/documentation) pour la liste exhaustive.
+
+### Précisions importantes
+
+- Le champ `applicant.email` identifie le demandeur : s'il n'existe pas, il est créé.
+- Le champ `organization.siret` identifie l'organisation : si elle n'existe pas, elle est créée et rafraîchie depuis l'INSEE de façon asynchrone.
+- Fournissez soit `type` (type d'habilitation, formulaire par défaut) soit `form_uid` (identifiant d'un formulaire spécifique).
+- Les demandes créées par l'API génèrent un événement `create_by_api` (utile pour filtrer vos demandes dans les webhooks).
+
+## Cas d'usage : mise à jour programmée (CRM → DataPass)
+
+`PATCH /demandes/{id}` permet de mettre à jour une demande **en état `draft`** depuis l'API. Les demandes déjà soumises ne sont pas modifiables via cet endpoint.
+
+```ruby
+uri = URI("https://datapass.api.gouv.fr/api/v1/demandes/#{demande_id}")
+
+request = Net::HTTP::Patch.new(uri)
+request['Authorization'] = "Bearer #{access_token}"
+request['Content-Type'] = 'application/json'
+request.body = {
+  demande: {
+    data: {
+      volumetrie_approximative: 50_000,
+      scopes: ['unites_legales_etablissements_insee', 'associations_rna']
+    }
+  }
+}.to_json
+
+Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+```
+
+Chaque mise à jour génère un événement `update_by_api` consultable via `GET /demandes/{id}/events` ou via un webhook.
+
+## Rediriger l'utilisateur vers sa demande
+
+La réponse d'un `POST /demandes` réussi contient deux identifiants, qui servent à des usages **distincts** :
+
+| Champ | URL | Usage |
+| --- | --- | --- |
+| `id` (numérique interne, ex. `123`) | `/demandes/{id}` | Page **authentifiée** du demandeur. Permet de **compléter, modifier et soumettre** la demande. C'est cette URL qu'il faut utiliser pour rediriger l'utilisateur depuis votre CRM. |
+| `public_id` (préfixé, ex. `D123`) | `/public/demandes/{public_id}` | Page **publique en lecture seule**. Lisible, partageable par email, utile pour transmettre un lien à un tiers sans lui donner accès à l'édition. |
+
+**Ne les interchangez pas** : `/demandes/{public_id}` échoue (la recherche utilise l'`id` numérique côté `AuthorizationRequestsController#show`), et `/public/demandes/{id}` échoue de la même manière dans l'autre sens.
+
+### Cas 1 — rediriger l'utilisateur pour qu'il complète et soumette
+
+C'est le cas de loin le plus fréquent : votre CRM pré-remplit la demande, l'utilisateur finalise côté DataPass.
+
+```
+https://datapass.api.gouv.fr/demandes/{id}
+```
+
+Remplacez le domaine par l'environnement ciblé :
+
+- Production : `https://datapass.api.gouv.fr/demandes/{id}`
+- Staging : `https://staging.datapass.api.gouv.fr/demandes/{id}`
+- Sandbox : `https://sandbox.datapass.api.gouv.fr/demandes/{id}`
+
+```javascript
+const response = await fetch('https://datapass.api.gouv.fr/api/v1/demandes', {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify(payload)
+})
+
+if (response.status === 201) {
+  const demande = await response.json()
+  const url = `https://datapass.api.gouv.fr/demandes/${demande.id}`
+
+  return reply.redirect(url)
+}
+```
+
+```ruby
+if response.code == '201'
+  demande = JSON.parse(response.body)
+  redirect_to "https://datapass.api.gouv.fr/demandes/#{demande['id']}"
+end
+```
+
+### Cas 2 — partager un lien public en lecture seule
+
+Pour diffuser un lien de consultation (reporting, partage externe, email au demandeur pour référence), utilisez le `public_id` :
+
+```
+https://datapass.api.gouv.fr/public/demandes/{public_id}
+```
+
+Cette page est accessible sans authentification et ne permet aucune action : ni édition, ni soumission.
+
+L'utilisateur arrive sur sa demande pré-remplie ; s'il est connecté (ou après authentification via ProConnect), il peut compléter les champs restants puis soumettre. Cela évite de dupliquer le formulaire DataPass dans votre interface — votre rôle se limite au pré-remplissage initial à partir des données déjà connues de votre CRM.
+
+> **Pré-requis côté utilisateur** : l'email passé dans `applicant.email` doit correspondre au compte ProConnect de la personne qui sera redirigée, sinon elle ne verra pas la demande dans son espace.
+
+## Workflow recommandé
+
+1. **Créer** la demande en `draft` depuis votre formulaire/CRM (`POST /demandes`).
+2. **Rediriger** l'utilisateur vers `https://datapass.api.gouv.fr/demandes/{id}` pour qu'il finalise et soumette.
+3. **Suivre** les transitions d'état (soumission, validation, refus) via les webhooks — voir [le tutoriel webhooks](/developpeurs/tutoriels/webhooks).
+4. **Synchroniser** l'habilitation délivrée dans votre système interne à réception de l'événement `approve`.
+
+## Aller plus loin
+
+- [Documentation OpenAPI — POST /demandes](/developpeurs/documentation)
+- [Tutoriel : suivre les demandes via webhooks](/developpeurs/tutoriels/webhooks)
+- [Cycle de vie d'une demande](https://github.com/etalab/data_pass/blob/main/docs/lifecycle_documentation.md)

--- a/docs/developers/tutorials/lecture.md
+++ b/docs/developers/tutorials/lecture.md
@@ -1,0 +1,188 @@
+# Tutoriel : exploiter l'API DataPass en lecture
+
+Ce tutoriel s'adresse aux fournisseurs de données qui souhaitent **consulter** les demandes et habilitations DataPass depuis un système externe : tableau de bord de pilotage, synchronisation vers un CRM, export comptable, etc.
+
+## Prérequis
+
+Avant toute chose, l'utilisateur dont dépend votre application OAuth2 doit avoir le rôle **« développeur »** (`developer`) pour le ou les types d'habilitation concernés.
+
+- Ce rôle conditionne **tout** l'accès à l'API : un utilisateur sans rôle développeur reçoit `403 Forbidden` même avec un token valide.
+- Le rôle est attribué manuellement par un administrateur DataPass pour chaque type d'habilitation (ex : `api_entreprise:developer`, `api_impot_particulier:developer`).
+- La liste des types sur lesquels vous avez ce rôle est consultable sur [/developpeurs/applications](/developpeurs/applications).
+
+Une application OAuth2 est également nécessaire (un `client_id` + `client_secret`). Elle est gérée depuis [/developpeurs/applications](/developpeurs/applications).
+
+## Obtenir un jeton d'accès
+
+L'API utilise le flow OAuth2 `client_credentials`. Pour la lecture, demandez le scope `read_authorizations`.
+
+### En Ruby
+
+```ruby
+require 'net/http'
+require 'json'
+
+response = Net::HTTP.post_form(
+  URI('https://datapass.api.gouv.fr/api/v1/oauth/token'),
+  grant_type: 'client_credentials',
+  client_id: ENV.fetch('DATAPASS_CLIENT_ID'),
+  client_secret: ENV.fetch('DATAPASS_CLIENT_SECRET'),
+  scope: 'read_authorizations'
+)
+
+body = JSON.parse(response.body)
+access_token = body.fetch('access_token')
+expires_at = Time.now + body.fetch('expires_in')
+```
+
+> `post_form` positionne automatiquement l'en-tête `Content-Type: application/x-www-form-urlencoded` attendu par l'endpoint OAuth2. Utiliser `Net::HTTP.post` avec une chaîne encodée manuellement échoue silencieusement (`invalid_request`) car le header n'est pas fixé.
+
+### En Python
+
+```python
+import os
+import requests
+
+response = requests.post(
+    'https://datapass.api.gouv.fr/api/v1/oauth/token',
+    data={
+        'grant_type': 'client_credentials',
+        'client_id': os.environ['DATAPASS_CLIENT_ID'],
+        'client_secret': os.environ['DATAPASS_CLIENT_SECRET'],
+        'scope': 'read_authorizations',
+    },
+)
+
+access_token = response.json()['access_token']
+```
+
+### En JavaScript (Node)
+
+```javascript
+const body = new URLSearchParams({
+  grant_type: 'client_credentials',
+  client_id: process.env.DATAPASS_CLIENT_ID,
+  client_secret: process.env.DATAPASS_CLIENT_SECRET,
+  scope: 'read_authorizations'
+})
+
+const response = await fetch('https://datapass.api.gouv.fr/api/v1/oauth/token', {
+  method: 'POST',
+  body
+})
+
+const { access_token: accessToken } = await response.json()
+```
+
+Les scopes disponibles sont détaillés dans [la documentation OpenAPI](/developpeurs/documentation) (section `securitySchemes.OAuth2`) :
+
+| Scope | Usage |
+| --- | --- |
+| `public` | Informations minimales sur l'utilisateur (`GET /me`) ; n'autorise aucun accès aux demandes. |
+| `read_authorizations` | Lecture des demandes, événements et habilitations. |
+| `write_authorizations` | Création et mise à jour des demandes. |
+| `read_webhooks` | Lecture de l'historique des appels webhooks (`GET /webhooks/{id}/attempts`). |
+
+### Durée de vie du token
+
+La réponse de `/oauth/token` contient `expires_in` (en secondes ; valeur par défaut : 7 200). Un dev naïf qui ré-authentifie à chaque requête sature inutilement l'endpoint. Mettre le token en cache jusqu'à `expires_at - marge` (par ex. 60 s avant expiration), puis redemander un token. Il n'y a pas de `refresh_token` avec le flow `client_credentials` : on redemande simplement un nouveau token avec les mêmes identifiants.
+
+## Cas d'usage : tableau de bord de pilotage
+
+Objectif : afficher en interne le nombre de demandes en cours, validées, refusées, avec une actualisation quotidienne.
+
+L'endpoint `GET /demandes` accepte les filtres `state`, `siret`, et pagine via `limit` + `offset`. Voir [la documentation OpenAPI](/developpeurs/documentation) pour la liste complète des paramètres et du schéma `Demande`.
+
+### Récupérer toutes les demandes validées d'un SIRET
+
+```python
+import os, requests
+
+headers = {'Authorization': f'Bearer {access_token}'}
+params = {'state[]': ['validated'], 'siret': '13002526500013', 'limit': 100}
+
+demandes = []
+offset = 0
+
+while True:
+    response = requests.get(
+        'https://datapass.api.gouv.fr/api/v1/demandes',
+        headers=headers,
+        params={**params, 'offset': offset},
+    )
+    page = response.json()
+    demandes.extend(page)
+
+    if len(page) < params['limit']:
+        break
+    offset += params['limit']
+```
+
+### Construire des agrégats pour un dashboard
+
+`limit` est plafonné à **1000** côté API. Au-delà, il faut paginer via `offset`.
+
+```ruby
+require 'net/http'
+require 'json'
+
+def fetch_page(offset:, limit: 1000, access_token:)
+  uri = URI('https://datapass.api.gouv.fr/api/v1/demandes')
+  uri.query = URI.encode_www_form(limit:, offset:)
+  request = Net::HTTP::Get.new(uri)
+  request['Authorization'] = "Bearer #{access_token}"
+
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+  JSON.parse(response.body)
+end
+
+demandes = []
+offset = 0
+limit = 1000
+
+loop do
+  page = fetch_page(offset:, limit:, access_token:)
+  demandes.concat(page)
+  break if page.size < limit
+
+  offset += limit
+end
+
+par_etat = demandes.group_by { |d| d['state'] }.transform_values(&:count)
+# => { "validated" => 42, "submitted" => 7, "draft" => 3 }
+```
+
+## Les endpoints utiles en lecture
+
+| Endpoint | Usage |
+| --- | --- |
+| `GET /me` | Informations sur l'utilisateur lié au token (scope `public`) |
+| `GET /definitions` | Types d'habilitation accessibles (avec la liste des clés `data` acceptées) |
+| `GET /definitions/{id}` | Détail d'une définition (scopes, étapes sandbox/production) |
+| `GET /demandes` | Liste des demandes (filtres `state`, `siret`) |
+| `GET /demandes/{id}` | Détail d'une demande avec ses événements et habilitations |
+| `GET /demandes/{id}/events` | Historique des événements d'une demande |
+| `GET /habilitations` | Liste des habilitations actives |
+| `GET /habilitations/{id}` | Détail d'une habilitation |
+
+> **Bon à savoir** : l'API accepte aussi bien les identifiants avec préfixe (`D123`, `H456`) que sans (`123`, `456`).
+
+## Comprendre la clé `data`
+
+Chaque type d'habilitation possède un jeu d'attributs métier qui vivent sous la clé `data` d'une demande. La liste des clés acceptées pour un type donné est **dynamique** et exposée par `GET /definitions/{id}` sous le champ `data` :
+
+```json
+{
+  "id": "api_entreprise",
+  "data": ["intitule", "description", "destinataire_donnees_caractere_personnel", "duree_conservation_donnees_caractere_personnel", "cadre_juridique_url", "cadre_juridique_nature", "date_prevue_mise_en_production", "volumetrie_approximative", "scopes"]
+}
+```
+
+**Avant toute intégration en écriture, récupérez dynamiquement ce tableau** pour construire votre payload : il peut évoluer (ajout d'un champ, dépréciation d'un scope). Voir le tutoriel [Exploiter l'API en écriture](/developpeurs/tutoriels/ecriture) pour l'usage complet.
+
+## Aller plus loin
+
+- [Documentation OpenAPI complète](/developpeurs/documentation)
+- [Tutoriel : exploiter l'API en écriture](/developpeurs/tutoriels/ecriture)
+- [Tutoriel : suivre les demandes via webhooks](/developpeurs/tutoriels/webhooks)
+- [Cycle de vie d'une demande](https://github.com/etalab/data_pass/blob/main/docs/lifecycle_documentation.md)

--- a/docs/developers/tutorials/webhooks.md
+++ b/docs/developers/tutorials/webhooks.md
@@ -1,0 +1,216 @@
+# Tutoriel : suivre les demandes via webhooks
+
+Les webhooks permettent d'être **notifié en temps réel** des changements d'état d'une demande d'habilitation, sans avoir à interroger régulièrement l'API. Ils sont complémentaires des endpoints de lecture et d'écriture.
+
+## Prérequis
+
+- Avoir le rôle **« développeur »** pour le type d'habilitation concerné (sans ce rôle, l'interface de création de webhooks n'est pas accessible).
+- Disposer d'un endpoint HTTPS public capable de recevoir un `POST` JSON et de répondre `200` en moins de quelques secondes.
+
+La documentation exhaustive (événements, signature HMAC, retry, désactivation automatique) est disponible sur la page [Documentation des webhooks](/developpeurs/webhooks/documentation). Ce tutoriel se concentre sur les cas d'usage d'intégration.
+
+## Cas d'usage : suivre le cycle de vie des demandes
+
+Scénario : un agent soumet une demande via votre CRM (créée par API), vous voulez recevoir les événements `submit`, `approve`, `refuse`, `request_changes` pour mettre à jour le dossier côté CRM.
+
+### 1. Créer le webhook depuis l'interface
+
+Rendez-vous sur [/developpeurs/webhooks](/developpeurs/webhooks) et créez un webhook :
+
+- **Type d'habilitation** : le type pour lequel vous voulez recevoir les événements (limité aux types où vous avez le rôle développeur).
+- **URL** : l'URL HTTPS publique de votre endpoint.
+- **Événements** : cochez `submit`, `approve`, `refuse`, `request_changes` (par exemple).
+
+Un **test automatique** est envoyé à la création : si votre endpoint ne répond pas `200`, le webhook est créé désactivé.
+
+Un **secret** est affiché une seule fois après création. Stockez-le dans votre coffre de secrets, il sert à vérifier la signature des appels reçus.
+
+### 2. Recevoir et vérifier les appels
+
+Chaque appel est un `POST` JSON contenant l'événement et la demande associée. Il est signé via HMAC-SHA256 dans l'en-tête `X-Hub-Signature-256`.
+
+Exemple de payload reçu pour un événement `approve` :
+
+```json
+{
+  "event": "approve",
+  "occurred_at": "2026-04-22T10:15:32Z",
+  "data": {
+    "id": 123,
+    "public_id": "D123",
+    "type": "api_entreprise",
+    "state": "validated",
+    "applicant": { "email": "demandeur@mairie-exemple.fr" },
+    "organization": { "siret": "13002526500013" }
+  }
+}
+```
+
+Le schéma détaillé (champs complets de la demande, événements spécifiques) est dans la [documentation webhooks](/developpeurs/webhooks/documentation).
+
+#### En Ruby (Rails / Sinatra)
+
+```ruby
+require 'openssl'
+
+class WebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def datapass
+    payload = request.raw_post
+    signature = request.headers['X-Hub-Signature-256'].to_s
+    expected = 'sha256=' + OpenSSL::HMAC.hexdigest('sha256', ENV.fetch('DATAPASS_WEBHOOK_SECRET'), payload)
+
+    if signature.bytesize != expected.bytesize ||
+       !ActiveSupport::SecurityUtils.fixed_length_secure_compare(signature, expected)
+      head :unauthorized and return
+    end
+
+    event = JSON.parse(payload)
+
+    case event['event']
+    when 'submit'   then MettreAJourDossier.call(event['data'], statut: 'soumis')
+    when 'approve'  then MettreAJourDossier.call(event['data'], statut: 'valide')
+    when 'refuse'   then MettreAJourDossier.call(event['data'], statut: 'refuse')
+    when 'request_changes' then NotifierAgent.call(event['data'])
+    end
+
+    head :ok
+  end
+end
+```
+
+> `ActiveSupport::SecurityUtils.secure_compare` lève `ArgumentError` si les deux chaînes n'ont pas la même taille. Un appel sans en-tête `X-Hub-Signature-256` (ou avec une valeur tronquée) ferait alors remonter une `500` à la place d'une `401`. On garde un contrôle de taille explicite avant `fixed_length_secure_compare`.
+
+#### En Python (Flask)
+
+```python
+import hmac, hashlib, os
+from flask import Flask, request, abort
+
+app = Flask(__name__)
+SECRET = os.environ['DATAPASS_WEBHOOK_SECRET'].encode()
+
+@app.post('/webhooks/datapass')
+def datapass():
+    signature = request.headers.get('X-Hub-Signature-256', '')
+    expected = 'sha256=' + hmac.new(SECRET, request.data, hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(signature, expected):
+        abort(401)
+
+    event = request.get_json()
+    # dispatch selon event['event']
+    return '', 200
+```
+
+#### En Node.js (Express)
+
+> **Ordre des middlewares Express** : si `app.use(express.json())` est monté globalement en amont, le body sera déjà consommé et re-sérialisé lorsque `express.raw` s'exécute, ce qui fait échouer le HMAC. Monter la route webhook **avant** tout `express.json()` global, ou exclure ce chemin du parseur JSON.
+
+```javascript
+import express from 'express'
+import crypto from 'crypto'
+
+const app = express()
+
+app.post(
+  '/webhooks/datapass',
+  express.raw({ type: 'application/json' }),
+  (req, res) => {
+    const expected =
+      'sha256=' +
+      crypto
+        .createHmac('sha256', process.env.DATAPASS_WEBHOOK_SECRET)
+        .update(req.body)
+        .digest('hex')
+
+    const signature = req.get('X-Hub-Signature-256') || ''
+
+    if (
+      signature.length !== expected.length ||
+      !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+    ) {
+      return res.sendStatus(401)
+    }
+
+    const event = JSON.parse(req.body.toString('utf8'))
+    // dispatch selon event.event
+    res.sendStatus(200)
+  }
+)
+```
+
+> **Important** : vérifiez la signature **avant** de parser le JSON, et utilisez une comparaison constante (`secure_compare`, `hmac.compare_digest`, `timingSafeEqual`).
+
+### 3. Répondre rapidement et traiter en asynchrone
+
+Les webhooks attendent une réponse `2xx` sous quelques secondes. Si votre traitement est lourd (mise à jour CRM, envoi de mail), enfilez un job asynchrone et répondez `200` immédiatement.
+
+## Cas d'usage : distinguer les événements initiés par l'API
+
+Si votre CRM pousse des demandes via `POST /demandes` (voir [le tutoriel écriture](/developpeurs/tutoriels/ecriture)), les événements générés sont typés :
+
+- `create_by_api` — création via l'API
+- `update_by_api` — mise à jour via l'API
+
+Concrètement : si votre système est à la fois émetteur (push vers DataPass) **et** consommateur (écoute webhooks), filtrer ces événements évite de retraiter une création que vous venez vous-même d'émettre — typique des boucles de synchronisation CRM qui se déclenchent en cascade.
+
+## Cas d'usage : rejouer un appel en échec
+
+L'historique des appels est visible sur [/developpeurs/webhooks](/developpeurs/webhooks) (bouton « Voir les appels ») :
+
+- Consultez le code HTTP renvoyé et la réponse reçue.
+- Rejouez manuellement un appel via le bouton « Rejouer cet appel ».
+- Programmatiquement, consultez l'endpoint API `GET /webhooks/{webhook_id}/attempts` (scope `read_webhooks`). Voir la [spec OpenAPI](/developpeurs/documentation).
+
+### Politique de retry
+
+En cas de réponse non-2xx (ou d'absence de réponse), l'appel est rejoué automatiquement selon un back-off exponentiel. Après **5 échecs consécutifs**, le webhook est **automatiquement désactivé** — les événements suivants ne sont plus envoyés tant qu'il n'est pas réactivé manuellement depuis l'interface.
+
+Les détails exacts (délais entre tentatives, nombre maximal de tentatives par appel, codes qui déclenchent un retry) sont dans la [documentation webhooks](/developpeurs/webhooks/documentation). Activez une alerte interne sur les codes non-2xx pour ne pas découvrir une désactivation par hasard.
+
+## Événements disponibles
+
+| Événement | Déclenché par |
+| --- | --- |
+| `create` | Création d'une demande depuis l'interface |
+| `create_by_api` | Création d'une demande via l'API |
+| `update` | Mise à jour d'une demande depuis l'interface |
+| `update_by_api` | Mise à jour d'une demande via l'API |
+| `submit` | Soumission d'une demande par le demandeur |
+| `approve` | Validation par un instructeur |
+| `refuse` | Refus par un instructeur |
+| `request_changes` | Demande de modifications par un instructeur |
+| `revoke` | Révocation d'une habilitation |
+| `archive` | Archivage |
+| `reopen` | Réouverture d'une demande clôturée |
+| `cancel_reopening` | Annulation d'une réouverture |
+| `transfer` | Transfert à une autre organisation |
+
+La liste complète, le format détaillé du payload, la politique de retry et les bonnes pratiques de sécurité sont dans la [documentation des webhooks](/developpeurs/webhooks/documentation).
+
+### Correspondance événement ↔ état
+
+Les noms d'événements ne reprennent pas toujours le nom de l'état cible de la demande. Référentiel utile quand vous enchaînez lecture (`state`) et webhooks (`event`) :
+
+| Événement | État résultant de la demande |
+| --- | --- |
+| `submit` | `submitted` |
+| `approve` | `validated` |
+| `refuse` | `refused` |
+| `request_changes` | `changes_requested` |
+| `archive` | `archived` |
+| `revoke` | `revoked` (côté habilitation) |
+| `create` / `create_by_api` | `draft` |
+| `update` / `update_by_api` | inchangé |
+
+Le détail complet du cycle de vie est documenté dans [lifecycle_documentation.md](https://github.com/etalab/data_pass/blob/main/docs/lifecycle_documentation.md).
+
+## Aller plus loin
+
+- [Documentation complète des webhooks](/developpeurs/webhooks/documentation)
+- [Mes webhooks](/developpeurs/webhooks)
+- [Documentation OpenAPI](/developpeurs/documentation)
+- [Tutoriel : exploiter l'API en lecture](/developpeurs/tutoriels/lecture)
+- [Tutoriel : exploiter l'API en écriture](/developpeurs/tutoriels/ecriture)

--- a/features/developpeurs/tutoriels.feature
+++ b/features/developpeurs/tutoriels.feature
@@ -1,0 +1,25 @@
+# language: fr
+
+Fonctionnalité: Développeurs: consultation des tutoriels
+
+  Scénario: Je peux voir l'index des tutoriels sans être connecté
+    Quand je me rends sur le chemin "/developpeurs/tutoriels"
+    Alors la page contient "Tutoriels développeurs"
+    Et il y a un lien vers "/developpeurs/tutoriels/lecture"
+    Et il y a un lien vers "/developpeurs/tutoriels/ecriture"
+    Et il y a un lien vers "/developpeurs/tutoriels/webhooks"
+
+  Scénario: Je peux consulter le tutoriel lecture
+    Quand je me rends sur le chemin "/developpeurs/tutoriels/lecture"
+    Alors la page contient "Tutoriel : exploiter l'API DataPass en lecture"
+    Et la page contient "read_authorizations"
+
+  Scénario: Je peux consulter le tutoriel écriture
+    Quand je me rends sur le chemin "/developpeurs/tutoriels/ecriture"
+    Alors la page contient "Tutoriel : exploiter l'API DataPass en écriture"
+    Et la page contient "write_authorizations"
+
+  Scénario: Je peux consulter le tutoriel webhooks
+    Quand je me rends sur le chemin "/developpeurs/tutoriels/webhooks"
+    Alors la page contient "Tutoriel : suivre les demandes via webhooks"
+    Et la page contient "X-Hub-Signature-256"

--- a/spec/helpers/concerns/skip_links_spec.rb
+++ b/spec/helpers/concerns/skip_links_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe SkipLinks do
       it 'raises SkipLinksNotDefinedError to highlight missing skip links' do
         expect { validate_skip_links_in_test! }.to raise_error(
           SkipLinksImplementedChecker::SkipLinksNotDefinedError,
-          /Accessibility Error: No skip links have been defined for the current page \(non_existent#show\)\. To ensure proper navigation for keyboard and screen reader users, add skip links by using `content_for\(:skip_links\)` in your view or defining them through a dedicated helper method\./
+          /Accessibility Error: No skip links have been defined for the current page \(non_existent#show\)\./
         )
       end
     end

--- a/spec/services/skip_links_implemented_spec.rb
+++ b/spec/services/skip_links_implemented_spec.rb
@@ -34,8 +34,12 @@ RSpec.describe SkipLinksImplementedChecker do
 
         expect {
           skip_links_checker.perform!
-        }.to raise_error(SkipLinksImplementedChecker::SkipLinksNotDefinedError,
-          /Accessibility Error: No skip links have been defined for the current page \(test#show\)\. To ensure proper navigation for keyboard and screen reader users, add skip links by using `content_for\(:skip_links\)` in your view or defining them through a dedicated helper method\./)
+        }.to raise_error(SkipLinksImplementedChecker::SkipLinksNotDefinedError) { |error|
+          expect(error.message).to include('Accessibility Error: No skip links have been defined for the current page (test#show).')
+          expect(error.message).to include('Add `test#show` to SkipLinksImplementedChecker::WHITELISTED_ROUTES')
+          expect(error.message).to include('content_for(:content_skip_link_text)')
+          expect(error.message).to include('Define `content_for(:skip_links)` in your view')
+        }
       end
     end
   end


### PR DESCRIPTION
Les fournisseurs de données qui intègrent DataPass depuis un CRM, un formulaire externe ou un outil de pilotage n'avaient jusqu'ici que la spec OpenAPI et la doc webhooks comme points d'entrée. Le chemin depuis « j'ai un rôle développeur » jusqu'à une intégration qui marche restait à reconstituer à chaque fois.

Cette section /developpeurs/tutoriels propose trois guides consultables sans authentification : lecture de l'API, écriture de l'API, et exploitation des webhooks. Chaque guide couvre les cas d'usage typiques (tableau de bord, intégration CRM, suivi de demandes) et renvoie vers la documentation OpenAPI et la doc webhooks pour les détails.

----

<img width="2664" height="1398" alt="screenshot-2026-04-22--14-01-47--000586" src="https://github.com/user-attachments/assets/1b64eeb3-cf43-4bdc-ad89-bf57e7607712" />
<img width="2652" height="1224" alt="screenshot-2026-04-22--14-01-36--000585" src="https://github.com/user-attachments/assets/684997c5-93f3-468b-9bfb-fe886640f5ac" />
