### PR TITLE
Permettre N templates de cas d'usage pour 1 formulaire (DP-1718)

### DIFF
--- a/app/models/authorization_request_form.rb
+++ b/app/models/authorization_request_form.rb
@@ -28,31 +28,48 @@ class AuthorizationRequestForm < StaticApplicationRecord
   end
 
   def self.db_records
-    return [] unless HabilitationType.table_exists?
+    return [] unless FormTemplate.table_exists?
 
-    HabilitationType.includes(:data_provider).filter_map do |record|
-      build_form_from_habilitation_type(record)
+    FormTemplate.includes(:habilitation_type).filter_map do |template|
+      build_form_from_template(template)
     end
   rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
     []
   end
 
-  def self.build_form_from_habilitation_type(record)
-    klass = authorization_request_class_for(record)
+  # rubocop:disable Metrics/AbcSize
+  def self.build_form_from_template(template)
+    klass = authorization_request_class_for(template.habilitation_type)
     return unless klass
 
+    ht = template.habilitation_type
     new(
-      uid: record.slug,
-      default: true,
-      introduction: record.form_introduction,
+      uid: template.slug,
+      default: template.default,
+      name: cascaded(template.name, ht.name),
+      description: cascaded(template.description, ht.description),
+      introduction: cascaded(template.introduction, ht.form_introduction),
+      public: template.public,
+      startable_by_applicant: template.startable_by_applicant,
+      use_case: template.use_case,
+      single_page_view: template.single_page_view,
+      service_provider: template.service_provider,
       authorization_request_class: klass,
-      steps: record.ordered_steps.map { |name| { name: name } },
-      static_blocks: [],
-      service_provider: nil,
-      use_case: nil,
-      single_page_view: nil,
-      scopes_config: {},
+      steps: cascaded_steps(template, ht),
+      static_blocks: template.static_blocks.map(&:deep_symbolize_keys),
+      scopes_config: template.scopes_config.deep_symbolize_keys,
+      initialize_with: template.initialize_with.deep_symbolize_keys,
     )
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def self.cascaded(template_value, fallback)
+    template_value.presence || fallback
+  end
+
+  def self.cascaded_steps(template, habilitation_type)
+    template.steps.presence&.map(&:deep_symbolize_keys) ||
+      habilitation_type.ordered_steps.map { |step_name| { name: step_name } }
   end
 
   def self.authorization_request_class_for(record)
@@ -61,7 +78,7 @@ class AuthorizationRequestForm < StaticApplicationRecord
     nil
   end
 
-  private_class_method :yaml_records, :db_records, :build_form_from_habilitation_type, :authorization_request_class_for
+  private_class_method :yaml_records, :db_records, :build_form_from_template, :cascaded, :cascaded_steps, :authorization_request_class_for
 
   # rubocop:disable Metrics/AbcSize
   def self.build(uid, hash)

--- a/app/models/form_template.rb
+++ b/app/models/form_template.rb
@@ -1,0 +1,68 @@
+class FormTemplate < ApplicationRecord
+  extend FriendlyId
+
+  has_paper_trail
+
+  friendly_id :name, use: :slugged
+
+  belongs_to :habilitation_type
+
+  validates :slug, presence: true, uniqueness: true
+  validate :service_provider_must_exist, if: -> { service_provider_id.present? }
+  validate :slug_not_taken_by_yaml
+  validate :ht_keeps_at_least_one_default, on: :update
+  validate :only_one_default_per_habilitation_type, if: :default?
+  before_destroy :ensure_not_last_default
+
+  after_commit :reset_arf_cache, on: %i[create update destroy]
+
+  def service_provider
+    return nil if service_provider_id.blank?
+
+    ServiceProvider.find(service_provider_id)
+  rescue StaticApplicationRecord::EntryNotFound
+    nil
+  end
+
+  private
+
+  def reset_arf_cache
+    AuthorizationRequestForm.reset!
+  end
+
+  def service_provider_must_exist
+    return if ServiceProvider.exists?(id: service_provider_id)
+
+    errors.add(:service_provider_id, :inclusion)
+  end
+
+  def slug_not_taken_by_yaml
+    return if slug.blank?
+    return unless AuthorizationRequestFormConfigurations.instance.all.key?(slug.to_sym)
+
+    errors.add(:slug, :taken_by_yaml_form)
+  end
+
+  def other_defaults
+    habilitation_type.form_templates.where(default: true).where.not(id: id)
+  end
+
+  def ht_keeps_at_least_one_default
+    return unless default_was && !default
+
+    errors.add(:default, :last_default_form_template) unless other_defaults.exists?
+  end
+
+  def only_one_default_per_habilitation_type
+    errors.add(:default, :already_taken) if other_defaults.exists?
+  end
+
+  def ensure_not_last_default
+    return if destroyed_by_association
+    return unless default?
+    return if other_defaults.exists?
+
+    errors.add(:base, :last_default_form_template)
+    throw :abort
+  end
+end

