### PR TITLE
Migre les rôles vers une table dédiée user_roles

### DIFF
--- a/app/controllers/admin/users_with_roles_controller.rb
+++ b/app/controllers/admin/users_with_roles_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersWithRolesController < AdminController
   def index
-    @search_engine = User.with_roles.includes(:organizations).ransack(params[:search_query])
+    @search_engine = User.with_roles.includes(:organizations, :user_roles).ransack(params[:search_query])
     @search_engine.sorts = 'created_at desc' if @search_engine.sorts.empty?
 
     @users = @search_engine.result(distinct: true).page(params[:page]).per(50)

--- a/app/interactors/admin/remove_habilitation_type_roles.rb
+++ b/app/interactors/admin/remove_habilitation_type_roles.rb
@@ -1,12 +1,5 @@
 class Admin::RemoveHabilitationTypeRoles < ApplicationInteractor
   def call
-    uid = context.habilitation_type.uid
-    fd_slug = context.habilitation_type.data_provider.slug
-
-    exact_roles = User::ROLES.map { |role_type| "#{fd_slug}:#{uid}:#{role_type}" }
-    User.with_role_matching(exact_roles).find_each do |user|
-      user.roles.reject! { |r| ParsedRole.parse(r).definition_id == uid }
-      user.save!
-    end
+    UserRole.where(authorization_definition_id: context.habilitation_type.uid).destroy_all
   end
 end

--- a/app/interactors/admin/update_user_roles_attribute.rb
+++ b/app/interactors/admin/update_user_roles_attribute.rb
@@ -1,14 +1,47 @@
 class Admin::UpdateUserRolesAttribute < ApplicationInteractor
   def call
-    user.roles = valid_roles
-    user.roles.uniq!
-    user.save
+    remove_obsolete_roles
+    add_missing_roles
+    user.user_roles.reset
+  end
+
+  def remove_obsolete_roles
+    user.user_roles.reload.reject { |ur| desired_attrs.any? { |d| role_matches?(ur, d) } }.each(&:destroy!)
+  end
+
+  def add_missing_roles
+    desired_attrs.reject { |d| user.user_roles.reload.any? { |ur| role_matches?(ur, d) } }
+      .each { |attrs| user.user_roles.create!(attrs) }
   end
 
   private
 
-  def valid_roles
-    context.roles.select { |role| ParsedRole.valid?(role) }
+  def desired_attrs
+    @desired_attrs ||= valid_role_attrs
+  end
+
+  def valid_role_attrs
+    context.roles.select { |r| ParsedRole.valid?(r) }.filter_map { |r| build_attrs(r) }
+  end
+
+  def build_attrs(role_string)
+    parsed = ParsedRole.parse(role_string)
+    return { role: 'admin' } if parsed.admin?
+
+    dp = DataProvider.find_by(slug: parsed.provider_slug)
+
+    {
+      role: parsed.role,
+      data_provider: dp,
+      data_provider_slug: parsed.provider_slug,
+      authorization_definition_id: parsed.fd_level? ? nil : parsed.definition_id,
+    }
+  end
+
+  def role_matches?(user_role, attrs)
+    user_role.role == attrs[:role] &&
+      user_role.data_provider_slug == attrs[:data_provider_slug] &&
+      user_role.authorization_definition_id == attrs[:authorization_definition_id]
   end
 
   def user

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -175,9 +175,11 @@ class Seeds
       email: 'api-entreprise@yopmail.com',
       external_id: '4',
       job_title: 'Responsable des instructions',
-      phone_number: '0423456789',
-      roles: ['dinum:api_entreprise:instructor', 'dinum:api_entreprise:developer']
-    )
+      phone_number: '0423456789'
+    ).tap do |user|
+      user.grant_role(:instructor, 'api_entreprise')
+      user.grant_role(:developer, 'api_entreprise')
+    end
   end
 
   def api_entreprise_reporter
@@ -187,30 +189,27 @@ class Seeds
       email: 'user12@yopmail.com',
       external_id: '12',
       job_title: 'Responsable des reporteurs',
-      phone_number: '0423456789',
-      roles: ['dinum:api_entreprise:reporter']
-    )
+      phone_number: '0423456789'
+    ).tap do |user|
+      user.grant_role(:reporter, 'api_entreprise')
+    end
   end
 
   def data_pass_admin
-    @data_pass_admin ||= User.create!(
-      email: 'datapass@yopmail.com',
-      roles: ['admin'] + all_authorization_definition_manager_roles + ['dinum:api_entreprise:developer', 'dinum:api_particulier:developer'],
-    )
+    @data_pass_admin ||= User.create!(email: 'datapass@yopmail.com').tap do |user|
+      user.grant_admin_role
+      AuthorizationDefinition.all.each do |definition|
+        user.grant_role(:manager, definition.id) if definition.provider_slug
+      end
+      user.grant_role(:developer, 'api_entreprise')
+      user.grant_role(:developer, 'api_particulier')
+    end
   end
 
   def dgfip_instructor_developer
