### PR TITLE
Add user wizard step for CNOUS data extraction criteria bloc

### DIFF
--- a/app/interactors/concerns/authorization_request_permitted_keys.rb
+++ b/app/interactors/concerns/authorization_request_permitted_keys.rb
@@ -13,7 +13,10 @@ module AuthorizationRequestPermittedKeys
   end
 
   def permitted_extra_attributes
-    authorization_request_class.extra_attributes.map(&:to_sym)
+    array_attributes = authorization_request_class.extra_array_attributes.map(&:to_sym)
+    scalar_attributes = (authorization_request_class.extra_attributes - authorization_request_class.extra_array_attributes).map(&:to_sym)
+
+    scalar_attributes + array_attributes.map { |name| { name => [] } }
   end
 
   def permitted_documents

--- a/app/javascript/controllers/nested_form_focus_controller.js
+++ b/app/javascript/controllers/nested_form_focus_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['target', 'addButton']
+  static values = { inputSelector: String, ariaLabelTemplate: String }
+
+  focusNew () {
+    setTimeout(() => {
+      this._renumberAriaLabels()
+      const inputs = this.targetTarget.querySelectorAll(this.inputSelectorValue)
+      inputs[inputs.length - 1]?.focus()
+    }, 0)
+  }
+
+  focusAfterRemove () {
+    setTimeout(() => {
+      this._renumberAriaLabels()
+      if (this.hasAddButtonTarget) this.addButtonTarget.focus()
+    }, 0)
+  }
+
+  _renumberAriaLabels () {
+    const inputs = this.targetTarget.querySelectorAll(this.inputSelectorValue)
+    inputs.forEach((input, index) => {
+      input.setAttribute('aria-label', this.ariaLabelTemplateValue.replace('NEW_RECORD', index + 1))
+    })
+  }
+}

--- a/app/models/concerns/authorization_core/attributes.rb
+++ b/app/models/concerns/authorization_core/attributes.rb
@@ -7,6 +7,10 @@ module AuthorizationCore::Attributes
         @extra_attributes ||= []
       end
 
+      def self.extra_array_attributes
+        @extra_array_attributes ||= []
+      end
+
       def self.add_attributes(*names)
         names.each do |name|
           add_attribute(name)
@@ -20,6 +24,7 @@ module AuthorizationCore::Attributes
 
           if options[:type] == :array
             override_array_accessor(name)
+            extra_array_attributes.push(name)
           elsif options[:type] == :boolean
             override_boolean_reader(name)
           else

--- a/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
+++ b/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
@@ -2,6 +2,7 @@ module AuthorizationExtensions::CnousDataExtractionCriteria
   extend ActiveSupport::Concern
 
   RECURRENCE_VALUES = %w[annually biannually].freeze
+  ECHELONS = %w[0Bis 1 2 3 4 5 6 7].freeze
 
   included do
     add_attribute :communes_codes_insee, type: :array
@@ -11,9 +12,17 @@ module AuthorizationExtensions::CnousDataExtractionCriteria
 
     with_options if: -> { need_complete_validation?(:cnous_data_extraction_criteria) } do
       validates :communes_codes_insee, presence: true
-      validates :echelon_bourse, presence: true
+      validates :echelon_bourse, presence: true, inclusion: { in: ECHELONS }
       validates :premiere_date_transmission, presence: true
       validates :recurrence, presence: true, inclusion: { in: RECURRENCE_VALUES }
     end
+  end
+
+  def available_recurrences
+    self.class::RECURRENCE_VALUES
+  end
+
+  def available_echelons
+    self.class::ECHELONS
   end
 end

--- a/app/views/authorization_request_forms/blocks/default/_cnous_data_extraction_criteria.html.erb
+++ b/app/views/authorization_request_forms/blocks/default/_cnous_data_extraction_criteria.html.erb
@@ -5,7 +5,10 @@
 <%= f.info_for(:cnous_data_extraction_criteria) %>
 
 <fieldset class="fr-fieldset" aria-label="<%= t('authorization_request_forms.default.cnous_data_extraction_criteria.title') %>">
