### PR TITLE
Limite le nombre de fichiers uploadés à 6 par champ document

### DIFF
--- a/app/models/concerns/authorization_core/documents.rb
+++ b/app/models/concerns/authorization_core/documents.rb
@@ -24,10 +24,13 @@ module AuthorizationCore::Documents
         @documents ||= []
       end
 
+      MAX_FILES_PER_DOCUMENT = 6
+
       def self.add_documents(name, validation_options = {})
+        merged_options = { limit: { max: MAX_FILES_PER_DOCUMENT } }.merge(validation_options)
         class_eval do
           has_many_attached name
-          validates name, validation_options unless ENV['SKIP_DOCUMENT_VALIDATION']
+          validates name, merged_options unless ENV['SKIP_DOCUMENT_VALIDATION']
 
           documents << DocumentType.new(name:, multiple: true)
         end

--- a/spec/models/concerns/authorization_core/documents_spec.rb
+++ b/spec/models/concerns/authorization_core/documents_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe AuthorizationCore::Documents do
+  let(:pdf_file) { Rack::Test::UploadedFile.new('spec/fixtures/dummy.pdf', 'application/pdf') }
+
+  describe 'MAX_FILES_PER_DOCUMENT' do
+    it 'is set to 6' do
+      expect(AuthorizationCore::Documents::MAX_FILES_PER_DOCUMENT).to eq(6)
+    end
+  end
+
+  describe 'file limit validation' do
+    let(:authorization_request) { build(:authorization_request, :api_declaration_cesu) }
+
+    context 'when the number of files does not exceed the limit' do
+      before do
+        authorization_request.maquette_projet.attach(Array.new(6) { pdf_file })
+      end
+
+      it 'is valid' do
+        expect(authorization_request).to be_valid
+      end
+    end
+
+    context 'when the number of files exceeds the limit' do
+      before do
+        authorization_request.maquette_projet.attach(Array.new(7) { pdf_file })
+      end
+
+      it 'is invalid' do
+        expect(authorization_request).not_to be_valid
+      end
+
+      it 'adds an explicit error message on the document field' do
+        authorization_request.valid?
+        expect(authorization_request.errors[:maquette_projet]).to include(
+          'trop de fichiers joints (le maximum autorisé est 6 fichiers, obtenu 7)'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sans cette limite, un utilisateur pouvait attacher un nombre illimité de fichiers à chaque champ document d'une demande.