### PR TITLE
Corrige les form_uid stales après la migration des slugs DataDyn

### DIFF
--- a/db/migrate/20260505092509_fix_dyn_form_uids_after_slug_suffix_migration.rb
+++ b/db/migrate/20260505092509_fix_dyn_form_uids_after_slug_suffix_migration.rb
@@ -1,0 +1,83 @@
+class FixDynFormUidsAfterSlugSuffixMigration < ActiveRecord::Migration[8.1]
+  ROLE_TYPES = %w[reporter instructor manager developer].freeze
+  SETTING_PREFIXES = %w[
+    instruction_submit_notifications_for
+    instruction_messages_notifications_for
+  ].freeze
+
+  def up
+    dyn_habilitation_types.each do |slug|
+      sti_class = "AuthorizationRequest::#{slug.tr('-', '_').classify}"
+      canonical_def_id = slug.tr('-', '_')
+      stale_def_ids = stale_def_id_candidates(canonical_def_id, slug)
+
+      fix_form_uid(slug, sti_class)
+      fix_user_roles(canonical_def_id, stale_def_ids)
+      fix_user_settings(canonical_def_id, stale_def_ids)
+    end
+  end
+
+  def down
+    # No-op : the previous state was inconsistent (some records hyphenated, others
+    # underscored, none aligned with the static AuthorizationRequestForm uids).
+  end
+
+  private
+
+  def dyn_habilitation_types
+    execute("SELECT slug FROM habilitation_types WHERE slug LIKE '%-dyn'").to_a.map { |row| row['slug'] }
+  end
+
+  def stale_def_id_candidates(canonical_def_id, slug)
+    [
+      canonical_def_id.delete_suffix('_dyn'), # "test_test"   — pre-suffix-migration form
+      slug,                                   # "test-test-dyn" — hyphenated final form
+      slug.delete_suffix('-dyn'),             # "test-test"   — pre-suffix-migration hyphenated
+    ].uniq.reject { |s| s == canonical_def_id || s.empty? }
+  end
+
+  def fix_form_uid(slug, sti_class)
+    %w[authorization_requests authorizations instructor_draft_requests].each do |table|
+      column = table == 'authorization_requests' ? 'type' : 'authorization_request_class'
+      execute(sanitize(
+        "UPDATE #{table} SET form_uid = ? WHERE #{column} = ? AND form_uid != ?",
+        slug, sti_class, slug
+      ))
+    end
+  end
+
+  def fix_user_roles(canonical_def_id, stale_def_ids)
+    stale_def_ids.each do |stale|
+      pattern = "^([^:]+):#{Regexp.escape(stale)}:([^:]+)$"
+      replacement = "\\1:#{canonical_def_id}:\\2"
+
+      execute(sanitize(<<~SQL.squish, pattern, replacement, "%:#{stale}:%"))
+        UPDATE users
+        SET roles = (
+          SELECT array_agg(regexp_replace(r, ?, ?))
+          FROM unnest(roles) AS r
+        )
+        WHERE EXISTS (SELECT 1 FROM unnest(roles) r WHERE r LIKE ?)
+      SQL
+    end
+  end
+
+  def fix_user_settings(canonical_def_id, stale_def_ids)
+    stale_def_ids.each do |stale|
+      SETTING_PREFIXES.each do |prefix|
+        old_key = "#{prefix}_#{stale}"
+        new_key = "#{prefix}_#{canonical_def_id}"
+
+        execute(sanitize(<<~SQL.squish, old_key, new_key, old_key, old_key))
+          UPDATE users
+          SET settings = (settings - ?) || jsonb_build_object(?, settings -> ?)
+          WHERE jsonb_exists(settings, ?)
+        SQL
+      end
+    end
+  end
+
+  def sanitize(sql, *args)
+    ActiveRecord::Base.sanitize_sql_array([sql, *args])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_092509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"


### PR DESCRIPTION
## Contexte

La migration `20260401152848_add_dyn_suffix_to_habilitation_type_slugs` (mergée sur develop le 1er avril) a renommé les slugs des `HabilitationType` en leur ajoutant un suffixe `-dyn` (par exemple `test-test` → `test-test-dyn`). Pour rester cohérent, elle propage le rename à plusieurs endroits :

- `habilitation_types.slug`
- `authorization_requests.type` (STI class)
- `authorization_requests.form_uid` (et `authorizations`, `instructor_draft_requests`)
- `users.roles`
- `users.settings`

## Le bug

Pour propager le renommage, la migration construit les valeurs cibles via `slug.tr('-', '_')` :

```ruby
def migrate_habilitation_type(from_slug, to_slug)
  from_uid = from_slug.tr('-', '_')   # "test-test" → "test_test"
  to_uid = to_slug.tr('-', '_')       # "test-test-dyn" → "test_test_dyn"
  ...
  update_form_uid(from_uid, to_uid)   # ❌ form_uid utilise les TIRETS
  update_user_roles(from_uid, to_uid) # ✅ def_id dans les roles utilise les UNDERSCORES
  update_user_settings(from_uid, to_uid) # ✅ idem pour les settings keys
end
```

