### PR TITLE
chore: officialiser bin/test-parallel (wrapper local parallel_tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ COVERAGE=true bundle exec cucumber
 INSPECTOR=true bundle exec cucumber
 ```
 
+#### Suite en parallèle (aligné avec la CI)
+
+Pour exécuter la suite avec `parallel_tests` (comme la CI), utiliser le wrapper `bin/test-parallel`. Setup une seule fois par worktree :
+
+```sh
+bin/test-parallel setup    # crée les bases de tests parallèles
+bin/test-parallel          # rspec + cucumber en parallèle
+```
+
+Voir [`docs/technique/tests_paralleles.md`](docs/technique/tests_paralleles.md) pour le détail (flag retry opt-in, rerun ciblé, etc.).
+
 ## Static security
 
 Through [Brakeman](https://github.com/presidentbeef/brakeman)

--- a/bin/test-parallel
+++ b/bin/test-parallel
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Run specs and cucumber features in parallel using the parallel_tests gem.
+# Each process gets its own test DB via TEST_ENV_NUMBER (see config/database.yml
+# and the DATABASE_TEST_NAME entry in .env.local).
+#
+# Usage:
+#   bin/test-parallel              # rspec + cucumber, auto-detect process count
+#   bin/test-parallel rspec        # rspec only
+#   bin/test-parallel cucumber     # cucumber only
+#   bin/test-parallel rerun        # replays failures from the last cucumber run
+#   bin/test-parallel setup        # create + load schema on all parallel DBs
+#   bin/test-parallel drop         # drop all parallel test DBs
+#   bin/test-parallel -n 4         # force 4 processes for rspec + cucumber
+#   bin/test-parallel cucumber -r 2  # cucumber with auto-retry (see below)
+#
+# Flakies : par défaut PAS de retry, pour ne pas masquer les flakies en local.
+# Passer `-r N` (cucumber ou all) active --retry N et écrit les scénarios
+# encore en échec après retries dans tmp/cucumber-rerun.txt ; utiliser
+# `bin/test-parallel rerun` pour rejouer uniquement ceux-là.
+#
+# First-time setup (once per worktree): bin/test-parallel setup
+
+set -e
+
+count=""
+retry=""
+cmd="all"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n)
+      count=$2
+      shift 2
+      ;;
+    -r)
+      retry=$2
+      shift 2
+      ;;
+    rspec|cucumber|rerun|setup|drop|all)
+      cmd=$1
+      shift
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [-n COUNT] [-r RETRY] [rspec|cucumber|rerun|setup|drop|all]"
+      exit 1
+      ;;
+  esac
+done
+
+count_arg=""
+if [ -n "$count" ]; then
+  count_arg="-n $count"
+fi
+
+run_setup() {
+  echo "=== Creating parallel test databases ==="
+  RAILS_ENV=test bundle exec rake "parallel:create[${count:-}]"
+  echo "=== Loading schema into parallel test databases ==="
+  RAILS_ENV=test bundle exec rake "parallel:load_schema[${count:-}]"
+}
+
+run_drop() {
+  echo "=== Dropping parallel test databases ==="
+  RAILS_ENV=test bundle exec rake "parallel:drop[${count:-}]"
+}
+
+run_rspec() {
+  echo "=== parallel_rspec $count_arg ==="
+  bundle exec parallel_rspec $count_arg -o '--format progress' spec/
+}
+
+run_cucumber() {
+  echo "=== parallel_cucumber $count_arg ==="
+
+  local cucumber_opts='--format progress'
+  if [ -n "$retry" ]; then
+    mkdir -p tmp/cucumber-rerun
+    rm -f tmp/cucumber-rerun/worker-*.txt tmp/cucumber-rerun.txt
+    cucumber_opts="$cucumber_opts --retry $retry --format rerun --out tmp/cucumber-rerun/worker-TEST_ENV_NUMBER.txt"
+  fi
+
+  set +e
+  bundle exec parallel_cucumber $count_arg -o "$cucumber_opts" features/
+  local exit_code=$?
+  set -e
+
+  if [ -n "$retry" ] && ls tmp/cucumber-rerun/worker-*.txt >/dev/null 2>&1; then
+    cat tmp/cucumber-rerun/worker-*.txt 2>/dev/null | tr ' ' '\n' | grep . > tmp/cucumber-rerun.txt || true
+  fi
+
+  if [ -n "$retry" ] && [ -s tmp/cucumber-rerun.txt ]; then
+    echo ""
+    echo "=== $(wc -l < tmp/cucumber-rerun.txt) scénario(s) failed après retries ==="
+    echo "Détail : tmp/cucumber-rerun.txt"
+    echo "Rejoue : bin/test-parallel rerun"
+  fi
+
+  return $exit_code
+}
+
+run_rerun() {
+  if [ ! -s tmp/cucumber-rerun.txt ]; then
+    echo "Aucun scénario à rejouer (tmp/cucumber-rerun.txt absent ou vide)."
+    exit 0
+  fi
+
+  echo "=== cucumber rerun ($(wc -l < tmp/cucumber-rerun.txt) scénario(s)) ==="
+  xargs -a tmp/cucumber-rerun.txt bundle exec cucumber --format progress --retry 2
+}
+
+case "$cmd" in
+  setup)    run_setup ;;
+  drop)     run_drop ;;
+  rspec)    run_rspec ;;
+  cucumber) run_cucumber ;;
+  rerun)    run_rerun ;;
+  all)      run_rspec && run_cucumber ;;
+esac

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,4 +8,4 @@ development:
 
 test:
   <<: *default
-  database: <%= ENV.fetch('DATABASE_TEST_NAME') { 'data_pass_test' } %>
+  database: <%= ENV.fetch('DATABASE_TEST_NAME') { 'data_pass_test' } %><%= ENV['TEST_ENV_NUMBER'] %>

--- a/docs/technique/tests_paralleles.md
+++ b/docs/technique/tests_paralleles.md
@@ -1,0 +1,77 @@
+# Tests en parallèle
+
+La CI exécute la suite en parallèle via le gem [`parallel_tests`](https://github.com/grosser/parallel_tests) — voir [`.github/workflows/test.yaml`](../../.github/workflows/test.yaml) : RSpec sur 4 groupes, Cucumber sur 6 groupes.
+
+Le wrapper `bin/test-parallel` permet de lancer la même chose en local, en s'appuyant sur les mêmes binstubs (`parallel_rspec` / `parallel_cucumber`) et la même variable d'environnement `TEST_ENV_NUMBER` que la CI.
+
+## Comment ça fonctionne
+
+`parallel_tests` lance N processus de test, chacun reçoit un sous-ensemble des fichiers à exécuter et une variable `TEST_ENV_NUMBER` distincte (vide pour le premier, `2`, `3`, … pour les suivants). Le gem ne touche pas à `ActiveRecord` — c'est à l'application d'utiliser cette variable. Côté DataPass, `config/database.yml` interpole `TEST_ENV_NUMBER` après le nom de base de test :
+
+```yaml
+test:
+  database: <%= ENV.fetch('DATABASE_TEST_NAME') { 'data_pass_test' } %><%= ENV['TEST_ENV_NUMBER'] %>
+```
+
+Résultat : à partir de `DATABASE_TEST_NAME` (défini dans `.env.local`), le suffixe `TEST_ENV_NUMBER` produit `data_pass_test`, `data_pass_test2`, `data_pass_test3`, … Chaque processus a donc sa propre base, ce qui supprime la contention DB qui rend les tests non-déterministes en exécution concurrente sans Docker (voir le warning dans le README). Sans cette interpolation, les N processus taperaient tous sur la même base et provoqueraient des deadlocks au TRUNCATE de fin de test.
+
+## Setup initial (une fois par worktree)
+
+```sh
+bin/test-parallel setup
+```
+
+Crée toutes les bases de tests parallèles et y charge le schéma courant. À rejouer après chaque modification de schéma (nouvelle migration), sinon les processus 2+ tourneront sur un schéma périmé.
+
+Pour supprimer ces bases (quand le worktree est retiré, par exemple) :
+
+```sh
+bin/test-parallel drop
+```
+
+Les tâches `parallel:create` / `parallel:load_schema` sont fournies par le Railtie de `parallel_tests`. Le gem étant déclaré dans `group :test` du Gemfile, ses tâches ne sont visibles qu'avec `RAILS_ENV=test` — d'où le préfixe dans `bin/test-parallel setup`.
+
+## Lancer la suite
+
+```sh
+bin/test-parallel              # rspec + cucumber, nombre de process auto-détecté
+bin/test-parallel rspec        # rspec seul
+bin/test-parallel cucumber     # cucumber seul
+bin/test-parallel -n 4         # force 4 process (rspec + cucumber)
+```
+
+Sans `-n`, le nombre de processus est déterminé par `parallel_tests` à partir des cœurs CPU disponibles.
+
+Le wrapper exécute toujours toute la suite (`spec/` ou `features/`). Pour cibler un fichier précis, repasser sur les commandes classiques (`bundle exec rspec spec/path/to/file_spec.rb`) — le parallèle n'apporte rien à ce niveau-là.
+
+## Flag `-r N` (retry cucumber, opt-in)
+
+Par défaut, aucun retry n'est appliqué. Raisons :
+
+- La CI ne retry pas non plus — garder le même comportement en local évite qu'un scénario flaky passe localement et casse en CI (ou inversement).
+- Un retry masque les flakies sans les remonter : si un scénario échoue 1 fois sur 3, on veut le savoir tôt pour l'attaquer, pas le découvrir des semaines plus tard en CI.
+
+Le flag `-r N` reste utile quand on veut explicitement vérifier qu'un échec donné est dû à un flakie connu, sans avoir à le rejouer à la main :
+
+```sh
+bin/test-parallel cucumber -r 2
+```
+
+Avec `-r`, les scénarios encore en échec après les retries sont écrits dans `tmp/cucumber-rerun.txt`. La sous-commande `rerun` les rejoue (avec `--retry 2`, cette fois en série) :
+
+```sh
+bin/test-parallel rerun
+```
+
+`tmp/cucumber-rerun.txt` est régénéré à chaque run avec `-r`, et n'est jamais touché par les runs sans `-r`.
+
+## Cohérence CI / local
+
+| Aspect           | CI                                    | Local                                 |
+|------------------|---------------------------------------|---------------------------------------|
+| Binstub RSpec    | `parallel_rspec -n 4 --only-group N`  | `parallel_rspec -n COUNT`             |
+| Binstub Cucumber | `parallel_cucumber -n 6 --only-group N` | `parallel_cucumber -n COUNT`        |
+| Variable d'env   | `TEST_ENV_NUMBER`                     | `TEST_ENV_NUMBER`                     |
+| Retry            | non                                   | opt-in via `-r N`                     |
+
+La différence principale : la CI shard la suite en `--only-group` sur plusieurs runners GitHub Actions, le local lance tous les groupes sur la même machine.


### PR DESCRIPTION
## Summary

- Ajoute `bin/test-parallel`, wrapper bash autour de `parallel_rspec` / `parallel_cucumber` pour exécuter la suite en local en parallèle (aligné avec la CI : `.github/workflows/test.yaml`).
- `--retry` est **opt-in** via `-r N` (par défaut pas de retry — mêmes conditions que la CI, et un retry masque les flakies sans les remonter).
- `bin/test-parallel setup` préfixe ses appels rake par `RAILS_ENV=test` (le gem `parallel_tests` est en `group :test` → son Railtie ne charge `parallel:create`/`parallel:load_schema` qu'en env test).
- Doc dans `docs/technique/tests_paralleles.md` + mention dans `README.md` (section *Without docker*).

Linear : [DP-1714](https://linear.app/pole-api/issue/DP-1714).

## Hors-scope (suivis possibles)

- **`-g GROUP`** pour reproduire un job CI précis en local — YAGNI, à rajouter si vrai besoin.
- **Intégration dans `bundle exec rspec`** par défaut — changerait le contrat équipe.
- **Retry par défaut** — explicitement décidé non.

## Test plan

- [ ] `bin/test-parallel setup` sur un worktree neuf crée bien les bases `data_pass_test_wtX`, `data_pass_test_wtX2`, … et y charge le schéma.
- [ ] `bin/test-parallel rspec spec/models/` tourne sans retry.
- [ ] `bin/test-parallel cucumber -r 2` génère bien `tmp/cucumber-rerun.txt` quand un scénario échoue après retries.
- [ ] `bin/test-parallel rerun` rejoue le contenu de `tmp/cucumber-rerun.txt`.
- [ ] `bin/test-parallel --unknown` affiche l'usage et exit 1.
- [ ] CI verte sur cette PR (la PR ne touche pas de code Ruby applicatif, juste un script + doc).