### PR TITLE
Fix missing previous button on personal_data wizard step

### DIFF
--- a/app/views/authorization_request_forms/build/_wizard_buttons.html.erb
+++ b/app/views/authorization_request_forms/build/_wizard_buttons.html.erb
@@ -1,7 +1,7 @@
 <% content_for :sticky_bar do %>
   <div class="fr-container fr-grid-row">
     <div class="fr-col">
-      <% if defined?(previous_wizard_path) && !current_page?(previous_wizard_path) && !request.path.include?(previous_wizard_path) %>
+      <% if defined?(previous_wizard_path) && !current_page?(previous_wizard_path) %>
         <%= link_to t('authorization_request_forms.form.previous'), previous_wizard_path, id: :previous_authorization_request, class: %w(fr-btn fr-btn--secondary fr-icon-arrow-left-fill fr-btn--icon-left) %>
       <% end %>
     </div>

--- a/features/habilitation_en_plusieurs_etapes.feature
+++ b/features/habilitation_en_plusieurs_etapes.feature
@@ -49,3 +49,12 @@ Fonctionnalité: Interactions sur une demande d'habilitation en plusieurs étape
     Alors il y a un message d'erreur contenant "Nom du projet doit être"
     Et la page contient "Nom du projet"
 
+  Scénario: Le bouton précédent s'affiche sur l'étape "traitement des données personnelles" quand l'étape précédente est "données"
+    Quand je veux remplir une demande pour "API Entreprise" via le formulaire "Socle de base DLNUF"
+    Et que je clique sur "Débuter ma demande"
+    Et que je renseigne les infos de bases du projet
+    Et que je clique sur "Suivant"
+    Et que je clique sur "Suivant"
+    Alors la page contient "Le traitement des données personnelles"
+    Et la page contient "Précédent"
+


### PR DESCRIPTION
The condition `!request.path.include?(previous_wizard_path)` used a substring check instead of an equality check. The `scopes` step translates to `donnees` in French while `personal_data` translates to `donnees-personnelles`. Since `donnees` is a substring of `donnees-personnelles`, the check incorrectly evaluated to false, hiding the previous button whenever the user reached the personal_data step coming from scopes.

`!current_page?(previous_wizard_path)` already handles the first-step case where no previous button should appear, making the `include?` check redundant and harmful. Removing it is sufficient.