### PR TITLE
Ajoute un TitleDefinedChecker pour forcer set_title! sur chaque vue

### DIFF
--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -11,6 +11,20 @@ module PageTitleHelper
   end
 
   def page_title
-    content_for(:page_title) || format_title
+    return content_for(:page_title) if content_for?(:page_title)
+
+    validate_page_title_in_test! if Rails.env.test?
+
+    format_title
+  end
+
+  private
+
+  def validate_page_title_in_test!
+    TitleDefinedChecker.new(
+      controller_name: controller_path,
+      action_name: action_name,
+      has_title: content_for?(:page_title)
+    ).perform!
   end
 end

--- a/app/services/title_defined_checker.rb
+++ b/app/services/title_defined_checker.rb
@@ -1,0 +1,81 @@
+class TitleDefinedChecker
+  attr_reader :controller_name, :action_name, :has_title
+
+  WHITELISTED_ROUTES = %w[
+    archive_authorization_requests#new
+    authorization_request_forms#new
+    authorization_requests#new
+    cancel_authorization_reopenings#new
+    cancel_next_authorization_request_stage#new
+    claim_instructor_draft_requests#show
+    developers/oauth_applications#index
+    developers/webhook_attempts#index
+    developers/webhooks#index
+    instruction/approve_authorization_requests#new
+    instruction/archive_authorization_requests#new
+    instruction/cancel_authorization_reopenings#new
+    instruction/cancel_next_authorization_request_stages#new
+    instruction/instructor_draft_requests/invite#new
+    instruction/message_templates#index
+    instruction/refuse_authorization_requests#new
+    instruction/request_changes_on_authorization_requests#create
+    instruction/request_changes_on_authorization_requests#new
+    instruction/revoke_authorization_requests#new
+    instruction/revoke_authorizations#new
+    instruction/transfer_authorization_requests#new
+    manual_transfer_authorization_requests#new
+    organizations#new
+    reopen_authorizations#new
+    transfer_authorization_requests#new
+    developers/webhook_attempts#show
+    developers/webhooks#edit
+    developers/webhooks#enable
+    developers/webhooks#new
+    developers/webhooks#show_secret
+    instruction/cancel_authorization_reopenings#create
+    instruction/instructor_draft_requests/invite#create
+    instruction/message_templates#edit
+    instruction/message_templates#new
+    instruction/refuse_authorization_requests#create
+    instruction/transfer_authorization_requests#create
+    organizations#create
+    organizations#show
+    transfer_authorization_requests#create
+    instruction/message_templates#create
+  ].freeze
+
+  def initialize(controller_name:, action_name:, has_title: false)
+    @controller_name = controller_name
+    @action_name = action_name
+    @has_title = has_title
+  end
+
+  def perform!
+    return true if has_title
+    return true if whitelisted?
+
+    current_route = "#{controller_name}##{action_name}"
+    raise TitleNotDefinedError, <<~MSG.strip
+      Accessibility/SEO Error: No page title has been defined for the current page (#{current_route}).
+
+      Two ways to fix this:
+
+      1. Standard case (nearly every page):
+         Add `<% set_title! t('page_titles.<key>') %>` at the top of your view.
+         Declare the i18n key in `config/locales/page_titles.fr.yml`.
+
+      2. Exception (layout-rendered page with intentional default title):
+         Add `#{current_route}` to TitleDefinedChecker::WHITELISTED_ROUTES.
+
+      Prefer option 1 unless the page is explicitly title-less.
+    MSG
+  end
+
+  private
+
+  def whitelisted?
+    WHITELISTED_ROUTES.include?("#{controller_name}##{action_name}")
+  end
+
+  class TitleNotDefinedError < StandardError; end
+end

--- a/app/services/title_defined_checker.rb
+++ b/app/services/title_defined_checker.rb
@@ -10,38 +10,38 @@ class TitleDefinedChecker
     claim_instructor_draft_requests#show
     developers/oauth_applications#index
     developers/webhook_attempts#index
+    developers/webhook_attempts#show
+    developers/webhooks#edit
+    developers/webhooks#enable
     developers/webhooks#index
+    developers/webhooks#new
+    developers/webhooks#show_secret
     instruction/approve_authorization_requests#new
     instruction/archive_authorization_requests#new
+    instruction/cancel_authorization_reopenings#create
     instruction/cancel_authorization_reopenings#new
     instruction/cancel_next_authorization_request_stages#new
+    instruction/instructor_draft_requests/invite#create
     instruction/instructor_draft_requests/invite#new
+    instruction/message_templates#create
+    instruction/message_templates#edit
     instruction/message_templates#index
+    instruction/message_templates#new
+    instruction/refuse_authorization_requests#create
     instruction/refuse_authorization_requests#new
     instruction/request_changes_on_authorization_requests#create
     instruction/request_changes_on_authorization_requests#new
     instruction/revoke_authorization_requests#new
     instruction/revoke_authorizations#new
+    instruction/transfer_authorization_requests#create
     instruction/transfer_authorization_requests#new
     manual_transfer_authorization_requests#new
-    organizations#new
-    reopen_authorizations#new
-    transfer_authorization_requests#new
-    developers/webhook_attempts#show
-    developers/webhooks#edit
-    developers/webhooks#enable
-    developers/webhooks#new
-    developers/webhooks#show_secret
-    instruction/cancel_authorization_reopenings#create
-    instruction/instructor_draft_requests/invite#create
-    instruction/message_templates#edit
-    instruction/message_templates#new
-    instruction/refuse_authorization_requests#create
-    instruction/transfer_authorization_requests#create
     organizations#create
+    organizations#new
     organizations#show
+    reopen_authorizations#new
     transfer_authorization_requests#create
-    instruction/message_templates#create
+    transfer_authorization_requests#new
   ].freeze
 
   def initialize(controller_name:, action_name:, has_title: false)

