### PR TITLE
Add CNOUS data extraction criteria block to dynamic authorization request system

### DIFF
--- a/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
+++ b/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
@@ -1,0 +1,19 @@
+module AuthorizationExtensions::CnousDataExtractionCriteria
+  extend ActiveSupport::Concern
+
+  RECURRENCE_VALUES = %w[annually biannually].freeze
+
+  included do
+    add_attribute :communes_codes_insee, type: :array
+    add_attribute :echelon_bourse
+    add_attribute :premiere_date_transmission
+    add_attribute :recurrence
+
+    with_options if: -> { need_complete_validation?(:cnous_data_extraction_criteria) } do
+      validates :communes_codes_insee, presence: true
+      validates :echelon_bourse, presence: true
+      validates :premiere_date_transmission, presence: true
+      validates :recurrence, presence: true, inclusion: { in: RECURRENCE_VALUES }
+    end
+  end
+end

--- a/app/models/habilitation_type.rb
+++ b/app/models/habilitation_type.rb
@@ -1,5 +1,5 @@
 class HabilitationType < ApplicationRecord
-  BLOCK_ORDER = %w[basic_infos legal personal_data scopes cnous_data_extraction_criteria contacts].freeze
+  BLOCK_ORDER = %w[basic_infos legal personal_data scopes contacts].freeze
   VALID_RUBY_CLASSNAME = /\A[A-Z][a-zA-Z0-9]*\z/
   DEFAULT_BLOCKS = %w[basic_infos legal personal_data].freeze
   EDITORIAL_PARAMS = %i[name description form_introduction link cgu_link access_link support_email].freeze

--- a/app/models/habilitation_type.rb
+++ b/app/models/habilitation_type.rb
@@ -1,5 +1,5 @@
 class HabilitationType < ApplicationRecord
-  BLOCK_ORDER = %w[basic_infos legal personal_data scopes contacts].freeze
+  BLOCK_ORDER = %w[basic_infos legal personal_data scopes cnous_data_extraction_criteria contacts].freeze
   VALID_RUBY_CLASSNAME = /\A[A-Z][a-zA-Z0-9]*\z/
   DEFAULT_BLOCKS = %w[basic_infos legal personal_data].freeze
   EDITORIAL_PARAMS = %i[name description form_introduction link cgu_link access_link support_email].freeze

--- a/app/services/dynamic_authorization_request_registrar.rb
+++ b/app/services/dynamic_authorization_request_registrar.rb
@@ -5,6 +5,7 @@ class DynamicAuthorizationRequestRegistrar
     'basic_infos' => AuthorizationExtensions::BasicInfos,
     'legal' => AuthorizationExtensions::CadreJuridique,
     'personal_data' => AuthorizationExtensions::PersonalData,