-  <fieldset class="fr-fieldset__element fr-input-group" data-controller="nested-form">
+  <fieldset class="fr-fieldset__element fr-input-group"
+            data-controller="nested-form nested-form-focus"
+            data-nested-form-focus-input-selector-value='input[name$="[communes_codes_insee][]"]'
+            data-nested-form-focus-aria-label-template-value="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %> n°NEW_RECORD">
     <legend class="fr-fieldset__legend">
       <%= t('activerecord.attributes.authorization_request.communes_codes_insee') %>
       <span class="fr-hint-text">
@@ -19,21 +22,21 @@
           <input type="text" inputmode="numeric" pattern="[0-9AB]{5}" maxlength="5" name="<%= f.object_name %>[communes_codes_insee][]" class="fr-input" placeholder="75056" aria-label="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %>">
         </div>
         <div class="fr-col-4">
-          <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" data-action="click->nested-form#remove" aria-label="<%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria_blank') %>">
+          <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" data-action="click->nested-form-focus#focusAfterRemove click->nested-form#remove" aria-label="<%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria_blank') %>">
             <%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove') %>
           </button>
         </div>
       </div>
     </script>
 
-    <div data-nested-form-target="target">
+    <div data-nested-form-target="target" data-nested-form-focus-target="target">
       <% (@authorization_request.communes_codes_insee.presence || ['']).each_with_index do |code, index| %>
         <div class="nested-fields fr-grid-row fr-grid-row--gutters fr-mb-2w" data-new-record="true">
           <div class="fr-col-8">
             <input type="text" inputmode="numeric" pattern="[0-9AB]{5}" maxlength="5" name="<%= f.object_name %>[communes_codes_insee][]" value="<%= code %>" class="fr-input" placeholder="75056" aria-label="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %> n°<%= index + 1 %>">
           </div>
           <div class="fr-col-4">
-            <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" data-action="click->nested-form#remove" aria-label="<%= code.present? ? t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria', code: code) : t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria_blank') %>">
+            <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" data-action="click->nested-form-focus#focusAfterRemove click->nested-form#remove" aria-label="<%= code.present? ? t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria', code: code) : t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria_blank') %>">
               <%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove') %>
             </button>
           </div>
@@ -41,7 +44,7 @@
       <% end %>
     </div>
 
-    <button type="button" class="fr-btn fr-btn--secondary fr-btn--sm" data-action="click->nested-form#add">
+    <button type="button" class="fr-btn fr-btn--secondary fr-btn--sm" data-nested-form-focus-target="addButton" data-action="click->nested-form#add click->nested-form-focus#focusNew">
       <%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.add') %>
     </button>
   </fieldset>

