### PR TITLE
Ajoute un encart de connexion rapide hors production

### DIFF
--- a/app/views/pages/shared/unauthenticated_pages/_bypass_login_info.html.erb
+++ b/app/views/pages/shared/unauthenticated_pages/_bypass_login_info.html.erb
@@ -1,0 +1,14 @@
+<div class="fr-alert fr-alert--info fr-alert--sm fr-mt-3w" style="text-align: left;">
+  <p class="fr-alert__title">Connexion rapide</p>
+  <p>Vous êtes en environnement de test, vous pouvez vous connecter rapidement en cliquant sur l’un des comptes prédéfinis ci-dessous :</p>
+  <% if Rails.env.staging? %>
+    <div class="fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-mb-0">
+      <%= link_to 'user@yopmail.com', '/local-sign-in?email=user@yopmail.com', class: 'fr-btn fr-btn--secondary', data: { turbo_prefetch: false } %>
+    </div>
+  <% else %>
+    <div class="fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-mb-0">
+      <%= link_to 'Utilisateur de base (demandeur)', '/local-sign-in?email=user@yopmail.com', class: 'fr-btn fr-btn--secondary', data: { turbo_prefetch: false } %>
+      <%= link_to 'Admin / instructeur', '/local-sign-in?email=datapass@yopmail.com', class: 'fr-btn fr-btn--secondary', data: { turbo_prefetch: false } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/pages/shared/unauthenticated_pages/_bypass_login_info.html.erb
+++ b/app/views/pages/shared/unauthenticated_pages/_bypass_login_info.html.erb
@@ -1,14 +1,20 @@
-<div class="fr-alert fr-alert--info fr-alert--sm fr-mt-3w" style="text-align: left;">
-  <p class="fr-alert__title">Connexion rapide</p>
-  <p>Vous êtes en environnement de test, vous pouvez vous connecter rapidement en cliquant sur l’un des comptes prédéfinis ci-dessous :</p>
-  <% if Rails.env.staging? %>
-    <div class="fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-mb-0">
-      <%= link_to 'user@yopmail.com', '/local-sign-in?email=user@yopmail.com', class: 'fr-btn fr-btn--secondary', data: { turbo_prefetch: false } %>
-    </div>
-  <% else %>
-    <div class="fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-mb-0">
-      <%= link_to 'Utilisateur de base (demandeur)', '/local-sign-in?email=user@yopmail.com', class: 'fr-btn fr-btn--secondary', data: { turbo_prefetch: false } %>
-      <%= link_to 'Admin / instructeur', '/local-sign-in?email=datapass@yopmail.com', class: 'fr-btn fr-btn--secondary', data: { turbo_prefetch: false } %>
-    </div>
-  <% end %>
+<% accounts = if Rails.env.staging?
+    [{ label: 'user@yopmail.com', email: 'user@yopmail.com' }]
+else
+    [
+      { label: 'Utilisateur de base (demandeur)', email: 'user@yopmail.com' },
+      { label: 'Admin / instructeur', email: 'datapass@yopmail.com' }
+    ]
+end %>
+
+<div class="fr-alert fr-alert--info fr-mt-3w">
+  <h3 class="fr-alert__title">Connexion rapide</h3>
+  <p>Environnement de test : connectez-vous sans passer par ProConnect via l’un des comptes prédéfinis ci-dessous :</p>
+  <div class="fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-mb-0 fr-mt-4v">
+    <% accounts.each do |account| %>
+      <%= link_to account[:label], "/local-sign-in?email=#{account[:email]}",
+        class: 'fr-btn fr-btn--secondary',
+        data: { turbo_prefetch: false } %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/pages/shared/unauthenticated_pages/_pro_connect.html.erb
+++ b/app/views/pages/shared/unauthenticated_pages/_pro_connect.html.erb
@@ -20,4 +20,6 @@
       </a>
     </p>
   <% end %>
+
+  <%= render partial: 'pages/shared/unauthenticated_pages/bypass_login_info' unless Rails.env.production? %>
 </div>


### PR DESCRIPTION
Permet aux développeurs et testeurs de se connecter en un clic via /local-sign-in sur les environnements de développement, staging et sandbox, sans passer par ProConnect. Le bloc est rendu depuis le partial _pro_connect (home + unauthenticated_start) et masqué en production. En staging seul le compte demandeur de base est exposé ; dev/sandbox affichent aussi le compte admin/instructeur.

<img width="2538" height="1384" alt="screenshot-2026-05-14--12-22-28--000734" src="https://github.com/user-attachments/assets/8e9821fb-9ca2-4707-94ce-8e28da7a4458" />