-    @dgfip_instructor_developer ||= User.create!(
-      email: 'dgfip@yopmail.com',
-      roles: %w[dgfip:*:instructor dgfip:*:developer]
-    )
-  end
-
-  def all_authorization_definition_manager_roles
-    AuthorizationDefinition.all.filter_map do |definition|
-      next unless definition.provider_slug
-
-      "#{definition.provider_slug}:#{definition.id}:manager"
+    @dgfip_instructor_developer ||= User.create!(email: 'dgfip@yopmail.com').tap do |user|
+      user.grant_fd_role(:instructor, 'dgfip')
+      user.grant_fd_role(:developer, 'dgfip')
     end
   end
 

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -17,6 +17,7 @@ class DataProvider < ApplicationRecord
   validates :link, presence: true, format: { with: URL_REGEX, message: I18n.t('activemodel.errors.messages.url_format') }
   validates :logo, content_type: %w[image/png image/jpeg image/svg+xml], if: -> { logo.attached? }
 
+  before_destroy :cleanup_user_roles
   after_save :reset_static_caches
 
   def linked_habilitation_types?
@@ -66,6 +67,12 @@ class DataProvider < ApplicationRecord
   end
 
   def users_for_roles(roles)
-    User.with_role_for_provider(slug, roles)
+    User.joins(:user_roles).merge(
+      UserRole.for_roles(roles).for_provider(slug)
+    ).distinct
+  end
+
+  def cleanup_user_roles
+    UserRole.where(data_provider_id: id).destroy_all
   end
 end

--- a/app/models/role_set.rb
+++ b/app/models/role_set.rb
@@ -1,34 +1,20 @@
 class RoleSet
-  def initialize(roles_array, kind)
-    qualifying = RoleHierarchy.qualifying_roles(kind)
-    @roles = roles_array.filter_map do |r|
-      parsed = ParsedRole.parse(r)
-      parsed if qualifying.include?(parsed.role)
-    end
+  def initialize(user_roles_relation, kind)
+    @roles = user_roles_relation.effective_for_role(kind)
   end
 
   def covers?(definition_id = nil)
-    return @roles.any? unless definition_id
+    return @roles.exists? unless definition_id
 
-    fd_slug = ParsedRole.resolve_provider_slug(definition_id)
-
-    @roles.any? do |parsed|
-      parsed.definition_id == definition_id || (parsed.fd_level? && parsed.provider_slug == fd_slug)
-    end
+    @roles.effective_for_definition(definition_id).exists?
   end
 
-  delegate :any?, to: :@roles
+  def any?
+    @roles.exists?
+  end
 
   def definition_ids
-    @definition_ids ||= @roles.flat_map { |parsed|
-      if parsed.fd_level?
-        AuthorizationDefinition.all
-          .select { |ad| ad.provider_slug == parsed.provider_slug }
-          .map(&:id)
-      else
-        [parsed.definition_id]
-      end
-    }.uniq
+    @definition_ids ||= @roles.flat_map(&:covered_definition_ids).compact.uniq
   end
 
   def authorization_request_types

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,39 +55,20 @@ class User < ApplicationRecord
     inverse_of: :admin,
     dependent: :restrict_with_exception
 
-  scope :with_roles, -> { where("roles <> '{}'") }
+  has_many :user_roles, dependent: :destroy
+
+  scope :with_roles, -> { where(id: UserRole.select(:user_id)) }
   scope :banned, -> { where.not(banned_at: nil) }
 
-  scope :with_role_matching, lambda { |role_strings|
-    where(
-      'EXISTS (SELECT 1 FROM unnest(roles) AS r WHERE r IN (?))',
-      role_strings
-    )
-  }
-
-  scope :with_role_for_definition, lambda { |definition_id, kind|
-    fd_slug = ParsedRole.resolve_provider_slug(definition_id)
-    qualifying = RoleHierarchy.qualifying_roles(kind)
-
-    with_role_matching(
-      qualifying.flat_map { |role_type| ["#{fd_slug}:#{definition_id}:#{role_type}", "#{fd_slug}:*:#{role_type}"] }
-    )
-  }
-
-  scope :with_role_for_provider, lambda { |provider_slug, roles|
-    where(
-      'EXISTS (SELECT 1 FROM unnest(roles) AS r WHERE r LIKE ANY(ARRAY[?]))',
-      roles.map { |role| "#{provider_slug}:%:#{role}" }
-    )
-  }
-
   %i[instructor developer manager reporter].each do |role|
-    scope :"#{role}_for", ->(type) { with_role_for_definition(type.underscore, role) }
+    scope :"#{role}_for", lambda { |type|
+      joins(:user_roles).merge(
+        UserRole.effective_for_role(role).effective_for_definition(type.underscore)
+      ).distinct
+    }
   end
 
-  scope :admin, lambda {
-    where("'admin' = ANY(roles)")
-  }
+  scope :admin, -> { joins(:user_roles).merge(UserRole.admin_role).distinct }
 
   add_instruction_boolean_settings :submit_notifications, :messages_notifications
 
@@ -121,7 +102,7 @@ class User < ApplicationRecord
 
   def roles_for(kind)
     @role_sets ||= {}