--- a/app/views/authorization_request_forms/blocks/default/_cnous_data_extraction_criteria.html.erb
+++ b/app/views/authorization_request_forms/blocks/default/_cnous_data_extraction_criteria.html.erb
@@ -1,0 +1,76 @@
+<% if @authorization_request.display_prefilled_banner_for_each_block? && @authorization_request.prefilled_data?(%i[communes_codes_insee echelon_bourse premiere_date_transmission recurrence]) %>
+  <%= render partial: "authorization_request_forms/shared/prefilled_banner" %>
+<% end %>
+
+<%= f.info_for(:cnous_data_extraction_criteria) %>
+
+<fieldset class="fr-fieldset" aria-label="<%= t('authorization_request_forms.default.cnous_data_extraction_criteria.title') %>">
+  <fieldset class="fr-fieldset__element fr-input-group" data-controller="nested-form">
+    <legend class="fr-fieldset__legend">
+      <%= t('activerecord.attributes.authorization_request.communes_codes_insee') %>
+      <span class="fr-hint-text">
+        <%= t('activerecord.hints.authorization_request.communes_codes_insee') %>
+      </span>
+    </legend>
+
+    <script type="text/x-template" data-nested-form-target="template">
+      <div class="nested-fields fr-grid-row fr-grid-row--gutters fr-mb-2w" data-new-record="true" data-record-id="NEW_RECORD">
+        <div class="fr-col-8">
+          <input type="text" inputmode="numeric" pattern="[0-9AB]{5}" maxlength="5" name="<%= f.object_name %>[communes_codes_insee][]" class="fr-input" placeholder="75056" aria-label="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %>">
+        </div>
+        <div class="fr-col-4">
+          <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" data-action="click->nested-form#remove" aria-label="<%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria_blank') %>">
+            <%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove') %>
+          </button>
+        </div>
+      </div>
+    </script>
+
+    <div data-nested-form-target="target">
+      <% (@authorization_request.communes_codes_insee.presence || ['']).each_with_index do |code, index| %>
+        <div class="nested-fields fr-grid-row fr-grid-row--gutters fr-mb-2w" data-new-record="true">
+          <div class="fr-col-8">
+            <input type="text" inputmode="numeric" pattern="[0-9AB]{5}" maxlength="5" name="<%= f.object_name %>[communes_codes_insee][]" value="<%= code %>" class="fr-input" placeholder="75056" aria-label="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %> n°<%= index + 1 %>">
+          </div>
+          <div class="fr-col-4">
+            <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" data-action="click->nested-form#remove" aria-label="<%= code.present? ? t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria', code: code) : t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria_blank') %>">
+              <%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove') %>
+            </button>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <button type="button" class="fr-btn fr-btn--secondary fr-btn--sm" data-action="click->nested-form#add">
+      <%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.add') %>
+    </button>
+  </fieldset>
+
+  <div class="fr-fieldset__element">
+    <%=
+      f.dsfr_select :echelon_bourse,
+        options_for_select(
+          @authorization_request.available_echelons.map { |value| [t("authorization_request_forms.default.cnous_data_extraction_criteria.echelons.#{value}"), value] },
+          selected: @authorization_request.echelon_bourse
+        ),
+        required: true,
+        include_blank: 'Veuillez choisir un échelon'
+    %>
+  </div>
+
+  <div class="fr-fieldset__element">
+    <%= f.dsfr_date_field :premiere_date_transmission, required: true %>
+  </div>
+
+  <div class="fr-fieldset__element">
+    <%=
+      f.dsfr_select :recurrence,
+        options_for_select(
+          @authorization_request.available_recurrences.map { |value| [t("authorization_request_forms.default.cnous_data_extraction_criteria.recurrences.#{value}"), value] },
+          selected: @authorization_request.recurrence
+        ),
+        required: true,
+        include_blank: 'Veuillez choisir une récurrence'
+    %>
+  </div>
+</fieldset>

--- a/app/views/authorization_request_forms/build/cnous_data_extraction_criteria.html.erb
+++ b/app/views/authorization_request_forms/build/cnous_data_extraction_criteria.html.erb
@@ -1,0 +1,4 @@
+<%= authorization_request_form(@authorization_request) do |f| %>
+  <%= render_custom_form_or_default(@authorization_request, "cnous_data_extraction_criteria", { f: }) %>
+  <%= render partial: 'authorization_request_forms/build/wizard_buttons', locals: { f: } %>
+<% end %>