--- a/app/models/habilitation_type.rb
+++ b/app/models/habilitation_type.rb
@@ -12,6 +12,7 @@ class HabilitationType < ApplicationRecord
   friendly_id :name, use: :slugged
 
   belongs_to :data_provider
+  has_many :form_templates, dependent: :destroy
 
   enum :kind, { api: 'api', service: 'service' }, validate: true
 
@@ -24,11 +25,11 @@ class HabilitationType < ApplicationRecord
   validates :scopes, presence: true, if: :scopes_block_selected?
   validate :validate_each_scope, if: :scopes_block_selected?
 
+  after_create :ensure_default_form_template!
   before_destroy :ensure_no_authorization_requests
   after_destroy :unregister_dynamic_class
-  after_destroy :reset_static_caches
   after_save :register_dynamic_class
-  after_save :reset_static_caches
+  after_commit :reset_static_caches, on: %i[create update destroy]
 
   def public
     true
@@ -61,6 +62,12 @@ class HabilitationType < ApplicationRecord
   def ordered_steps
     block_names = block_name_list
     BLOCK_ORDER.select { |name| block_names.include?(name) }
+  end
+
+  def ensure_default_form_template!
+    return if form_templates.exists?(default: true)
+
+    form_templates.create!(slug:, default: true)
   end
 
   def self.preload_requests_counts!(habilitation_types)

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -182,6 +182,16 @@ fr:
       habilitation_type/kind/values:
         api: API
         service: Service
+      form_template:
+        name: Nom du cas d’usage
+        description: Description
+        introduction: Introduction
+        use_case: Identifiant du cas d’usage
+        default: Cas d’usage par défaut
+        public: Public
+        startable_by_applicant: Demande initiable par le demandeur
+        single_page_view: Vue en une seule page
+        service_provider_id: Fournisseur de service
       instructor_draft_request:
         applicant_email: Adresse email du demandeur
         organization_siret: Numéro de SIRET de l'organisation
@@ -275,6 +285,17 @@ fr:
               scope_name_blank: "ne peut pas être vide"
               scope_value_blank: "ne peut pas être vide"
               scope_value_duplicate: "est déjà utilisée par un autre scope"
+        form_template:
+          attributes:
+            base:
+              last_default_form_template: "ne peut pas être supprimé : il doit rester au moins un template par défaut pour ce type d’habilitation"
+            slug:
+              taken_by_yaml_form: "est déjà utilisé par un formulaire YAML"
+            default:
+              last_default_form_template: "ne peut pas être désactivé : il doit rester au moins un template par défaut pour ce type d’habilitation"
+              already_taken: "un autre template par défaut existe déjà pour ce type d’habilitation"
+            service_provider_id:
+              inclusion: "n’existe pas dans la liste des fournisseurs de service"
         impersonation:
           attributes:
             user:

--- a/db/migrate/20260513000001_create_form_templates.rb
+++ b/db/migrate/20260513000001_create_form_templates.rb
@@ -1,0 +1,26 @@
+class CreateFormTemplates < ActiveRecord::Migration[8.1]
+  def change
+    create_table :form_templates do |t|
+      t.string :slug, null: false
+      t.references :habilitation_type, null: false, foreign_key: true
+      t.string :service_provider_id
+      t.string :name
+      t.text :description
+      t.text :introduction
+      t.string :use_case
+      t.boolean :default, null: false, default: false
+      t.boolean :public, null: false, default: true
+      t.boolean :startable_by_applicant, null: false, default: true
+      t.boolean :single_page_view, null: false, default: false
+      t.jsonb :steps, null: false, default: []
+      t.jsonb :static_blocks, null: false, default: []
+      t.jsonb :scopes_config, null: false, default: {}
+      t.jsonb :initialize_with, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :form_templates, :slug, unique: true
+    add_index :form_templates, %i[habilitation_type_id default]
+  end
+end

--- a/db/migrate/20260608193914_enforce_single_default_form_template_per_habilitation_type.rb
+++ b/db/migrate/20260608193914_enforce_single_default_form_template_per_habilitation_type.rb
@@ -1,0 +1,12 @@
+class EnforceSingleDefaultFormTemplatePerHabilitationType < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :form_templates,
+      column: %i[habilitation_type_id default],
+      name: 'index_form_templates_on_habilitation_type_id_and_default'
+
+    add_index :form_templates, :habilitation_type_id,
+      unique: true,
+      where: '"default"',
+      name: 'index_one_default_form_template_per_habilitation_type'
+  end
+end

