### PR TITLE
DP-1689 - Gère EntityNotFoundError dans UpdateOrganizationINSEEPayloadJob

### DIFF
--- a/app/jobs/update_organization_insee_payload_job.rb
+++ b/app/jobs/update_organization_insee_payload_job.rb
@@ -5,6 +5,9 @@ class UpdateOrganizationINSEEPayloadJob < ApplicationJob
   retry_on Faraday::ConnectionFailed, wait: :polynomially_longer, attempts: Float::INFINITY
   retry_on Faraday::UnauthorizedError, wait: 1, attempts: 5
   retry_on INSEESireneAPIClient::InvalidResponseError, wait: :polynomially_longer, attempts: Float::INFINITY
+  rescue_from INSEESireneAPIClient::EntityNotFoundError do |e|
+    Sentry.capture_exception(e, level: :warning)
+  end
 
   def perform(organization_id)
     return if skip_development?

--- a/spec/jobs/update_organization_insee_payload_job_spec.rb
+++ b/spec/jobs/update_organization_insee_payload_job_spec.rb
@@ -68,10 +68,20 @@ RSpec.describe UpdateOrganizationINSEEPayloadJob do
 
       before do
         allow(insee_sirene_api_client).to receive(:etablissement).and_raise(INSEESireneAPIClient::EntityNotFoundError)
+        allow(Sentry).to receive(:capture_exception)
       end
 
-      it 're raise this error' do
-        expect { update_organization_insee_payload_job }.to raise_error(INSEESireneAPIClient::EntityNotFoundError)
+      it 'does not raise' do
+        expect { update_organization_insee_payload_job }.not_to raise_error
+      end
+
+      it 'reports to Sentry as a warning' do
+        update_organization_insee_payload_job
+
+        expect(Sentry).to have_received(:capture_exception).with(
+          an_instance_of(INSEESireneAPIClient::EntityNotFoundError),
+          level: :warning,
+        )
       end
     end
   end


### PR DESCRIPTION
## Contexte

Suite à une alerte [Sentry](https://errors.data.gouv.fr/organizations/sentry/issues/286634/?project=28)
en production sur `UpdateOrganizationINSEEPayloadJob` : 50 jobs déclenchés en 20 minutes
pour un seul utilisateur authentifié avec un SIRET Luhn-valide mais inexistant à l'INSEE (`57539780742358`).

## Cause racine

`EntityNotFoundError` n'était pas gérée dans le job : GoodJob retentait indéfiniment,
et le `before_action` du controller re-planifiait un nouveau job à chaque requête puisque
`last_insee_payload_updated_at` n'était jamais mis à jour.

## Ce que fait cette PR

`rescue_from EntityNotFoundError` au niveau classe du job : la 404 INSEE est une erreur
définitive, on la capture en warning Sentry sans re-tenter.

## Ce que cette PR ne fait pas

La question de savoir comment cet utilisateur a pu s'authentifier avec un SIRET inexistant
est un sujet séparé qui implique notre fournisseur d'identité (ProConnect / MonComptePro).
À investiguer et remonter en dehors de cette PR.