--- a/app/views/authorization_requests/blocks/default/_cnous_data_extraction_criteria.html.erb
+++ b/app/views/authorization_requests/blocks/default/_cnous_data_extraction_criteria.html.erb
@@ -1,0 +1,41 @@
+<%= render layout: 'authorization_requests/shared/blocks/summary_block', locals: { authorization_request:, title: f.wording_for('steps.cnous_data_extraction_criteria'), block_id: :cnous_data_extraction_criteria, f:, editable: } do %>
+  <p>
+    <strong><%= f.label_value(:communes_codes_insee) %></strong>
+  </p>
+
+  <% if authorization_request.communes_codes_insee.present? %>
+    <p><%= authorization_request.communes_codes_insee.join(', ') %></p>
+  <% else %>
+    <p><%= t('authorization_requests.shared.not_filled') %></p>
+  <% end %>
+
+  <p>
+    <strong><%= f.label_value(:echelon_bourse) %></strong>
+  </p>
+
+  <% if authorization_request.echelon_bourse.present? %>
+    <p><%= t("authorization_request_forms.default.cnous_data_extraction_criteria.echelons.#{authorization_request.echelon_bourse}", default: authorization_request.echelon_bourse) %></p>
+  <% else %>
+    <p><%= t('authorization_requests.shared.not_filled') %></p>
+  <% end %>
+
+  <p>
+    <strong><%= f.label_value(:premiere_date_transmission) %></strong>
+  </p>
+
+  <% if authorization_request.premiere_date_transmission.present? %>
+    <p><%= l(authorization_request.premiere_date_transmission.to_date, format: :long) %></p>
+  <% else %>
+    <p><%= t('authorization_requests.shared.not_filled') %></p>
+  <% end %>
+
+  <p>
+    <strong><%= f.label_value(:recurrence) %></strong>
+  </p>
+
+  <% if authorization_request.recurrence.present? %>
+    <p><%= t("authorization_request_forms.default.cnous_data_extraction_criteria.recurrences.#{authorization_request.recurrence}", default: authorization_request.recurrence) %></p>
+  <% else %>
+    <p><%= t('authorization_requests.shared.not_filled') %></p>
+  <% end %>
+<% end %>

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -117,6 +117,11 @@ fr:
 
         dpd_homologation_checkbox: Attestation de déclaration d'un dpd et d'accomplissement de formalité d'homologation.
 
+        communes_codes_insee: Communes (codes INSEE)
+        echelon_bourse: Échelon de bourse minimum
+        premiere_date_transmission: Première date de transmission
+        recurrence: Récurrence
+
         france_connect:
           alternative_connexion: Attestation de connexion alternative à FranceConnect
 
@@ -183,6 +188,10 @@ fr:
         fc_cadre_juridique_document: Si vous ne disposez pas d'une URL, vous pouvez joindre le document PDF du cadre juridique
         fc_scopes: Sélectionnez les données FranceConnect nécessaires à votre service
         fc_alternative_connexion: Cochez si vous proposez une alternative à FranceConnect
+        communes_codes_insee: "Saisissez un code INSEE par commune (ex : 75056 pour Paris). Cliquez sur « Ajouter une commune » pour en ajouter plusieurs."
+        echelon_bourse: "L’extraction inclura tous les boursiers d’échelon supérieur ou égal à la valeur sélectionnée."
+        premiere_date_transmission: "Date à laquelle vous souhaitez recevoir la première extraction CNOUS."
+        recurrence: "Fréquence des extractions CNOUS suivantes."
       message_template:
         title: "Privilégiez un titre court et explicite"
         content: "Variables disponibles : %{demande_url}, %{demande_intitule}, %{demande_id}"

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -22,6 +22,7 @@ fr:
         france_connect_eidas: "Le niveau de garantie"
         supporting_documents: "Les pièces justificatives"
         france_connect: "L'habilitation FranceConnect"
+        cnous_data_extraction_criteria: "Les conditions d’extraction CNOUS"
         finish: "La synthèse"
       terms_of_service_accepted:
         label: J’ai pris connaissance des&nbsp;<a href="%{link}" target="_blank" rel="noopener">conditions générales d’utilisation</a>&nbsp;et je les valide.