-    @role_sets[kind] ||= RoleSet.new(roles, kind)
+    @role_sets[kind] ||= RoleSet.new(user_roles, kind)
   end
 
   def instructor?(definition_id = nil)
@@ -150,34 +131,37 @@ class User < ApplicationRecord
     roles_for(kind).authorization_request_types
   end
 
+  def authorization_definition_roles_as(kind)
+    roles_for(kind).authorization_definitions
+  end
+
   def grant_role(kind, definition_id)
     fd = ParsedRole.resolve_provider_slug(definition_id)
     raise ParsedRole::UnknownDefinitionError, "Unknown definition: #{definition_id}" unless fd
 
-    roles << "#{fd}:#{definition_id}:#{kind}"
-    roles.uniq!
+    dp = DataProvider.find_by(slug: fd)
+    user_roles.find_or_create_by!(role: kind.to_s, data_provider: dp, data_provider_slug: fd, authorization_definition_id: definition_id)
     @role_sets = nil
   end
 
   def grant_fd_role(kind, provider_slug)
-    roles << "#{provider_slug}:*:#{kind}"
-    roles.uniq!
+    dp = DataProvider.find_by(slug: provider_slug)
+    user_roles.find_or_create_by!(role: kind.to_s, data_provider: dp, data_provider_slug: provider_slug, authorization_definition_id: nil)
     @role_sets = nil
   end
 
   def grant_admin_role
-    roles << 'admin'
-    roles.uniq!
+    user_roles.find_or_create_by!(role: 'admin')
     @role_sets = nil
   end
 
   def revoke_all_roles
-    self.roles = []
+    user_roles.destroy_all
     @role_sets = nil
   end
 
   def admin?
-    roles.include?('admin') ||
+    user_roles.admin_role.exists? ||
       bug_bounty_users_within_staging_env?
   end
 
@@ -186,8 +170,20 @@ class User < ApplicationRecord
       /-ywhadmin@yopmail.com$/.match?(email)
   end
 
-  def authorization_definition_roles_as(kind)
-    roles_for(kind).authorization_definitions
+  def roles_as_strings
+    user_roles.map do |ur|
+      if ur.admin?
+        'admin'
+      elsif ur.fd_level?
+        "#{ur.data_provider_slug}:*:#{ur.role}"
+      else
+        "#{ur.data_provider_slug}:#{ur.authorization_definition_id}:#{ur.role}"
+      end
+    end
+  end
+
+  def roles
+    roles_as_strings
   end
 
   def self.ransackable_attributes(_auth_object = nil)