--- a/db/migrate/20260615100802_backfill_default_form_templates.rb
+++ b/db/migrate/20260615100802_backfill_default_form_templates.rb
@@ -1,0 +1,18 @@
+class BackfillDefaultFormTemplates < ActiveRecord::Migration[8.1]
+  def up
+    execute(<<~SQL.squish)
+      INSERT INTO form_templates (habilitation_type_id, slug, "default", created_at, updated_at)
+      SELECT ht.id, ht.slug, true, NOW(), NOW()
+      FROM habilitation_types ht
+      WHERE NOT EXISTS (
+        SELECT 1 FROM form_templates ft
+        WHERE ft.habilitation_type_id = ht.id AND ft."default" = true
+      )
+    SQL
+  end
+
+  def down
+    # Backfill non réversible : impossible de distinguer les defaults créés ici
+    # de ceux créés depuis (callback ensure_default_form_template! ou admin).
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_100802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -208,6 +208,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
     t.string "reason", null: false
     t.datetime "updated_at", null: false
     t.index ["authorization_request_id"], name: "index_denial_of_authorizations_on_authorization_request_id"
+  end
+
+  create_table "form_templates", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "default", default: false, null: false
+    t.text "description"
+    t.bigint "habilitation_type_id", null: false
+    t.jsonb "initialize_with", default: {}, null: false
+    t.text "introduction"
+    t.string "name"
+    t.boolean "public", default: true, null: false
+    t.jsonb "scopes_config", default: {}, null: false
+    t.string "service_provider_id"
+    t.boolean "single_page_view", default: false, null: false
+    t.string "slug", null: false
+    t.boolean "startable_by_applicant", default: true, null: false
+    t.jsonb "static_blocks", default: [], null: false
+    t.jsonb "steps", default: [], null: false
+    t.datetime "updated_at", null: false
+    t.string "use_case"
+    t.index ["habilitation_type_id"], name: "index_form_templates_on_habilitation_type_id"
+    t.index ["habilitation_type_id"], name: "index_one_default_form_template_per_habilitation_type", unique: true, where: "\"default\""
+    t.index ["slug"], name: "index_form_templates_on_slug", unique: true
   end
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -731,6 +754,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_000000) do
   add_foreign_key "bulk_authorization_request_update_notification_reads", "bulk_authorization_request_updates"
   add_foreign_key "bulk_authorization_request_update_notification_reads", "users"
   add_foreign_key "denial_of_authorizations", "authorization_requests"
+  add_foreign_key "form_templates", "habilitation_types"
   add_foreign_key "habilitation_types", "data_providers"
   add_foreign_key "impersonation_actions", "impersonations"
   add_foreign_key "impersonations", "users"

--- a/docs/technique/habilitation_type_dynamique.md
+++ b/docs/technique/habilitation_type_dynamique.md
@@ -182,13 +182,70 @@ def self.backend
   yaml_records + db_records
 end
 
+# Côté AuthorizationDefinition : 1 HabilitationType ──► 1 AuthorizationDefinition
 def self.db_records
   return [] unless HabilitationType.table_exists?
   HabilitationType.includes(:data_provider).map { |record| build_from_db_record(record) }
 rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
   []
 end
+
+# Côté AuthorizationRequestForm : 1 HabilitationType ──has_many──► N FormTemplate ──► N forms
+def self.db_records
+  return [] unless FormTemplate.table_exists?
+  FormTemplate.includes(:habilitation_type).filter_map { |t| build_form_from_template(t) }
+rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+  []
+end
 ```
+
+`FormTemplate` (table `form_templates`, FK `habilitation_type_id`) intercale entre
+`HabilitationType` et `AuthorizationRequestForm` : un HT a 1+ FormTemplate dont
+**exactement 1** marqué `default: true` (invariant garanti par les validations
+`only_one_default_per_habilitation_type` + `ht_keeps_at_least_one_default` +
+`ensure_not_last_default`, plus le callback
+`HabilitationType#after_create :ensure_default_form_template!`). Le slug du
+FormTemplate sert d'`uid` côté façade ARF. Cf. [DP-1718](https://linear.app/pole-api/issue/DP-1718).
+
+**Filet DB : index partiel unique.** L'unicité du default est aussi gravée dans
+le schéma — `index_one_default_form_template_per_habilitation_type` sur
+`habilitation_type_id` `WHERE "default"` (le mot `default` est réservé, d'où le
+quoting). Les validations donnent les beaux messages ; l'index protège des
+contournements (`update_column`, `insert_all`) et des courses concurrentes.
+⚠️ **PR2/PR3 — opération « changer le default »** : promouvoir un template alors
+qu'un autre est déjà default doit **rétrograder l'ancien avant de promouvoir le
+nouveau**, dans une transaction (sinon deux `default: true` transitoires →
+`RecordNotUnique`). Alternative si l'ordre devient gênant : passer la contrainte
+en `DEFERRABLE INITIALLY DEFERRED` (SQL brut, la vérif se fait au `COMMIT`).
+
+**Slug du template default = slug du HT (pas de suffixe).** Le default auto-créé
+reprend tel quel le slug du `HabilitationType` (`form_templates.create!(slug:,
+default: true)`), il n'encode **pas** son statut (`-default` proscrit). L'uid est
+un identifiant **public, persisté et immuable** : URLs « commencer une demande »
+transmises aux partenaires, `form_uid` POSTé via l'API v1, colonne
+`authorization_request.form_uid`, filtres export DGFIP. Encoder un état mutable
+dans l'uid casserait tout cela le jour où le default change de template (la
+désignation `default` est une **colonne booléenne** — `default_form` la lit via
+`available_forms.find(&:default)`, jamais le slug). Bonus : réutiliser le slug du
+HT préserve l'uid d'avant DP-1718 (`uid: record.slug`), donc les demandes
+existantes continuent de résoudre leur form sans data-migration sur `form_uid`.
+Les templates **non-default** reçoivent des slugs explicites et stables, eux aussi
+immuables une fois diffusés.
+
+**Cascade éditoriale HT → FT default**. Le FormTemplate auto-créé ne porte que
+`slug` + `default: true` ; les champs éditoriaux (`name`, `description`,
+`introduction`, `steps`) restent **vides** côté template et sont résolus à la
+volée dans `build_form_from_template` via `template.<champ>.presence || ht.<champ>`.
+Conséquence : éditer le HT propage automatiquement aux ARF qui en dépendent,
+tant qu'aucun override explicite n'est posé sur le template. Quand l'UI admin
+FormTemplate arrivera (DP-1718 PR2/PR3), renseigner un champ sur le template le
+fera prendre le pas sur le HT.
+
+**Invalidation du cache ARF**. `FormTemplate.after_commit :reset_arf_cache` et
+`HabilitationType.after_commit :reset_static_caches` (post-commit, pas
+`after_save`) bumpent le compteur Redis **après** que la transaction soit
+committée — autrement, un autre process pourrait reconstruire `@all` depuis
+une vue pré-commit (race).
 
 `StaticApplicationRecord` mémorise le backend dans `@all` et invalide via un
 compteur Redis (`Kredis.counter(redis_cache_key).increment`). Coordination