L'hypothèse `tr('-', '_')` est :
- ✅ **correcte** pour `users.roles` (le `def_id` y est l'`AuthorizationDefinition.id` qui utilise les underscores)
- ✅ **correcte** pour `users.settings` (les clés sont du genre `instruction_submit_notifications_for_<def_id_underscored>`)
- ❌ **incorrecte** pour `authorization_requests.form_uid` (qui pointe vers `AuthorizationRequestForm.uid`, format avec **tirets**)

Conséquences :

1. Sur `form_uid`, la clause `WHERE form_uid = 'test_test'` ne matche rien (les valeurs en base ont des tirets) → les records gardent leur ancien `form_uid` au lieu d'être mis à jour vers `test-test-dyn`.
2. Si par hasard un record avait déjà un `form_uid` avec underscores (ex. `api_debug`), la migration *l'a* mis à jour, mais vers `api_debug_dyn` (underscores) au lieu de `api-debug-dyn` (tirets) attendu par le YAML.
3. Sur `roles` et `settings`, **tout est OK en théorie** — mais on l'aligne quand même de manière défensive (cf. plus bas).

## Exemple concret

Sur ma DB de dev, après la migration buggée :

| table | id | type / class STI | form_uid | attendu |
|---|---|---|---|---|
| `authorization_requests` | 121 | `AuthorizationRequest::TestLegalDyn` ✅ | `test-legal` ❌ | `test-legal-dyn` |
| `authorization_requests` | 123 | `AuthorizationRequest::TestTestDyn` ✅ | `test-test` ❌ | `test-test-dyn` |
| `authorization_requests` | 122 | `AuthorizationRequest::APIDebugDyn` ✅ | `api_debug_dyn` ❌ | `api-debug-dyn` |
| `authorizations` | 74 | `AuthorizationRequest::TestLegalDyn` ✅ | `test-legal` ❌ | `test-legal-dyn` |

La colonne `type` (STI) a été correctement migrée parce qu'elle suit le ClassName, pas le slug. Mais `form_uid` est resté désaligné.

## Symptôme côté utilisateur

Quand un user dispose d'une demande/habilitation référençant un `HabilitationType` dynamique, son dashboard plante avec :

```
StaticApplicationRecord::EntryNotFound in Dashboard#show
Couldn't find AuthorizationRequestForm with 'id'='test-test' within static entries
```

L'app fait `AuthorizationRequestForm.find(form_uid)` avec `form_uid = 'test-test'`, mais le YAML statique ne connaît que `test-test-dyn` depuis le 1er avril.

## Périmètre du fix : pourquoi je touche aussi roles + settings

La DB de dev n'est pas représentative de staging/prod. Bien que **l'analyse du code** (cf. ci-dessus) suggère que `users.roles` et `users.settings` ont été correctement migrés par la migration originale (parce que les deux endroits utilisent le format underscore), je préfère **sécuriser** plutôt que parier sur l'état des données réelles.

Cette migration corrective passe donc défensivement sur les 3 zones suivantes pour chaque type dynamique :

### 1. `form_uid` (le bug réel)

Met à jour les 3 tables concernées (`authorization_requests`, `authorizations`, `instructor_draft_requests`), filtrant par classe STI (qui est la source de vérité post-migration) :

```sql
UPDATE authorization_requests
SET form_uid = 'test-test-dyn'
WHERE type = 'AuthorizationRequest::TestTestDyn'
  AND form_uid != 'test-test-dyn';
```

### 2. `users.roles`

Format actuel attendu : 3-part `<provider>:<def_id>:<role_type>` où `def_id` est `AuthorizationDefinition.id` (underscore + suffixe `_dyn`).

Pour chaque type dyn, on cherche les rôles qui pointeraient vers une forme « stale » du `def_id` :
- `<provider>:test_test:reporter` (sans suffixe `_dyn`, pre-2026-04-01)
- `<provider>:test-test-dyn:reporter` (avec tirets, anomalie défensive)
- `<provider>:test-test:reporter` (avec tirets et sans suffixe)

Et on remplace en gardant `<provider>` et `<role_type>` intacts via `regexp_replace` :

```sql
UPDATE users
SET roles = (
  SELECT array_agg(regexp_replace(r, '^([^:]+):test_test:([^:]+)$', '\1:test_test_dyn:\2'))
  FROM unnest(roles) AS r
)
WHERE EXISTS (SELECT 1 FROM unnest(roles) r WHERE r LIKE '%:test_test:%');
```

### 3. `users.settings`

Les clés de settings concernées sont les booléens de notification, déclarés dans `NotificationsSettings` :

```ruby
"instruction_#{name}_for_#{authorization_definition.id.underscore}"
```

Soit deux clés par définition (= toggles UI sur la page profil de l'instructeur) :
- `instruction_submit_notifications_for_<def_id>` — recevoir les emails de soumission d'une demande
- `instruction_messages_notifications_for_<def_id>` — recevoir les emails de nouveau message sur une demande

Pour chaque type dyn, on cherche les clés en forme stale et on les renomme :

```sql
UPDATE users
SET settings = (settings - 'instruction_submit_notifications_for_test_test')
            || jsonb_build_object(
                 'instruction_submit_notifications_for_test_test_dyn',
                 settings -> 'instruction_submit_notifications_for_test_test'
               )
WHERE jsonb_exists(settings, 'instruction_submit_notifications_for_test_test');
```

## Idempotence

Toutes les requêtes sont gardées par une condition « si la valeur cible n'existe pas déjà » (`form_uid != ?`, `EXISTS … LIKE %stale%`, `jsonb_exists(old_key)`). On peut donc rejouer la migration sans risque — testé en local avec un user contenant volontairement les 3 formes stale (mix tirets/underscores/sans-suffixe), et un 2ᵉ run après le 1er ne touche plus aucune ligne.

## Ce que la migration ne fait pas

- Pas de revert (`down` est un no-op explicite). L'état pré-migration était inconsistant (mélange tirets/underscores selon les records), il n'y a pas d'état précédent cohérent à restaurer.
- Pas de touche à `admin_events.before_attributes` / `.after_attributes` : ces JSON contiennent des snapshots de roles, mais sont historiques (pour l'audit). Si on veut les corriger, c'est un travail séparé sur l'historique d'audit — hors scope ici.

Fixes DP-1711