### PR TITLE
DP-1700 - Fix: affiche "sans changement" au lieu de "ancienne version" pour les soumissions modernes vides

### DIFF
--- a/app/interactors/create_authorization_request_changelog.rb
+++ b/app/interactors/create_authorization_request_changelog.rb
@@ -51,7 +51,7 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
   end
 
   def latest_authorization_data
-    @latest_authorization_data ||= authorization_request.authorizations.order(:created_at).last&.data
+    @latest_authorization_data ||= authorization_request.latest_authorization&.data
   end
 
   def previous_value_from_last_authorization(key)

--- a/app/interactors/create_authorization_request_changelog.rb
+++ b/app/interactors/create_authorization_request_changelog.rb
@@ -40,10 +40,22 @@ class CreateAuthorizationRequestChangelog < ApplicationInteractor
 
   def reified_data_as_array
     authorization_request_data_keys.map do |key|
-      newest_diff = previous_changelog_diffs.find { |diff| diff[key].present? }
+      changelog_diff = previous_changelog_diffs.find { |diff| diff[key].present? }
 
-      [key, newest_diff[key].last] if newest_diff
+      if changelog_diff
+        [key, changelog_diff[key].last]
+      elsif (previous_value = previous_value_from_last_authorization(key))
+        [key, previous_value]
+      end
     end
+  end
+
+  def latest_authorization_data
+    @latest_authorization_data ||= authorization_request.authorizations.order(:created_at).last&.data
+  end
+
+  def previous_value_from_last_authorization(key)
+    latest_authorization_data&.[](key)
   end
 
   def initial_diff_with_prefilled_form

--- a/app/services/authorization_request_changelog_presenter.rb
+++ b/app/services/authorization_request_changelog_presenter.rb
@@ -11,20 +11,9 @@ class AuthorizationRequestChangelogPresenter
   def event_name
     return legacy_changelog_name if changelog.legacy?
     return legacy_changelog_name if previous_legacy_without_snapshot?
+    return initial_submit_event_name if first_changelog?
 
-    if first_changelog?
-      if !prefilled_data?
-        'initial_submit_without_prefilled_data'
-      elsif prefilled_changed?
-        'initial_submit_with_changes_on_prefilled_data'
-      else
-        'initial_submit_without_changes_on_prefilled_data'
-      end
-    elsif no_change?
-      'submit_without_changes'
-    else
-      'submit_with_changes'
-    end
+    no_change? ? 'submit_without_changes' : 'submit_with_changes'
   end
 
   def consolidated_changelog_entries
@@ -52,6 +41,16 @@ class AuthorizationRequestChangelogPresenter
     end
 
     DiffPresenter.new(changed_prefilled_diff, authorization_request)
+  end
+
+  def initial_submit_event_name
+    if !prefilled_data?
+      'initial_submit_without_prefilled_data'
+    elsif prefilled_changed?
+      'initial_submit_with_changes_on_prefilled_data'
+    else
+      'initial_submit_without_changes_on_prefilled_data'
+    end
   end
 
   def legacy_changelog_name

--- a/app/services/authorization_request_changelog_presenter.rb
+++ b/app/services/authorization_request_changelog_presenter.rb
@@ -9,7 +9,7 @@ class AuthorizationRequestChangelogPresenter
   end
 
   def event_name
-    return legacy_changelog_name if any_changelog_legacy?
+    return legacy_changelog_name if changelog.legacy?
 
     if first_changelog?
       if !prefilled_data?
@@ -75,11 +75,6 @@ class AuthorizationRequestChangelogPresenter
 
   def no_change?
     changelog.diff.empty?
-  end
-
-  def any_changelog_legacy?
-    changelog.legacy? ||
-      authorization_request.changelogs.where(legacy: true).any?
   end
 
   def authorization_request

--- a/app/services/authorization_request_changelog_presenter.rb
+++ b/app/services/authorization_request_changelog_presenter.rb
@@ -10,6 +10,7 @@ class AuthorizationRequestChangelogPresenter
 
   def event_name
     return legacy_changelog_name if changelog.legacy?
+    return legacy_changelog_name if previous_legacy_without_snapshot?
 
     if first_changelog?
       if !prefilled_data?
@@ -75,6 +76,11 @@ class AuthorizationRequestChangelogPresenter
 
   def no_change?
     changelog.diff.empty?
+  end
+
+  def previous_legacy_without_snapshot?
+    authorization_request.changelogs.where(legacy: true).any? &&
+      authorization_request.latest_authorization.nil?
   end
 
   def authorization_request

--- a/spec/interactors/create_authorization_request_changelog_spec.rb
+++ b/spec/interactors/create_authorization_request_changelog_spec.rb
@@ -140,6 +140,51 @@ RSpec.describe CreateAuthorizationRequestChangelog, type: :interactor do
             end
           end
         end