@@ -202,9 +259,6 @@ le find aboutit indistinctement côté YAML ou DB.
 
 ## Limitations connues
 
-- **`use_case` et `initialize_with` non disponibles côté DB** :
-  `build_form_from_habilitation_type` passe `use_case: nil` et n'expose pas
-  `initialize_with`. Le préremplissage par cas d'usage reste YAML-only.
 - **`custom_labels` (jsonb)** : présent en DB et factory, aucune lecture
   dans le code à ce jour. Surface réservée pour personnalisation éditoriale.
 - **Concerns existants non exposés au registrar** (présents dans
@@ -213,16 +267,24 @@ le find aboutit indistinctement côté YAML ou DB.
   `gdpr_contacts`, `modalities`, `operational_acceptance`,
   `safety_certification`, `technical_team`, `volumetrie`. Procédure
   d'exposition → [ajout_block_dynamique.md](./ajout_block_dynamique.md).
-- **`static_blocks` non porté côté DB** : `build_form_from_habilitation_type`
-  passe `static_blocks: []`.
+- **CRUD admin de `FormTemplate`** : pas encore exposée en UI (DP-1718 PR 1).
+  La création/édition se fait en `rails c` ; le default est auto-créé à la
+  création d'un `HabilitationType` (callback `ensure_default_form_template!`).
+  Les HT déjà en base sont dotés de leur default par la migration de données
+  `BackfillDefaultFormTemplates` (SQL idempotent, slug = slug du HT), qui
+  s'applique automatiquement à chaque environnement et en local.
 
 ## Tableau récap « où vit quoi »
 
 | Sujet | Fichier |
 | --- | --- |
 | Modèle DB | [`app/models/habilitation_type.rb`](.../../app/models/habilitation_type.rb) |
+| Modèle DB templates de form | [`app/models/form_template.rb`](.../../app/models/form_template.rb) |
 | Migration création | [`db/migrate/20260225111739_create_habilitation_types.rb`](../db/migrate/20260225111739_create_habilitation_types.rb) |
 | Migration suffixe `-dyn` | [`db/migrate/20260401152848_add_dyn_suffix_to_habilitation_type_slugs.rb`](../db/migrate/20260401152848_add_dyn_suffix_to_habilitation_type_slugs.rb) |
+| Migration form_templates | [`db/migrate/20260513000001_create_form_templates.rb`](../db/migrate/20260513000001_create_form_templates.rb) |
+| Migration index 1 default/HT | [`db/migrate/20260608193914_enforce_single_default_form_template_per_habilitation_type.rb`](../db/migrate/20260608193914_enforce_single_default_form_template_per_habilitation_type.rb) |
+| Migration backfill defaults | [`db/migrate/20260615100802_backfill_default_form_templates.rb`](../db/migrate/20260615100802_backfill_default_form_templates.rb) |
 | Registrar | [`app/services/dynamic_authorization_request_registrar.rb`](.../../app/services/dynamic_authorization_request_registrar.rb) |
 | Initializer Rails | [`config/initializers/dynamic_authorization_types.rb`](../../config/initializers/dynamic_authorization_types.rb) |
 | Concerns blocks | [`app/models/concerns/authorization_extensions/`](.../../app/models/concerns/authorization_extensions/) |
@@ -255,4 +317,6 @@ le find aboutit indistinctement côté YAML ou DB.
   inactif côté wizard). Pattern `cnous_data_extraction_criteria` — voir
   [ajout_block_dynamique.md](./ajout_block_dynamique.md).
 - **Couplage `data_provider` (FK SQL)** : un type DB appartient toujours à