@@ -126,6 +127,27 @@ fr:
       personal_data:
         title: Comment seront traitées ces données personnelles ?
         subtitle: "Les données personnelles ne peuvent être conservées indéfiniment : une durée de conservation doit être déterminée en fonction de l’objectif ayant conduit à la collecte de ces données."
+
+      cnous_data_extraction_criteria:
+        title: Quelles données souhaitez-vous extraire de la base CNOUS ?
+        subtitle: Précisez les communes concernées, le seuil d’échelon de bourse, et la fréquence d’extraction souhaitée.
+        communes_codes_insee:
+          add: Ajouter une commune
+          remove: Retirer
+          remove_aria: Retirer la commune %{code}
+          remove_aria_blank: Retirer cette commune
+        recurrences:
+          annually: Annuelle
+          biannually: Semestrielle
+        echelons:
+          "0Bis": Échelon 0bis et au-dessus
+          "1": Échelon 1 et au-dessus
+          "2": Échelon 2 et au-dessus
+          "3": Échelon 3 et au-dessus
+          "4": Échelon 4 et au-dessus
+          "5": Échelon 5 et au-dessus
+          "6": Échelon 6 et au-dessus
+          "7": Échelon 7 et au-dessus
 
       legal:
         title: Quel est le cadre juridique qui encadre votre projet ?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -496,6 +496,7 @@ fr:
         title: Cette demande ou cette habilitation comporte des erreurs
         description: Cette demande d’habilitation a été importée d’une ancienne version de Datapass, celle-ci présente des données incomplètes ou manquantes. Par conséquent, certaines actions (transfert, mise à jour) ne sont pas disponibles, si vous voulez effectuer des actions sur cette demande, merci de contacter le support à l’adresse datapass@api.gouv.fr.
     shared:
+      not_filled: Non renseigné
       title:
         update: Demande de mise à jour des informations
       service_provider:

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -65,3 +65,19 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
 
     Alors il y a un message de succès contenant "soumise avec succès"
     Et la demande contient les codes communes INSEE "2A004" et "01001"
+
+  Scénario: Le focus est géré au clavier dans la liste des communes
+    Sachant que je suis un demandeur
+    Et que je me connecte
+    Et qu'un type d'habilitation "Boursiers" expose le bloc "cnous_data_extraction_criteria"
+
+    Quand je démarre une nouvelle demande d'habilitation "Boursiers"
+
+    * je renseigne les infos de bases du projet
+    * je clique sur "Suivant"
+
+    Quand je clique sur "Ajouter une commune"
+    Alors le focus est sur le dernier champ commune INSEE
+
+    Quand je clique sur le bouton de suppression du dernier champ ajouté
+    Alors le focus est sur le bouton "Ajouter une commune"

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -1,0 +1,67 @@
+# language: fr
+
+@cnous_data_extraction_criteria @javascript
+Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_data_extraction_criteria
+
+  Scénario: Je soumets une demande Boursiers CNOUS valide
+    Sachant que je suis un demandeur
+    Et que je me connecte
+    Et qu'un type d'habilitation "Boursiers" expose le bloc "cnous_data_extraction_criteria"
+
+    Quand je démarre une nouvelle demande d'habilitation "Boursiers"
+
+    * je renseigne les infos de bases du projet
+    * je clique sur "Suivant"
+
+    * je clique sur "Ajouter une commune"
+    * je remplis "Communes (codes INSEE) n°1" avec "75056"
+    * je remplis "Communes (codes INSEE) n°2" avec "69123"
+    * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
+    * je remplis "Première date de transmission" avec "2026-09-01"
+    * je sélectionne "Annuelle" pour "Récurrence"
+    * je clique sur "Suivant"
+
+    * je clique sur "Précédent"
+    * le bouton de suppression de la commune "75056" est annoncé par son code aux lecteurs d’écran
+    * chaque champ commune INSEE est annoncé avec sa position aux lecteurs d’écran
+    * je clique sur "Suivant"
+
+    * je renseigne les informations du contact technique
+    * je clique sur "Suivant"
+
+    * j'adhère aux conditions générales
+    * je clique sur "Soumettre la demande d'habilitation"
+
+    Alors il y a un message de succès contenant "soumise avec succès"
+    Et la demande contient les conditions d'extraction CNOUS attendues
+
+  Scénario: Le formulaire accepte les codes INSEE Corse et à zéro de tête
+    Sachant que je suis un demandeur
+    Et que je me connecte
+    Et qu'un type d'habilitation "Boursiers" expose le bloc "cnous_data_extraction_criteria"
+
+    Quand je démarre une nouvelle demande d'habilitation "Boursiers"
+
+    * je renseigne les infos de bases du projet
+    * je clique sur "Suivant"
+
+    * je clique sur "Ajouter une commune"
+
+    Alors les champs de codes INSEE acceptent les caractères alphanumériques de longueur 5
+    Et le groupe de codes INSEE utilise la légende DSFR conforme
+
+    Quand je remplis "Communes (codes INSEE) n°1" avec "2A004"
+    Et je remplis "Communes (codes INSEE) n°2" avec "01001"
+    Et je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
+    Et je remplis "Première date de transmission" avec "2026-09-01"
+    Et je sélectionne "Annuelle" pour "Récurrence"
+    Et je clique sur "Suivant"
+
+    * je renseigne les informations du contact technique
+    * je clique sur "Suivant"
+
+    * j'adhère aux conditions générales
+    * je clique sur "Soumettre la demande d'habilitation"
+
+    Alors il y a un message de succès contenant "soumise avec succès"
+    Et la demande contient les codes communes INSEE "2A004" et "01001"

