### PR TITLE
Expose le phone_number de l'applicant dans l'API v1

### DIFF
--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -2,5 +2,6 @@ class API::V1::UserSerializer < ActiveModel::Serializer
   attributes :id,
     :email,
     :given_name,
-    :family_name
+    :family_name,
+    :phone_number
 end

--- a/config/openapi/v1.yaml
+++ b/config/openapi/v1.yaml
@@ -199,6 +199,11 @@ components:
           example: "Dupont"
           description: Nom de famille de l'utilisateur
           nullable: true
+        phone_number:
+          type: string
+          example: "0612345678"
+          description: Numéro de téléphone de l'utilisateur
+          nullable: true
       required:
         - id
         - email


### PR DESCRIPTION
Le champ phone_number est accepté en entrée lors de la création d'une demande d'habilitation et exposé dans les payloads webhooks, mais n'était pas retourné par l'API v1. Cette asymétrie rendait impossible pour un consommateur de l'API de récupérer le numéro de téléphone qu'il a lui-même fourni.

Ajoute l'attribut au UserSerializer et documente la propriété (nullable) dans le schéma Utilisateur de l'OpenAPI.