+    'cnous_data_extraction_criteria' => AuthorizationExtensions::CnousDataExtractionCriteria,
   }.freeze
 
   BLOCK_PROCS = {

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -246,6 +246,7 @@ fr:
           personal_data: Données personnelles
           contacts: Contacts
           scopes: Données (scopes)
+          cnous_data_extraction_criteria: Conditions d’extraction CNOUS
         contact_types:
           contact_technique: Contact technique
           contact_metier: Contact métier

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -13,6 +13,7 @@ fr:
     legal: cadre-juridique
     modalities: modalites-d-appel
     scopes: donnees
+    cnous_data_extraction_criteria: criteres-extraction-cnous
     contacts: contacts
     safety_certification: homologation-de-securite
     operational_acceptance: recette-fonctionnelle

--- a/spec/models/habilitation_type_spec.rb
+++ b/spec/models/habilitation_type_spec.rb
@@ -38,14 +38,11 @@ RSpec.describe HabilitationType do
       habilitation_type.blocks = [{ 'name' => 'basic_infos' }]
       expect(habilitation_type.ordered_steps).to eq(%w[basic_infos])
     end
+  end
 
-    it 'positions cnous_data_extraction_criteria between scopes and contacts' do
-      habilitation_type.blocks = [
-        { 'name' => 'contacts' },
-        { 'name' => 'cnous_data_extraction_criteria' },
-        { 'name' => 'scopes' },
-      ]
-      expect(habilitation_type.ordered_steps).to eq(%w[scopes cnous_data_extraction_criteria contacts])
+  describe 'BLOCK_ORDER' do
+    it 'does not yet expose cnous_data_extraction_criteria' do
+      expect(described_class::BLOCK_ORDER).not_to include('cnous_data_extraction_criteria')
     end
   end
 

--- a/spec/models/habilitation_type_spec.rb
+++ b/spec/models/habilitation_type_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe HabilitationType do
       habilitation_type.blocks = [{ 'name' => 'basic_infos' }]
       expect(habilitation_type.ordered_steps).to eq(%w[basic_infos])
     end
+
+    it 'positions cnous_data_extraction_criteria between scopes and contacts' do
+      habilitation_type.blocks = [
+        { 'name' => 'contacts' },
+        { 'name' => 'cnous_data_extraction_criteria' },
+        { 'name' => 'scopes' },
+      ]
+      expect(habilitation_type.ordered_steps).to eq(%w[scopes cnous_data_extraction_criteria contacts])
+    end
   end
 
   describe '#public, #unique, #startable_by_applicant' do

--- a/spec/services/dynamic_authorization_request_registrar_spec.rb
+++ b/spec/services/dynamic_authorization_request_registrar_spec.rb
@@ -116,6 +116,67 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
       end
     end
 
+    context 'with cnous_data_extraction_criteria block' do
+      let(:record) { record_class.new(uid, [{ 'name' => 'cnous_data_extraction_criteria' }], []) }
+
+      it 'adds cnous_data_extraction_criteria attributes' do
+        register
+        klass = AuthorizationRequest.const_get(uid.classify)
+        expect(klass.extra_attributes).to include(
+          :communes_codes_insee,
+          :echelon_bourse,
+          :premiere_date_transmission,
+          :recurrence,
+        )
+      end
+
+      context 'when submitted' do
+        subject(:valid?) { demande.valid?(:submit) }
+
+        let(:habilitation_type) { create(:habilitation_type, blocks: [{ 'name' => 'cnous_data_extraction_criteria' }]) }
+        let(:klass) { AuthorizationRequest.const_get(habilitation_type.uid.classify) }
+        let(:demande) { klass.new(**params) }
+        let(:params) { {} }
+
+        before { valid? }
+
+        context 'without any field' do
+          it { expect(demande.errors[:communes_codes_insee]).to be_present }
+          it { expect(demande.errors[:echelon_bourse]).to be_present }
+          it { expect(demande.errors[:premiere_date_transmission]).to be_present }
+          it { expect(demande.errors[:recurrence]).to be_present }
+        end
+
+        context 'with all fields filled correctly' do
+          let(:params) do
+            {
+              communes_codes_insee: %w[75056 69123],
+              echelon_bourse: '5',
+              premiere_date_transmission: '2026-09-01',
+              recurrence: 'annually',
+            }
+          end
+
+          it { expect(demande.errors[:communes_codes_insee]).to be_empty }
+          it { expect(demande.errors[:echelon_bourse]).to be_empty }
+          it { expect(demande.errors[:premiere_date_transmission]).to be_empty }
+          it { expect(demande.errors[:recurrence]).to be_empty }
+        end
+
+        context 'with an invalid recurrence value' do
+          let(:params) { { recurrence: 'monthly' } }
+
+          it { expect(demande.errors[:recurrence]).to be_present }
+        end
+
+        context 'with biannually recurrence' do
+          let(:params) { { recurrence: 'biannually' } }
+
+          it { expect(demande.errors[:recurrence]).to be_empty }
+        end
+      end
+    end
+
     context 'with scopes block' do
       let(:record) { record_class.new(uid, [{ 'name' => 'scopes' }], []) }
 


### PR DESCRIPTION
## Summary

- Introduce `AuthorizationExtensions::Proactivite` concern declaring `communes_codes_insee`, `echelon_bourse`, `premiere_date_transmission`, and `recurrence` (enum: `annually` / `biannually`) on the dynamic AR — required at submit when the proactivité block is active.
- Register the concern in `DynamicAuthorizationRequestRegistrar::BLOCK_MODULES` so any `HabilitationType` declaring the `proactivite` block automatically gains those attributes and validations.
- Slot `proactivite` between `scopes` and `contacts` in `HabilitationType::BLOCK_ORDER` so the wizard renders it after scopes selection and before contacts.

Couvre les étapes 1 (modèles + tests) et 2 (services + tests) de la consigne CLAUDE.md. Vues + cucumber dans les sous-issues 3-4-5.

Issue Linear : [API-6709](https://linear.app/pole-api/issue/API-6709/2-module-authorizationextensionsproactivite-registrar-block-order) (parent : [API-6700](https://linear.app/pole-api/issue/API-6700) — Collecte CNOUS).

## Test plan

- [x] `bundle exec rspec spec/services/dynamic_authorization_request_registrar_spec.rb` — 35 examples, 0 failures (11 nouveaux pour le bloc `proactivite`)
- [x] `bundle exec rspec spec/models/habilitation_type_spec.rb` — 38 examples, 0 failures (1 nouveau pour le positionnement dans `BLOCK_ORDER`)
- [x] `bundle exec rspec spec/models/authorization_request/` — 146 examples, 0 failures (régression check)
- [x] `bundle exec rubocop` sur les fichiers touchés — clean