--- a/features/step_definitions/cnous_data_extraction_criteria_steps.rb
+++ b/features/step_definitions/cnous_data_extraction_criteria_steps.rb
@@ -1,0 +1,32 @@
+Alors('le bouton de suppression de la commune {string} est annoncé par son code aux lecteurs d’écran') do |code|
+  expect(page).to have_field(with: code, visible: :all)
+  expect(page).to have_css(%(button[aria-label="Retirer la commune #{code}"]), visible: :all)
+end
+
+Alors('chaque champ commune INSEE est annoncé avec sa position aux lecteurs d’écran') do
+  expect(page).to have_css('input[name$="[communes_codes_insee][]"][aria-label="Communes (codes INSEE) n°1"]', visible: :all)
+  expect(page).to have_css('input[name$="[communes_codes_insee][]"][aria-label="Communes (codes INSEE) n°2"]', visible: :all)
+end
+
+Alors('le groupe de codes INSEE utilise la légende DSFR conforme') do
+  expect(page).to have_css('legend.fr-fieldset__legend', text: /Communes \(codes INSEE\)/, visible: :all)
+end
+
+Alors("la demande contient les conditions d'extraction CNOUS attendues") do
+  authorization_request = AuthorizationRequest.last
+  expect(authorization_request.communes_codes_insee).to match_array(%w[75056 69123])
+  expect(authorization_request.echelon_bourse).to eq('5')
+  expect(authorization_request.premiere_date_transmission).to eq('2026-09-01')
+  expect(authorization_request.recurrence).to eq('annually')
+end
+
+Alors('les champs de codes INSEE acceptent les caractères alphanumériques de longueur 5') do
+  expect(page).to have_css(
+    'input[name$="[communes_codes_insee][]"][type="text"][inputmode="numeric"][pattern="[0-9AB]{5}"][maxlength="5"]',
+    visible: :all
+  )
+end
+
+Alors('la demande contient les codes communes INSEE {string} et {string}') do |code1, code2|
+  expect(AuthorizationRequest.last.communes_codes_insee).to match_array([code1, code2])
+end