--- a/spec/helpers/page_title_helper_spec.rb
+++ b/spec/helpers/page_title_helper_spec.rb
@@ -36,13 +36,36 @@ RSpec.describe PageTitleHelper do
   end
 
   describe '#page_title' do
-    it 'returns the formatted title when title is set' do
-      helper.set_title!('Dashboard')
-      expect(helper.page_title).to eq('Dashboard - DataPass')
+    context 'when a title has been set' do
+      it 'returns the formatted title' do
+        helper.set_title!('Dashboard')
+        expect(helper.page_title).to eq('Dashboard - DataPass')
+      end
     end
 
-    it 'returns only site name when no title is set' do
-      expect(helper.page_title).to eq('DataPass')
+    context 'when no title has been set' do
+      context 'when in the test environment' do
+        before do
+          allow(helper).to receive_messages(controller_path: 'non_existent', action_name: 'show')
+        end
+
+        it 'raises TitleNotDefinedError to surface the missing set_title!' do
+          expect { helper.page_title }.to raise_error(
+            TitleDefinedChecker::TitleNotDefinedError,
+            /No page title has been defined for the current page \(non_existent#show\)/
+          )
+        end
+      end
+
+      context 'when outside the test environment' do
+        before do
+          allow(Rails.env).to receive(:test?).and_return(false)
+        end
+
+        it 'falls back to the site name' do
+          expect(helper.page_title).to eq('DataPass')
+        end
+      end
     end
   end
 end

--- a/spec/services/title_defined_checker_spec.rb
+++ b/spec/services/title_defined_checker_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe TitleDefinedChecker do
+  describe '#perform!' do
+    context 'when title is present' do
+      it 'returns true' do
+        checker = described_class.new(
+          controller_name: 'test',
+          action_name: 'show',
+          has_title: true
+        )
+
+        expect(checker.perform!).to be true
+      end
+    end
+
+    context 'when route is whitelisted' do
+      before do
+        stub_const("#{described_class}::WHITELISTED_ROUTES", %w[pages#home].freeze)
+      end
+
+      it 'returns true' do
+        checker = described_class.new(
+          controller_name: 'pages',
+          action_name: 'home',
+          has_title: false
+        )
+
+        expect(checker.perform!).to be true
+      end
+    end
+
+    context 'when route is not whitelisted and no title is present' do
+      it 'raises TitleNotDefinedError with guidance toward both fix options' do
+        checker = described_class.new(
+          controller_name: 'test',
+          action_name: 'show',
+          has_title: false
+        )
+
+        expect {
+          checker.perform!
+        }.to raise_error(described_class::TitleNotDefinedError) { |error|
+          expect(error.message).to include('Accessibility/SEO Error: No page title has been defined for the current page (test#show).')
+          expect(error.message).to include('set_title!')
+          expect(error.message).to include('page_titles')
+          expect(error.message).to include('TitleDefinedChecker::WHITELISTED_ROUTES')
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
L'oubli d'un `set_title!` n'était détecté par aucun test : cucumber/capybara assertent sur le body via `has_content?`, jamais sur le `<title>`. Le reviewer de la PR #1522 a pointé à l'œil que `developers#index` passait en prod avec le titre par défaut. Le même mécanisme existe déjà pour les skip-links (`SkipLinksImplementedChecker`), on le réplique pour les titres.

En env test, `PageTitleHelper#page_title` lève désormais `TitleDefinedChecker::TitleNotDefinedError` si la vue rendue n'a pas appelé `set_title!` et que la route n'est pas dans `WHITELISTED_ROUTES`. Le message d'erreur guide explicitement vers les deux options : ajouter `set_title!` (cas standard) ou whitelister (modal / page sans titre propre), en recommandant la première.

La whitelist initiale contient une quarantaine de routes existantes qui ignoraient `set_title!` — mélange de modals turbo-frame (titre parent suffit) et de vraies pages à auditer ultérieurement. L'objectif immédiat est d'empêcher toute *nouvelle* régression ; l'audit des routes déjà whitelistées pourra se faire ticket par ticket.