-  un `DataProvider`. Aucun couplage à un `ServiceProvider` côté DB.
+  un `DataProvider`. Le couplage à un `ServiceProvider` (YAML-backed
+  `StaticApplicationRecord`) se fait au niveau du `FormTemplate` via la
+  colonne string `service_provider_id`, résolue côté façade.

--- a/features/admin/habilitation_types.feature
+++ b/features/admin/habilitation_types.feature
@@ -128,6 +128,14 @@ Fonctionnalité: Espace admin: types d'habilitation
     Et la page contient "Modifier"
     Et la page ne contient pas "Supprimer"
 
+  Scénario: Je supprime un type d'habilitation sans demandes liées
+    Sachant que je me connecte
+    Et qu'un type d'habilitation "API Jetable" existe
+    Quand je me rends sur le chemin "/admin/types-habilitation"
+    Et que je clique sur "Supprimer" dans la rangée "API Jetable"
+    Alors il y a un message de succès contenant "supprimé"
+    Et la page contient "Aucun type d’habilitation créé."
+
   Scénario: Un admin peut modifier les champs éditoriaux d'un type avec des demandes liées
     Sachant que je me connecte
     Et qu'un type d'habilitation "API Protégée" avec des demandes liées existe

--- a/spec/factories/form_templates.rb
+++ b/spec/factories/form_templates.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :form_template do
+    habilitation_type
+    sequence(:name) { |n| "Template #{n}" }
+    description { 'Un template de test' }
+    introduction { nil }
+    use_case { nil }
+    default { false }
+    public { true }
+    startable_by_applicant { true }
+    single_page_view { false }
+    steps { [{ 'name' => 'basic_infos' }] }
+    static_blocks { [] }
+    scopes_config { {} }
+    initialize_with { {} }
+  end
+end

--- a/spec/models/authorization_request_form_spec.rb
+++ b/spec/models/authorization_request_form_spec.rb
@@ -5,49 +5,103 @@ RSpec.describe AuthorizationRequestForm do
     end
 
     context 'with DB records' do
-      before do
-        stub_const('AuthorizationRequest::MonAPI', Class.new(AuthorizationRequest))
-        allow(described_class).to receive(:db_records).and_return([db_form])
-        described_class.reset!
-      end
+      let!(:habilitation_type) { create(:habilitation_type, name: 'Mon API') }
+      let(:default_template) { habilitation_type.form_templates.find_by(default: true) }
+
+      before { described_class.reset! }
 
       after { described_class.reset! }
-
-      let(:db_form) do
-        described_class.new(
-          uid: 'mon-api',
-          default: true,
-          introduction: 'Mon introduction',
-          authorization_request_class: AuthorizationRequest::MonAPI,
-          steps: [{ name: 'basic_infos' }],
-          static_blocks: [],
-          service_provider: nil,
-          use_case: nil,
-          single_page_view: nil,
-          scopes_config: {},
-        )
-      end
 
       it 'includes YAML forms' do
         expect(described_class.all.map(&:uid)).to include('api-entreprise')
       end
 
-      it 'includes DB forms' do
-        expect(described_class.all.map(&:uid)).to include('mon-api')
+      it 'includes the auto-created default FormTemplate' do
+        expect(described_class.all.map(&:uid)).to include(default_template.slug)
       end
 
       it 'returns AuthorizationRequestForm instances for DB records' do
-        expect(described_class.all.find { |f| f.uid == 'mon-api' }).to be_a(described_class)
+        expect(described_class.all.find { |f| f.uid == default_template.slug }).to be_a(described_class)
       end
 
-      it 'has default: true for DB forms' do
-        form = described_class.all.find { |f| f.uid == 'mon-api' }
+      it 'reflects FormTemplate.default on the ARF' do
+        form = described_class.all.find { |f| f.uid == default_template.slug }
         expect(form.default).to be(true)
       end
 