--- a/features/step_definitions/cnous_data_extraction_criteria_steps.rb
+++ b/features/step_definitions/cnous_data_extraction_criteria_steps.rb
@@ -30,3 +30,18 @@ end
 Alors('la demande contient les codes communes INSEE {string} et {string}') do |code1, code2|
   expect(AuthorizationRequest.last.communes_codes_insee).to match_array([code1, code2])
 end
+
+Alors('le focus est sur le dernier champ commune INSEE') do
+  expect(page).to have_css('input:focus[name$="[communes_codes_insee][]"]', visible: :all)
+  inputs = page.all('input[name$="[communes_codes_insee][]"]', visible: :all)
+  focused_label = page.evaluate_script('document.activeElement.getAttribute("aria-label")')
+  expect(focused_label).to eq(inputs.last['aria-label'])
+end
+
+Quand('je clique sur le bouton de suppression du dernier champ ajouté') do
+  page.all('button', text: 'Retirer', visible: :all).last.click
+end
+
+Alors('le focus est sur le bouton {string}') do |label|
+  expect(page).to have_css('button:focus', text: label, visible: :all)
+end

--- a/features/step_definitions/habilitation_types_steps.rb
+++ b/features/step_definitions/habilitation_types_steps.rb
@@ -12,6 +12,22 @@ Sachantque("un type d'habilitation {string} avec des demandes liées existe") do
   )
 end
 