+
+        describe 'when first changelog is legacy with incomplete diff but there is an authorization snapshot' do
+          before do
+            invalid_changelog = described_class.call(authorization_request:).changelog
+            create(:authorization, request: authorization_request)
+            invalid_changelog.update!(
+              legacy: true,
+              diff: invalid_changelog.diff.except('intitule')
+            )
+          end
+
+          context 'when there is an update on a key missing from the legacy diff' do
+            before do
+              authorization_request.intitule = 'New intitule'
+              authorization_request.description = 'New description'
+            end
+
+            it 'recovers the missing key from the authorization snapshot' do
+              expect(changelog.diff).to include(
+                'intitule' => [old_intitule, 'New intitule'],
+                'description' => [old_description, authorization_request.description]
+              )
+            end
+          end
+        end
+
+        describe 'when first changelog is legacy with complete diff and there is an authorization snapshot' do
+          let(:legacy_intitule) { 'Legacy intitule value' }
+
+          before do
+            legacy_changelog = described_class.call(authorization_request:).changelog
+            legacy_changelog.update!(
+              legacy: true,
+              diff: legacy_changelog.diff.merge('intitule' => [old_intitule, legacy_intitule])
+            )
+            create(:authorization, request: authorization_request)
+            authorization_request.intitule = 'New intitule'
+          end
+
+          context 'when there is an update on a key present in the legacy diff' do
+            it 'uses the legacy diff last value as previous, not the authorization snapshot' do
+              expect(changelog.diff['intitule']).to eq([legacy_intitule, 'New intitule'])
+            end
+          end
+        end
       end
     end
 

--- a/spec/services/authorization_request_changelog_presenter_spec.rb
+++ b/spec/services/authorization_request_changelog_presenter_spec.rb
@@ -94,11 +94,20 @@ RSpec.describe AuthorizationRequestChangelogPresenter do
         it { is_expected.to eq('submit_with_changes') }
       end
 
-      context 'when legacy is true on an old changelog' do
+      context 'when legacy is true on a previous changelog but not the current one' do
         let(:legacy) { true }
-        let(:diff) { {} }
 
-        it { is_expected.to eq('legacy_submit_without_changes') }
+        context 'when there is no diff' do
+          let(:diff) { {} }
+
+          it { is_expected.to eq('submit_without_changes') }
+        end
+
+        context 'when there is diff' do
+          let(:diff) { { 'attr1' => %w[value1 value2] } }
+
+          it { is_expected.to eq('submit_with_changes') }
+        end
       end
     end
   end

--- a/spec/services/authorization_request_changelog_presenter_spec.rb
+++ b/spec/services/authorization_request_changelog_presenter_spec.rb
@@ -97,16 +97,34 @@ RSpec.describe AuthorizationRequestChangelogPresenter do
       context 'when legacy is true on a previous changelog but not the current one' do
         let(:legacy) { true }
 
-        context 'when there is no diff' do
-          let(:diff) { {} }
+        context 'when there is an authorization snapshot' do
+          before { create(:authorization, request: authorization_request) }
 
-          it { is_expected.to eq('submit_without_changes') }
+          context 'when there is no diff' do
+            let(:diff) { {} }
+
+            it { is_expected.to eq('submit_without_changes') }
+          end
+
+          context 'when there is diff' do
+            let(:diff) { { 'attr1' => %w[value1 value2] } }
+
+            it { is_expected.to eq('submit_with_changes') }
+          end
         end
 
-        context 'when there is diff' do
-          let(:diff) { { 'attr1' => %w[value1 value2] } }
+        context 'when there is no authorization snapshot' do
+          context 'when there is no diff' do
+            let(:diff) { {} }
 
-          it { is_expected.to eq('submit_with_changes') }
+            it { is_expected.to eq('legacy_submit_without_changes') }
+          end
+
+          context 'when there is diff' do
+            let(:diff) { { 'attr1' => %w[value1 value2] } }
+
+            it { is_expected.to eq('legacy_submit_with_changes') }
+          end
         end
       end
     end


### PR DESCRIPTION

La méthode any_changelog_legacy? propageait le statut legacy à tous les changelogs récents d'une demande dès qu'un seul ancien changelog était legacy: true — ce qui est le cas de toute demande existant avant la migration d'août 2024.

Conséquence : une soumission sans modification après réouverture affichait "certains changements ont pu être effectués mais sont absents de cet événement car provenant d'une ancienne version du logiciel", alors que le diff vide était correct et que le message submit_without_changes existait déjà pour ce cas.

Le flag legacy ne doit qualifier que le changelog courant, pas la demande entière. Suppression de la condition parasite sur les changelogs voisins.