-      it 'has the correct authorization_request_class' do
-        form = described_class.all.find { |f| f.uid == 'mon-api' }
-        expect(form.authorization_request_class).to eq(AuthorizationRequest::MonAPI)
+      it 'binds the correct authorization_request_class via the habilitation_type' do
+        form = described_class.all.find { |f| f.uid == default_template.slug }
+        expected_class = AuthorizationRequest.const_get(habilitation_type.uid.classify)
+        expect(form.authorization_request_class).to eq(expected_class)
+      end
+
+      it 'exposes N templates as N forms for a single habilitation_type' do
+        habilitation_type.form_templates.create!(name: 'Second cas', default: false)
+        habilitation_type.form_templates.create!(name: 'Troisième cas', default: false)
+        described_class.reset!
+
+        forms = described_class.all.select { |f| f.authorization_request_class.to_s == habilitation_type.authorization_request_type }
+        expect(forms.size).to eq(3)
+        expect(forms.count(&:default)).to eq(1)
+      end
+
+      context 'when FormTemplate fields are blank (cascade from HabilitationType)' do
+        it 'cascades name from HT.name' do
+          form = described_class.all.find { |f| f.uid == default_template.slug }
+
+          expect(default_template.name).to be_blank
+          expect(form.name).to eq(habilitation_type.name)
+        end
+
+        it 'cascades introduction from HT.form_introduction' do
+          habilitation_type.update!(form_introduction: 'Bienvenue v1')
+          described_class.reset!
+
+          form = described_class.all.find { |f| f.uid == default_template.slug }
+          expect(form.introduction).to eq('Bienvenue v1')
+        end
+
+        it 'cascades steps from HT.ordered_steps when template.steps is empty' do
+          habilitation_type.update!(blocks: [{ 'name' => 'basic_infos' }, { 'name' => 'legal' }])
+          described_class.reset!
+
+          form = described_class.all.find { |f| f.uid == default_template.slug }
+          expect(form.steps).to eq([{ name: 'basic_infos' }, { name: 'legal' }])
+        end
+
+        it 'lets a non-blank template override take precedence over HT' do
+          habilitation_type.update!(form_introduction: 'Hérité du HT')
+          default_template.update!(introduction: 'Override template')
+          described_class.reset!
+
+          form = described_class.all.find { |f| f.uid == default_template.slug }
+          expect(form.introduction).to eq('Override template')
+        end
+      end
+
+      it 'resolves the service_provider from FormTemplate.service_provider_id' do
+        sp_id = ServiceProvider.all.first.id
+        default_template.update!(service_provider_id: sp_id)
+        described_class.reset!
+
+        form = described_class.all.find { |f| f.uid == default_template.slug }
+        expect(form.service_provider).to eq(ServiceProvider.find(sp_id))
+      end
+
+      it 'deep-symbolizes all jsonb overrides consumed by views' do
+        default_template.update!(
+          steps: [{ 'name' => 'basic_infos', 'options' => { 'optional' => true } }],
+          static_blocks: [{ 'name' => 'specific_requirements' }],
+          scopes_config: { 'hide' => ['scope_a'] },
+          initialize_with: { 'scopes' => ['scope_b'] },
+        )
+        described_class.reset!
+
+        form = described_class.all.find { |f| f.uid == default_template.slug }
+        expect(form.steps).to eq([{ name: 'basic_infos', options: { optional: true } }])
+        expect(form.static_blocks).to eq([{ name: 'specific_requirements' }])
+        expect(form.scopes_config).to eq(hide: ['scope_a'])
+        expect(form.initialize_with[:scopes]).to include('scope_b')
       end
     end
   end