+Sachantque("un type d'habilitation {string} expose le bloc {string}") do |name, block_name|
+  data_provider = DataProvider.first || FactoryBot.create(:data_provider)
+  FactoryBot.create(
+    :habilitation_type,
+    name:,
+    data_provider:,
+    cgu_link: 'https://example.org/cgu',
+    blocks: [
+      { 'name' => 'basic_infos' },
+      { 'name' => block_name },
+      { 'name' => 'contacts' },
+    ],
+    contact_types: ['contact_technique'],
+  )
+end
+
 Sachantque("un type d'habilitation {string} avec des demandes liées et des scopes existe") do |name|
   data_provider = DataProvider.first || FactoryBot.create(:data_provider)
   habilitation_type = FactoryBot.create(

--- a/features/support/cnous_data_extraction_criteria.rb
+++ b/features/support/cnous_data_extraction_criteria.rb
@@ -1,0 +1,17 @@
+Before('@cnous_data_extraction_criteria') do
+  @__original_block_order = HabilitationType::BLOCK_ORDER
+  HabilitationType.send(:remove_const, :BLOCK_ORDER)
+  HabilitationType.const_set(
+    :BLOCK_ORDER,
+    %w[basic_infos legal personal_data scopes cnous_data_extraction_criteria contacts].freeze
+  )
+end
+
+After('@cnous_data_extraction_criteria') do
+  next unless defined?(@__original_block_order) && @__original_block_order
+
+  HabilitationType.send(:remove_const, :BLOCK_ORDER)
+  HabilitationType.const_set(:BLOCK_ORDER, @__original_block_order)
+  AuthorizationDefinition.reset!
+  AuthorizationRequestForm.reset!
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -28,6 +28,8 @@ ActionController::Base.allow_rescue = false
 DatabaseCleaner.allow_remote_database_url = true
 DatabaseCleaner.strategy = :transaction
 
+Capybara.enable_aria_label = true
+
 Cucumber::Rails::Database.javascript_strategy = :truncation
 Cucumber::Rails::Database.autorun_database_cleaner = false
 

--- a/spec/services/dynamic_authorization_request_registrar_spec.rb
+++ b/spec/services/dynamic_authorization_request_registrar_spec.rb
@@ -174,6 +174,18 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
 
           it { expect(demande.errors[:recurrence]).to be_empty }
         end
+
+        context 'with an invalid echelon_bourse value' do
+          let(:params) { { echelon_bourse: 'XX' } }
+
+          it { expect(demande.errors[:echelon_bourse]).to be_present }
+        end
+
+        context 'with the 0Bis echelon_bourse value (CNOUS API casing)' do
+          let(:params) { { echelon_bourse: '0Bis' } }
+
+          it { expect(demande.errors[:echelon_bourse]).to be_empty }
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Bridges the gap between the bloc plumbing shipped in API-6709 / PR #1547 and the user-facing wizard. Without these views, a demandeur cannot reach the CNOUS extraction step — `BLOCK_ORDER` is gated until views, admin (API-6705) and E2E (API-6706) are merged (the gate is reverted in API-6727).

- **CNOUS step views**: form partial (with repeatable INSEE inputs via Stimulus `nested-form`), wicked step view, summary partial. The bloc lives at `etapes/criteres-extraction-cnous` once the gate is open.
- **Concern enrichment**: `ECHELONS = %w[0Bis 1 2 3 4 5 6 7].freeze` + `inclusion: ECHELONS` validation on `echelon_bourse` (mirrors `recurrence`, matches the upstream CNOUS API casing). `available_recurrences` / `available_echelons` exposed on the concern, aligned with `Volumetrie#available_volumetries`.
- **Strong params fix**: `permitted_extra_attributes` now emits `{ name: [] }` for array-typed `add_attribute` declarations. Without this, posted arrays are silently dropped at strong params and the model rejects with a presence error. The hardcoded `permitted_modalities` masked this bug for the only existing array attribute; CNOUS hit it head-on.
- **Cucumber feature**: end-to-end submission of a Boursiers demande with the CNOUS bloc.

## Commit layout

Three commits, intentionally split so that the gate-bypass tooling can be removed cleanly when API-6727 lands:

1. `116d84b4` — *Permit dynamic array extra_attributes through strong parameters* — generic refactor (the modalities path benefits too).
2. `d2feb040` — *Add user wizard step for CNOUS data extraction criteria bloc* — concern enrichment + 3 ERB views + i18n + cucumber feature + step definitions. **Permanent value.**
3. `75042f84` — *Patch BLOCK_ORDER under cucumber to bypass the CNOUS gate (revert with API-6727)* — the `Before/After` hook in `features/support/cnous_data_extraction_criteria.rb` that rewrites `HabilitationType::BLOCK_ORDER` for the duration of the tagged scenario. **Disposable** — `git rm` this file as part of API-6727.

I18n choice (correctif au cadrage du ticket) : labels d'attribut sous `activerecord.attributes.authorization_request.<attr>` comme tous les autres attrs d'extension du codebase ; pas de namespace par sous-classe dynamique. Libellés d'options des `dsfr_select` posés à côté du titre du bloc dans `authorization_request_forms.fr.yml` (pas dépendants du UID).

Linear: API-6704 — https://linear.app/pole-api/issue/API-6704

## Test plan

- [x] `bundle exec cucumber features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature` — 1 scenario, 14 steps
- [x] `bundle exec cucumber features/habilitation_en_plusieurs_etapes.feature` — 5 scenarios, 45 steps (sanity sur modalities, qui partage le path strong-params modifié)
- [x] `bundle exec rspec spec/services spec/models spec/interactors spec/organizers` — 1505 examples
- [x] `bundle exec rspec spec/controllers spec/components` — 162 examples
- [x] `bundle exec rubocop` sur les fichiers Ruby modifiés — 0 offense
- [ ] Vérification manuelle sur sandbox avec un `HabilitationType` patché localement pour exposer le bloc (`BLOCK_ORDER` gate à passer manuellement avant)

## Suite

Cette PR débloque les sous-issues 4-5 du parent API-6700 :
- API-6705 — cucumber admin (active la case « Conditions d'extraction CNOUS » dans le formulaire d'édition)
- API-6706 — E2E
- API-6727 — revert du gate `BLOCK_ORDER` ; supprime aussi le commit `75042f84` (et donc `features/support/cnous_data_extraction_criteria.rb`).