@@ -213,9 +209,9 @@ class User < ApplicationRecord
     <<~SQL.squish
       COALESCE(
         (SELECT string_agg(DISTINCT def_id, ',') FROM (
-          SELECT split_part(elem, ':', 2) AS def_id
-          FROM unnest(users.roles) AS elem
-          WHERE elem ~ '^[^:]+:[^:]+:[^:]+$' AND split_part(elem, ':', 2) <> '*'
+          SELECT ur.authorization_definition_id AS def_id
+          FROM user_roles ur
+          WHERE ur.user_id = users.id AND ur.authorization_definition_id IS NOT NULL
           #{api_role_fd_expansion_sql}
         ) expanded),
         ''
@@ -234,10 +230,10 @@ class User < ApplicationRecord
     <<~SQL.squish
       UNION
       SELECT ad_map.def_id
-      FROM unnest(users.roles) AS elem
+      FROM user_roles ur
       JOIN (VALUES #{values}) AS ad_map(def_id, provider_slug)
-        ON ad_map.provider_slug = split_part(elem, ':', 1)
-      WHERE split_part(elem, ':', 2) = '*'
+        ON ad_map.provider_slug = ur.data_provider_slug
+      WHERE ur.user_id = users.id AND ur.authorization_definition_id IS NULL
     SQL
   end
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,0 +1,58 @@
+class UserRole < ApplicationRecord
+  ROLES = %w[reporter instructor manager developer].freeze
+
+  belongs_to :user
+  belongs_to :data_provider, optional: true
+
+  validates :role, presence: true, inclusion: { in: ROLES + %w[admin] }
+  validates :data_provider_slug, presence: true, unless: :admin?
+  validate :definition_belongs_to_provider, if: :authorization_definition_id?
+
+  before_validation :sync_data_provider_slug
+
+  scope :for_role, ->(role) { where(role: role) }
+  scope :for_roles, ->(roles) { where(role: roles) }
+  scope :for_provider, ->(slug) { where(data_provider_slug: slug) }
+  scope :for_definition, ->(id) { where(authorization_definition_id: id) }
+  scope :fd_level, -> { where(authorization_definition_id: nil).where.not(data_provider_slug: nil) }
+  scope :admin_role, -> { where(role: 'admin') }
+  scope :effective_for_role, ->(kind) { for_roles(RoleHierarchy.qualifying_roles(kind)) }
+
+  scope :effective_for_definition, lambda { |definition_id|
+    fd_slug = ParsedRole.resolve_provider_slug(definition_id)
+    where(authorization_definition_id: definition_id)
+      .or(where(data_provider_slug: fd_slug, authorization_definition_id: nil))
+  }
+
+  def fd_level?
+    data_provider_slug.present? && authorization_definition_id.nil?
+  end
+
+  def covered_definition_ids
+    if fd_level?
+      AuthorizationDefinition.all
+        .select { |ad| ad.provider_slug == data_provider_slug }
+        .map(&:id)
+    else
+      [authorization_definition_id]
+    end
+  end
+
+  def admin?
+    role == 'admin'
+  end
+
+  private
+
+  def sync_data_provider_slug
+    self.data_provider_slug = data_provider&.slug if data_provider_id.present?
+  end
+
+  def definition_belongs_to_provider
+    actual_provider = ParsedRole.resolve_provider_slug(authorization_definition_id)
+    return unless actual_provider
+    return if actual_provider == data_provider_slug
+
+    errors.add(:authorization_definition_id, 'does not belong to this provider')
+  end
+end

--- a/db/migrate/20260427000000_create_user_roles_table.rb
+++ b/db/migrate/20260427000000_create_user_roles_table.rb
@@ -1,0 +1,77 @@
+class CreateUserRolesTable < ActiveRecord::Migration[8.1]
+  def up
+    create_table :user_roles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :role, null: false
+      t.references :data_provider, foreign_key: true
+      t.string :data_provider_slug
+      t.string :authorization_definition_id
+      t.timestamps
+    end
+
+    add_index :user_roles,
+      %i[user_id role data_provider_id authorization_definition_id],
+      unique: true, nulls_not_distinct: true,
+      name: 'idx_user_roles_unique'
+    add_index :user_roles, %i[role data_provider_slug]
+    add_index :user_roles, %i[role authorization_definition_id]
+
+    migrate_existing_roles
+  end
+
+  def down
+    drop_table :user_roles
+  end
+
+  private
+
+  def migrate_existing_roles
+    execute(<<~SQL.squish).each do |row|
+      SELECT id, roles FROM users WHERE roles <> '{}'
+    SQL
+      migrate_user(row['id'], row['roles'])
+    end
+  end
+
+  def migrate_user(user_id, pg_roles)
+    pg_roles.delete('{}').split(',').map(&:strip).compact_blank.each do |role_string|
+      migrate_role(user_id, role_string)
+    end
+  end
+
+  def migrate_role(user_id, role_string)
+    if role_string == 'admin'
+      execute_insert(user_id, 'admin', nil, nil, nil)
+    else
+      parsed = ParsedRole.parse(role_string)
+      return unless parsed.role
+
+      provider_id = find_provider_id(parsed.provider_slug)
+      def_id = parsed.fd_level? ? nil : parsed.definition_id
+
+      execute_insert(user_id, parsed.role, provider_id, parsed.provider_slug, def_id)
+    end
+  end
+
+  def execute_insert(user_id, role, provider_id, provider_slug, def_id)
+    execute <<~SQL.squish
+      INSERT INTO user_roles (user_id, role, data_provider_id, data_provider_slug, authorization_definition_id, created_at, updated_at)
+      VALUES (
+        #{user_id},
+        #{quote(role)},
+        #{provider_id || 'NULL'},
+        #{provider_slug ? quote(provider_slug) : 'NULL'},
+        #{def_id ? quote(def_id) : 'NULL'},
+        NOW(), NOW()
+      )
+      ON CONFLICT DO NOTHING
+    SQL
+  end
+
+  def find_provider_id(slug)
+    return nil unless slug
+
+    result = execute("SELECT id FROM data_providers WHERE slug = #{quote(slug)}").first
+    result&.fetch('id', nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -633,6 +633,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
     t.index ["authorization_request_id"], name: "index_revocation_of_authorizations_on_authorization_request_id"
   end
 
+  create_table "user_roles", force: :cascade do |t|
+    t.string "authorization_definition_id"
+    t.datetime "created_at", null: false
+    t.bigint "data_provider_id"
+    t.string "data_provider_slug"
+    t.string "role", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["data_provider_id"], name: "index_user_roles_on_data_provider_id"
+    t.index ["role", "authorization_definition_id"], name: "index_user_roles_on_role_and_authorization_definition_id"
+    t.index ["role", "data_provider_slug"], name: "index_user_roles_on_role_and_data_provider_slug"
+    t.index ["user_id", "role", "data_provider_id", "authorization_definition_id"], name: "idx_user_roles_unique", unique: true, nulls_not_distinct: true
+    t.index ["user_id"], name: "index_user_roles_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.text "ban_reason"
     t.datetime "banned_at"
@@ -746,6 +761,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
   add_foreign_key "rails_pulse_requests", "rails_pulse_routes", column: "route_id"
   add_foreign_key "revocation_of_authorizations", "authorization_requests"
   add_foreign_key "revocation_of_authorizations", "authorizations"
+  add_foreign_key "user_roles", "data_providers"
+  add_foreign_key "user_roles", "users"
   add_foreign_key "webhook_attempts", "authorization_requests"
   add_foreign_key "webhook_attempts", "webhooks"
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     trait :from_applicant
 
     trait :from_instructor do
-      from { build(:user, :instructor) }
+      from { create(:user, :instructor) }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,17 +28,17 @@ FactoryBot.define do
 
     %i[reporter instructor developer manager].each do |role|
       trait role do
-        after(:build) do |user, evaluator|
+        after(:create) do |user, evaluator|
           evaluator.authorization_request_types.each do |art|
             user.grant_role(role, art.to_s)
           rescue ParsedRole::UnknownDefinitionError
-            user.roles << "unknown:#{art}:#{role}"
+            UserRole.create!(user: user, role: role.to_s, data_provider_slug: 'unknown', authorization_definition_id: art.to_s)
           end
         end
       end
 
       trait :"fd_#{role}" do
-        after(:build) do |user, evaluator|
+        after(:create) do |user, evaluator|
           evaluator.data_provider_slugs.each do |slug|
             user.grant_fd_role(role, slug)
           end
@@ -47,7 +47,7 @@ FactoryBot.define do
     end
 
     trait :admin do
-      after(:build, &:grant_admin_role)
+      after(:create, &:grant_admin_role)
     end
   end
 end

--- a/spec/interactors/admin/remove_habilitation_type_roles_spec.rb
+++ b/spec/interactors/admin/remove_habilitation_type_roles_spec.rb
@@ -6,29 +6,38 @@ RSpec.describe Admin::RemoveHabilitationTypeRoles, type: :interactor do
 
     let(:habilitation_type) { create(:habilitation_type) }
     let(:uid) { habilitation_type.uid }
-    let(:fd_slug) { habilitation_type.data_provider.slug }
+    let(:data_provider) { habilitation_type.data_provider }
 
     context 'when users have roles linked to the habilitation type' do
-      let!(:instructor) { create(:user, roles: ["#{fd_slug}:#{uid}:instructor", 'dinum:api_entreprise:instructor']) }
-      let!(:manager) { create(:user, roles: ["#{fd_slug}:#{uid}:manager"]) }
+      let!(:instructor) do
+        create(:user).tap do |user|
+          UserRole.create!(user: user, role: 'instructor', data_provider: data_provider, authorization_definition_id: uid)
+          user.grant_role(:instructor, 'api_entreprise')
+        end
+      end
+      let!(:manager) do
+        create(:user).tap do |user|
+          UserRole.create!(user: user, role: 'manager', data_provider: data_provider, authorization_definition_id: uid)
+        end
+      end
 
       it { is_expected.to be_success }
 
       it 'removes roles linked to the habilitation type' do
         result
 
-        expect(instructor.reload.roles).to eq(['dinum:api_entreprise:instructor'])
-        expect(manager.reload.roles).to be_empty
+        expect(instructor.reload.user_roles.pluck(:authorization_definition_id)).to eq(['api_entreprise'])
+        expect(manager.reload.user_roles).to be_empty
       end
     end
 
     context 'when users have roles from other habilitation types only' do
-      let!(:other_user) { create(:user, roles: ['dinum:api_entreprise:instructor']) }
+      let!(:other_user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
       it 'does not affect other roles' do
         result
 
-        expect(other_user.reload.roles).to eq(['dinum:api_entreprise:instructor'])
+        expect(other_user.reload.user_roles.count).to eq(1)
       end
     end
   end

--- a/spec/models/role_set_spec.rb
+++ b/spec/models/role_set_spec.rb
@@ -1,135 +1,114 @@
 require 'rails_helper'
 
 RSpec.describe RoleSet do
+  let(:user) { create(:user) }
+
+  def grant(kind, definition_id)
+    user.grant_role(kind, definition_id)
+  end
+
+  def grant_fd(kind, provider_slug)
+    user.grant_fd_role(kind, provider_slug)
+  end
+
   describe '#covers?' do
     it 'returns true when user has the exact role for the definition' do
-      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
+      grant(:instructor, 'api_entreprise')
 
-      expect(role_set.covers?('api_entreprise')).to be true
+      expect(user.roles_for(:instructor).covers?('api_entreprise')).to be true
     end
 
     it 'returns false when user does not have the role for the definition' do
-      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
+      grant(:instructor, 'api_entreprise')
 
-      expect(role_set.covers?('api_particulier')).to be false
+      expect(user.roles_for(:instructor).covers?('api_particulier')).to be false
     end
 
     it 'returns true when user has a qualifying role via hierarchy' do
-      role_set = described_class.new(%w[dinum:api_entreprise:manager], :instructor)
+      grant(:manager, 'api_entreprise')
 
-      expect(role_set.covers?('api_entreprise')).to be true
+      expect(user.roles_for(:instructor).covers?('api_entreprise')).to be true
     end
 
     it 'returns false when role does not qualify via hierarchy' do
-      role_set = described_class.new(%w[dinum:api_entreprise:reporter], :instructor)
+      grant(:reporter, 'api_entreprise')
 
-      expect(role_set.covers?('api_entreprise')).to be false
+      expect(user.roles_for(:instructor).covers?('api_entreprise')).to be false
     end
 
     it 'returns true with FD-level wildcard covering the definition' do
-      role_set = described_class.new(%w[dinum:*:instructor], :instructor)
+      grant_fd(:instructor, 'dinum')
 
-      expect(role_set.covers?('api_entreprise')).to be true
+      expect(user.roles_for(:instructor).covers?('api_entreprise')).to be true
     end
 
     it 'returns false with FD-level wildcard for wrong provider' do
-      role_set = described_class.new(%w[dgfip:*:instructor], :instructor)
+      grant_fd(:instructor, 'dgfip')
 
-      expect(role_set.covers?('api_entreprise')).to be false
+      expect(user.roles_for(:instructor).covers?('api_entreprise')).to be false
     end
 
     context 'without definition_id' do
       it 'returns true when user has any qualifying role' do
-        role_set = described_class.new(%w[dinum:api_entreprise:manager], :instructor)
+        grant(:manager, 'api_entreprise')
 
-        expect(role_set.covers?).to be true
+        expect(user.roles_for(:instructor).covers?).to be true
       end
 
       it 'returns false when user has no qualifying role' do
-        role_set = described_class.new(%w[dinum:api_entreprise:reporter], :instructor)
+        grant(:reporter, 'api_entreprise')
 
-        expect(role_set.covers?).to be false
+        expect(user.roles_for(:instructor).covers?).to be false
       end
     end
   end
 
   describe '#any?' do
     it 'returns true when matching roles exist' do
-      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
+      grant(:instructor, 'api_entreprise')
 
-      expect(role_set.any?).to be true
+      expect(user.roles_for(:instructor).any?).to be true
     end
 
     it 'returns false when no matching roles exist' do
-      role_set = described_class.new(%w[], :instructor)
-
-      expect(role_set.any?).to be false
+      expect(user.roles_for(:instructor).any?).to be false
     end
   end
 
   describe '#definition_ids' do
     it 'returns unique definition ids for matching roles' do
-      role_set = described_class.new(
-        %w[dinum:api_entreprise:instructor dinum:api_particulier:manager dinum:api_entreprise:manager],
-        :instructor,
-      )
+      grant(:instructor, 'api_entreprise')
+      grant(:manager, 'api_particulier')
 
-      expect(role_set.definition_ids).to match_array(%w[api_entreprise api_particulier])
-    end
-
-    it 'includes roles from hierarchy' do
-      role_set = described_class.new(
-        %w[dinum:api_entreprise:reporter dinum:api_particulier:instructor dinum:api_entreprise:manager],
-        :reporter,
-      )
-
-      expect(role_set.definition_ids).to match_array(%w[api_entreprise api_particulier])
+      expect(user.roles_for(:instructor).definition_ids).to match_array(%w[api_entreprise api_particulier])
     end
 
     it 'expands FD-level wildcard to all definitions under the provider' do
-      role_set = described_class.new(%w[dinum:*:instructor], :instructor)
+      grant_fd(:instructor, 'dinum')
 
       dinum_definition_ids = AuthorizationDefinition.all
         .select { |ad| ad.provider_slug == 'dinum' }
         .map(&:id)
 
-      expect(role_set.definition_ids).to match_array(dinum_definition_ids)
+      expect(user.roles_for(:instructor).definition_ids).to match_array(dinum_definition_ids)
     end
   end
 
   describe '#authorization_request_types' do
     it 'returns classified authorization request types' do
-      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
+      grant(:instructor, 'api_entreprise')
 
-      expect(role_set.authorization_request_types).to eq(["AuthorizationRequest::#{'api_entreprise'.classify}"])
+      expect(user.roles_for(:instructor).authorization_request_types).to eq(["AuthorizationRequest::#{'api_entreprise'.classify}"])
     end
   end
 
   describe '#authorization_definitions' do
     it 'returns authorization definitions for matching roles' do
-      role_set = described_class.new(%w[dinum:api_entreprise:instructor], :instructor)
+      grant(:instructor, 'api_entreprise')
 
-      result = role_set.authorization_definitions
+      result = user.roles_for(:instructor).authorization_definitions
 
       expect(result.map(&:id)).to include('api_entreprise')
     end
-
-    it 'skips unknown definitions' do
-      role_set = described_class.new(%w[dinum:unknown_definition:instructor], :instructor)
-
-      expect(role_set.authorization_definitions).to be_empty
-    end
-  end
-
-  it 'ignores admin role' do
-    role_set = described_class.new(%w[admin dinum:api_entreprise:instructor], :instructor)
-
-    expect(role_set.definition_ids).to eq(%w[api_entreprise])
-  end
-
-  it 'ignores malformed roles' do
-    role_set = described_class.new(%w[bad_format api_entreprise:instructor], :instructor)
-
-    expect(role_set.definition_ids).to eq([])
   end
 end

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.describe UserRole do
+  describe 'validations' do
+    it 'is valid with a role, data_provider, and definition' do
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      user_role = described_class.new(user: create(:user), role: 'instructor', data_provider: dp, authorization_definition_id: 'api_entreprise')
+
+      expect(user_role).to be_valid
+    end
+
+    it 'is valid as admin without data_provider' do
+      user_role = described_class.new(user: create(:user), role: 'admin')
+
+      expect(user_role).to be_valid
+    end
+
+    it 'is valid as FD-level (no authorization_definition_id)' do
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      user_role = described_class.new(user: create(:user), role: 'instructor', data_provider: dp)
+
+      expect(user_role).to be_valid
+    end
+
+    it 'is invalid without a role' do
+      user_role = described_class.new(user: create(:user), role: nil)
+
+      expect(user_role).not_to be_valid
+    end
+
+    it 'is invalid with unknown role' do
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      user_role = described_class.new(user: create(:user), role: 'unknown', data_provider: dp)
+
+      expect(user_role).not_to be_valid
+    end
+
+    it 'is invalid without data_provider for non-admin role' do
+      user_role = described_class.new(user: create(:user), role: 'instructor')
+
+      expect(user_role).not_to be_valid
+    end
+
+    it 'validates definition belongs to provider' do
+      dp = create(:data_provider, slug: 'wrong_provider', name: 'Wrong', link: 'https://wrong.fr')
+      user_role = described_class.new(user: create(:user), role: 'instructor', data_provider: dp, authorization_definition_id: 'api_entreprise')
+
+      expect(user_role).not_to be_valid
+      expect(user_role.errors[:authorization_definition_id]).to be_present
+    end
+  end
+
+  describe '#sync_data_provider_slug' do
+    it 'sets data_provider_slug from data_provider on validation' do
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      user_role = described_class.new(user: create(:user), role: 'instructor', data_provider: dp, authorization_definition_id: 'api_entreprise')
+
+      user_role.valid?
+
+      expect(user_role.data_provider_slug).to eq('dinum')
+    end
+  end
+
+  describe '.effective_for_role' do
+    it 'returns roles matching the hierarchy' do
+      user = create(:user)
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      manager_role = described_class.create!(user: user, role: 'manager', data_provider: dp, authorization_definition_id: 'api_entreprise')
+      described_class.create!(user: user, role: 'reporter', data_provider: dp, authorization_definition_id: 'api_particulier')
+
+      result = described_class.effective_for_role(:instructor)
+
+      expect(result).to include(manager_role)
+    end
+  end
+
+  describe '.effective_for_definition' do
+    it 'matches definition-level role' do
+      user = create(:user)
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      role = described_class.create!(user: user, role: 'instructor', data_provider: dp, authorization_definition_id: 'api_entreprise')
+
+      expect(described_class.effective_for_definition('api_entreprise')).to include(role)
+    end
+
+    it 'matches FD-level wildcard role' do
+      user = create(:user)
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      role = described_class.create!(user: user, role: 'instructor', data_provider: dp, authorization_definition_id: nil)
+
+      expect(described_class.effective_for_definition('api_entreprise')).to include(role)
+    end
+
+    it 'does not match role for different provider' do
+      user = create(:user)
+      dp = create(:data_provider, slug: 'other_provider', name: 'Other', link: 'https://other.fr')
+      role = described_class.create!(user: user, role: 'instructor', data_provider: dp, authorization_definition_id: nil)
+
+      expect(described_class.effective_for_definition('api_entreprise')).not_to include(role)
+    end
+  end
+
+  describe '#covered_definition_ids' do
+    it 'returns definition_id for definition-level role' do
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      user_role = described_class.new(role: 'instructor', data_provider: dp, data_provider_slug: 'dinum', authorization_definition_id: 'api_entreprise')
+
+      expect(user_role.covered_definition_ids).to eq(['api_entreprise'])
+    end
+
+    it 'returns all definitions under provider for FD-level role' do
+      dp = DataProvider.find_by(slug: 'dinum') || create(:data_provider, slug: 'dinum', name: 'DINUM', link: 'https://dinum.gouv.fr')
+      user_role = described_class.new(role: 'instructor', data_provider: dp, data_provider_slug: 'dinum', authorization_definition_id: nil)
+
+      dinum_ids = AuthorizationDefinition.all.select { |ad| ad.provider_slug == 'dinum' }.map(&:id)
+
+      expect(user_role.covered_definition_ids).to match_array(dinum_ids)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe User do
   it 'has valid factories' do
     expect(build(:user)).to be_valid
-    expect(build(:user, :instructor)).to be_valid
+    expect(create(:user, :instructor)).to be_valid
   end
 
   describe 'validation ban_reason' do
@@ -108,7 +108,7 @@ RSpec.describe User do
     end
 
     context 'when user is a reporter' do
-      let(:user) { build(:user, :reporter, authorization_request_types: %w[api_entreprise]) }
+      let(:user) { create(:user, :reporter, authorization_request_types: %w[api_entreprise]) }
 
       context 'without authorization_request_type' do
         let(:authorization_request_type) { nil }
@@ -132,7 +132,7 @@ RSpec.describe User do
     end
 
     context 'when user is an instructor' do
-      let(:user) { build(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+      let(:user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
       context 'without authorization_request_type' do
         let(:authorization_request_type) { nil }
@@ -156,7 +156,7 @@ RSpec.describe User do
     end
 
     context 'when user is a manager' do
-      let(:user) { build(:user, :manager, authorization_request_types: %w[api_entreprise]) }
+      let(:user) { create(:user, :manager, authorization_request_types: %w[api_entreprise]) }
 
       context 'without authorization_request_type' do
         let(:authorization_request_type) { nil }
@@ -200,7 +200,7 @@ RSpec.describe User do
     end
 
     context 'when user is an instructor' do
-      let(:user) { build(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+      let(:user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
       context 'without authorization_request_type' do
         let(:authorization_request_type) { nil }
@@ -224,7 +224,7 @@ RSpec.describe User do
     end
 
     context 'when user is a manager' do
-      let(:user) { build(:user, :manager, authorization_request_types: %w[api_entreprise]) }
+      let(:user) { create(:user, :manager, authorization_request_types: %w[api_entreprise]) }
 
       context 'without authorization_request_type' do
         let(:authorization_request_type) { nil }
@@ -268,7 +268,7 @@ RSpec.describe User do
     end
 
     context 'when user is a manager' do
-      let(:user) { build(:user, :manager, authorization_request_types: %w[api_entreprise]) }
+      let(:user) { create(:user, :manager, authorization_request_types: %w[api_entreprise]) }
 
       context 'without authorization_request_type' do
         let(:authorization_request_type) { nil }
@@ -304,7 +304,7 @@ RSpec.describe User do
     end
 
     context 'when user is an instructor' do
-      let(:user) { build(:user, :instructor, authorization_request_types:) }
+      let(:user) { create(:user, :instructor, authorization_request_types:) }
       let(:authorization_request_types) { %w[api_entreprise api_particulier] }
 
       let(:api_entreprise_definition) { AuthorizationDefinition.find('api_entreprise') }
@@ -316,7 +316,7 @@ RSpec.describe User do
     context 'when the user is reporter and developer for the same authorization definition' do
       let(:kind) { 'reporter' }
 
-      let(:user) { build(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+      let(:user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
       before do
         user.grant_role(:developer, 'api_entreprise')

--- a/spec/organizers/admin/destroy_habilitation_type_spec.rb
+++ b/spec/organizers/admin/destroy_habilitation_type_spec.rb
@@ -19,13 +19,17 @@ RSpec.describe Admin::DestroyHabilitationType, type: :organizer do
     end
 
     context 'when users have roles linked to the habilitation type' do
-      let(:fd_slug) { habilitation_type.data_provider.slug }
-      let!(:instructor) { create(:user, roles: ["#{fd_slug}:#{habilitation_type.uid}:instructor", 'dinum:api_entreprise:manager']) }
+      let!(:instructor) do
+        create(:user).tap do |user|
+          UserRole.create!(user: user, role: 'instructor', data_provider: habilitation_type.data_provider, authorization_definition_id: habilitation_type.uid)
+          user.grant_role(:manager, 'api_entreprise')
+        end
+      end
 
       it 'removes roles linked to the habilitation type' do
         organizer
 
-        expect(instructor.reload.roles).to eq(['dinum:api_entreprise:manager'])
+        expect(instructor.reload.user_roles.pluck(:authorization_definition_id)).to eq(['api_entreprise'])
       end
     end
 

--- a/spec/organizers/admin/update_user_roles_spec.rb
+++ b/spec/organizers/admin/update_user_roles_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
     subject(:update_user_roles) { described_class.call(admin:, user:, roles:) }
 
     let(:admin) { create(:user, :admin) }
-    let(:user) { create(:user, roles: %w[dinum:api_entreprise:reporter]) }
+    let(:user) { create(:user, :reporter, authorization_request_types: %w[api_entreprise]) }
     let(:roles) { %w[dinum:api_particulier:instructor admin] }
 
     before do
@@ -33,7 +33,7 @@ RSpec.describe Admin::UpdateUserRoles, type: :organizer do
     it 'updates the user roles' do
       expect {
         update_user_roles
-      }.to change { user.reload.roles }.from(%w[dinum:api_entreprise:reporter]).to(%w[dinum:api_particulier:instructor admin])
+      }.to change { user.reload.roles }.from(%w[dinum:api_entreprise:reporter]).to(match_array(%w[dinum:api_particulier:instructor admin]))
     end
 
     it 'notifies admins for roles update' do


### PR DESCRIPTION
Remplace le stockage des rôles dans la colonne array users.roles par une table user_roles avec FK vers users et data_providers, index unique NULLS NOT DISTINCT (PG17), et scopes dédiés.

RoleSet reçoit désormais une relation UserRole au lieu d'un array de strings. Les scopes User passent de unnest/IN à des JOIN sur user_roles. Les grant_*/revoke_all_roles créent/suppriment des records UserRole.

La colonne users.roles est conservée pour l'instant (suppression en Phase D) et un alias User#roles délègue à roles_as_strings pour la rétrocompatibilité.

Grâce au découplage via grant_role/roles_for introduit en Phase B, aucune policy, aucun controller, aucune vue et aucun cucumber step ne change.