--- a/spec/models/form_template_spec.rb
+++ b/spec/models/form_template_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+RSpec.describe FormTemplate do
+  let(:habilitation_type) do
+    ht = create(:habilitation_type)
+    ht.form_templates.delete_all
+    ht
+  end
+
+  describe 'creation' do
+    it 'persists with habilitation_type and name' do
+      template = described_class.create!(habilitation_type:, name: 'Mon Template')
+
+      expect(template).to be_persisted
+      expect(template.slug).to be_present
+    end
+  end
+
+  describe 'slug' do
+    it 'is auto-generated from name via friendly_id' do
+      template = described_class.create!(habilitation_type:, name: 'Mon Template Super')
+
+      expect(template.slug).to eq('mon-template-super')
+    end
+
+    it 'is unique' do
+      described_class.create!(habilitation_type:, name: 'Identique')
+      duplicate = described_class.new(habilitation_type:, name: 'Autre nom', slug: 'identique')
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:slug]).to be_present
+    end
+
+    it 'is refused if it collides with a YAML form uid' do
+      yaml_uid = AuthorizationRequestFormConfigurations.instance.all.keys.first.to_s
+      template = described_class.new(habilitation_type:, name: 'Conflit', slug: yaml_uid)
+
+      expect(template).not_to be_valid
+      expect(template.errors[:slug]).to be_present
+    end
+  end
+
+  describe 'default invariant' do
+    it 'cannot be flipped from true to false when it is the only default' do
+      default_template = described_class.create!(habilitation_type:, name: 'Default', default: true)
+      described_class.create!(habilitation_type:, name: 'Other', default: false)
+
+      default_template.default = false
+
+      expect(default_template.save).to be(false)
+      expect(default_template.errors[:default]).to be_present
+    end
+
+    it 'refuses a second default for the same habilitation_type' do
+      described_class.create!(habilitation_type:, name: 'A', default: true)
+      duplicate_default = described_class.new(habilitation_type:, name: 'B', default: true)
+
+      expect(duplicate_default).not_to be_valid
+      expect(duplicate_default.errors[:default]).to be_present
+    end
+
+    it 'is enforced at the database level even when validations are bypassed' do
+      described_class.create!(habilitation_type:, name: 'A', default: true)
+      duplicate_default = described_class.new(habilitation_type:, name: 'B', default: true, slug: 'contournement')
+
+      expect { duplicate_default.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe '#destroy' do
+    it 'is forbidden when destroying the last default of a habilitation_type' do
+      default_template = described_class.create!(habilitation_type:, name: 'Default', default: true)
+      described_class.create!(habilitation_type:, name: 'Other', default: false)
+
+      expect(default_template.destroy).to be(false)
+      expect(default_template.errors[:base]).to be_present
+      expect { default_template.reload }.not_to raise_error
+    end
+
+    it 'is allowed for a non-default template' do
+      described_class.create!(habilitation_type:, name: 'Default', default: true)
+      other = described_class.create!(habilitation_type:, name: 'Other', default: false)
+
+      expect { other.destroy }.to change(described_class, :count).by(-1)
+    end
+  end
+
+  describe '#service_provider' do
+    it 'returns nil when no service_provider_id is set' do
+      template = described_class.create!(habilitation_type:, name: 'No SP')
+
+      expect(template.service_provider).to be_nil
+    end
+
+    it 'resolves the ServiceProvider from the YAML backend when set' do
+      sp_id = ServiceProvider.all.first.id
+      template = described_class.create!(habilitation_type:, name: 'With SP', service_provider_id: sp_id)
+
+      expect(template.service_provider).to eq(ServiceProvider.find(sp_id))
+    end
+
+    it 'rejects an invalid service_provider_id at save time' do
+      template = described_class.new(habilitation_type:, name: 'Bad SP', service_provider_id: 'inexistant')
+
+      expect(template).not_to be_valid
+      expect(template.errors[:service_provider_id]).to be_present
+    end
+  end
+
+  describe 'paper_trail' do
+    it 'tracks a version on update' do
+      template = described_class.create!(habilitation_type:, name: 'Versionné')
+
+      expect { template.update!(description: 'nouvelle description') }
+        .to change { template.versions.count }.by(1)
+    end
+  end
+
+  describe 'AuthorizationRequestForm cache invalidation' do
+    before { AuthorizationRequestForm.reset! }
+
+    after { AuthorizationRequestForm.reset! }
+
+    it 'exposes a freshly created FormTemplate to the façade without manual reset' do
+      AuthorizationRequestForm.all
+
+      template = described_class.create!(habilitation_type:, name: 'Frais')
+
+      expect(AuthorizationRequestForm.all.map(&:uid)).to include(template.slug)
+    end
+
+    it 'removes a destroyed FormTemplate from the façade without manual reset' do
+      described_class.create!(habilitation_type:, name: 'Default conservé', default: true)
+      removable = described_class.create!(habilitation_type:, name: 'À jeter', default: false)
+      AuthorizationRequestForm.all
+
+      removable.destroy!
+
+      expect(AuthorizationRequestForm.all.map(&:uid)).not_to include(removable.slug)
+    end
+  end
+end

--- a/spec/models/habilitation_type_spec.rb
+++ b/spec/models/habilitation_type_spec.rb
@@ -192,7 +192,8 @@ RSpec.describe HabilitationType do
 
     it 'creates a version on destroy' do
       habilitation_type.save!
-      expect { habilitation_type.destroy! }.to change(PaperTrail::Version, :count).by(1)
+      expect { habilitation_type.destroy! }
+        .to change { PaperTrail::Version.where(item_type: 'HabilitationType').count }.by(1)
     end
 
     it 'tracks attribute changes as a Hash in object_changes' do
@@ -236,6 +237,28 @@ RSpec.describe HabilitationType do
       user = build(:user)
       expect(user).to respond_to(:"instruction_submit_notifications_for_#{habilitation_type.uid}")
     end
+
+    it 'auto-creates a default FormTemplate carrying only slug + default (editorial fields cascade from HT)' do
+      habilitation_type.blocks = [{ 'name' => 'basic_infos' }, { 'name' => 'legal' }]
+      habilitation_type.form_introduction = 'Introduction du formulaire'
+      habilitation_type.save!
+
+      default_template = habilitation_type.form_templates.find_by(default: true)
+      expect(default_template).to be_present
+      expect(default_template.slug).to eq(habilitation_type.slug)
+      expect(default_template.name).to be_blank
+      expect(default_template.introduction).to be_blank
+      expect(default_template.steps).to eq([])
+    end
+  end
+
+  describe '#ensure_default_form_template!' do
+    it 'is idempotent: does not create a second default' do
+      habilitation_type.save!
+
+      expect { habilitation_type.ensure_default_form_template! }
+        .not_to change { habilitation_type.form_templates.where(default: true).count }
+    end
   end
 
   describe 'validation on destroy' do
@@ -244,6 +267,16 @@ RSpec.describe HabilitationType do
     context 'when no authorization requests exist' do
       it 'allows destroy' do
         expect { record.destroy }.to change(described_class, :count).by(-1)
+      end
+
+      it 'cascades destruction to its form_templates, including the default one' do
+        record.form_templates.create!(name: 'Second cas d’usage', default: false)
+        template_ids = record.form_templates.pluck(:id)
+        expect(template_ids.size).to eq(2)
+
+        record.destroy
+
+        expect(FormTemplate.where(id: template_ids)).to be_empty
       end
     end
 
@@ -272,7 +305,7 @@ RSpec.describe HabilitationType do
     end
 
     it 'resets AuthorizationRequestForm cache' do
-      expect(AuthorizationRequestForm).to receive(:reset!)
+      expect(AuthorizationRequestForm).to receive(:reset!).at_least(:once)
       habilitation_type.destroy!
     end
 


### PR DESCRIPTION
## Contexte

[DP-1718](https://linear.app/pole-api/issue/DP-1718) — pré-requis structurant de l'étape 02 du projet [Autonomiser API Parteprise](https://linear.app/pole-api/project/autonomiser-api-parteprise-8f80da170dd6).

Aujourd'hui un `HabilitationType` BDD produit **1 seul** `AuthorizationRequestForm` virtuel (`default: true` forcé via `build_form_from_habilitation_type`). Cette PR introduit un `FormTemplate` (BDD) qui intercale entre `HabilitationType` et la façade `AuthorizationRequestForm` pour permettre **N templates par HT** sans toucher au YAML.

PR 2 (à venir, stackable) : rake idempotente d'import des YAML `api_particulier` et `api_entreprise` vers `FormTemplate`. Le déploiement de la rake dépendra de [DP-1671](https://linear.app/pole-api/issue/DP-1671) (qui migre les HT cibles en BDD).

## Architecture

```
                       AuthorizationRequestForm (façade, StaticApplicationRecord)
                                   │
                  .backend = yaml_records + db_records
                  ┌────────────────┴────────────────┐
                  │                                 │
            yaml_records                       db_records
                  │                                 │
        config/authorization_request_forms/*.yml    │
                  │                          FormTemplate.includes(habilitation_type: :data_provider)
                  ▼                                 ▼
        ARF #<api-particulier ...>         ARF #<mon-api-default ...>, ARF #<mon-api-cas-x ...>
                                                    │
                                                    └─ belongs_to :habilitation_type
```

Avant : `HabilitationType (1) ──► 1 ARF virtuel (default: true forcé)`
Après : `HabilitationType (1) ──has_many──► FormTemplate (1..n, ≥ 1 default) ──► n ARFs`

**Surface API publique de `AuthorizationRequestForm` inchangée** — 104 occurrences dans controllers / routes / vues / i18n / specs, aucune réécriture nécessaire côté call-sites.

## Invariants garantis

- **`slug` unique** cross-source : refusé en BDD si déjà pris par un `uid` YAML (`AuthorizationRequestFormConfigurations`).
- **≥ 1 default par HT** : auto-créé via `HabilitationType#after_create :ensure_default_form_template!`, et impossible à supprimer ou désactiver tant qu'il reste seul (`ensure_not_last_default`, `ht_keeps_at_least_one_default`). Bypass propre en cas de cascade `HT.destroy` (`destroyed_by_association`).
- **Cache cross-process** : `FormTemplate#after_save/destroy :reset_arf_cache` bump le compteur Redis via `StaticApplicationRecord#reset!`, garantissant que tous les workers (Puma + Sidekiq, dev multi-worktrees) voient le changement.

## Découpage

| Commit | Contenu |
|--------|---------|
| `bafb6bc3` | Modèle `FormTemplate` + migration + invariants + i18n + auto-create default + rake `form_templates:backfill_defaults` |
| `9e1a18c1` | Rewrite `AuthorizationRequestForm.db_records` via `FormTemplate`, suppression `build_form_from_habilitation_type`, fix indentation YAML i18n, docs `habilitation_type_dynamique.md` |
| `b1113349` | Specs cache invalidation + `rubocop -A` final |

## Hors scope (à reprendre dans des PRs séparées)

- Rename `HabilitationType → Form`
- FK `AuthorizationRequest.form_template_id`
- CRUD admin UI pour `FormTemplate` (édition via `rails c` ou rake pour cette PR)
- Concept `stage` DGFIP — reste YAML
- Import YAML `api_particulier` / `api_entreprise` → `FormTemplate` → **PR 2 stackable**, dépend de DP-1671 pour le run.

## Test plan

- [x] Full RSpec : 2631 / 0 (76 examples sur les fichiers touchés)
- [x] Full Cucumber : seuls 3 flakes connus restent, non reproductibles isolés
- [x] Rubocop clean
- [x] Brakeman clean
- [x] Rake `form_templates:backfill_defaults` smoke-testée en dev (idempotente)
- [ ] Reviewer : tester la création / édition / suppression d'un `FormTemplate` via `rails c` sur un HT auto-créé