### PR TITLE
Pré-remplissage d'une demande via query params

### DIFF
--- a/app/controllers/authorization_request_forms_controller.rb
+++ b/app/controllers/authorization_request_forms_controller.rb
@@ -15,6 +15,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
   before_action :extract_authorization_request_form
   before_action :extract_authorization_request, only: %i[show summary update]
   before_action :extract_potential_bulk_update_notification, only: %i[summary]
+  before_action :capture_prefill_data, only: %i[new]
 
   def new
     authorize @authorization_request_form, :new?
@@ -33,6 +34,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
     @authorization_request = BuildAuthorizationRequest.call(
       authorization_request_form: @authorization_request_form,
       applicant: current_user,
+      prefill_data: peek_prefill_data,
     ).authorization_request.decorate
 
     render view_path
@@ -103,6 +105,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
     @authorization_request = organizer.authorization_request.decorate
 
     if organizer.success?
+      clear_prefill_data
       success_message_for_authorization_request(@authorization_request, key: 'authorization_request_forms.create', tiny: true) unless next_submit?
 
       redirect_to authorization_request_form_build_path(
@@ -164,6 +167,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
     @authorization_request = organizer.authorization_request.decorate
 
     if organizer.success?
+      clear_prefill_data
       success_message_for_authorization_request(@authorization_request, key: 'authorization_request_forms.create', tiny: true)
 
       redirect_to authorization_request_form_path(form_uid: @authorization_request.form_uid, id: @authorization_request.id)
@@ -180,6 +184,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
     @authorization_request = organizer.authorization_request.decorate
 
     if organizer.success? && review_authorization_request.success?
+      clear_prefill_data
       redirect_to summary_authorization_request_form_path(form_uid: @authorization_request.form_uid, id: @authorization_request.id)
     else
       error_message_for_authorization_request(@authorization_request, key: 'authorization_request_forms.create_for_single_page_form')
@@ -199,6 +204,7 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
       user: current_user,
       authorization_request_form: @authorization_request_form,
       authorization_request_params: authorization_request_create_params,
+      prefill_data: peek_prefill_data,
     )
   end
 
@@ -349,6 +355,31 @@ class AuthorizationRequestFormsController < AuthenticatedUserController
 
   def model_to_track_for_impersonation
     @authorization_request
+  end
+
+  def peek_prefill_data
+    prefill = session[:authorization_request_prefill]
+    return nil if prefill.blank?
+    return nil if prefill['form_uid'] != @authorization_request_form.id
+
+    prefill['data']
+  end
+
+  def capture_prefill_data
+    allowed = @authorization_request_form.authorization_request_class.prefillable_attribute_names
+    filtered = request.query_parameters.to_h.slice(*allowed)
+
+    if filtered.present?
+      session[:authorization_request_prefill] = { 'form_uid' => @authorization_request_form.id, 'data' => filtered }
+    else
+      clear_prefill_data
+    end
+  end
+
+  def clear_prefill_data
+    return unless peek_prefill_data
+
+    session.delete(:authorization_request_prefill)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/interactors/assign_query_params_data_to_authorization_request.rb
+++ b/app/interactors/assign_query_params_data_to_authorization_request.rb
@@ -1,0 +1,25 @@
+class AssignQueryParamsDataToAuthorizationRequest < ApplicationInteractor
+  def call
+    return if prefill_data.blank?
+
+    filtered_data.each do |name, value|
+      context.authorization_request.public_send(:"#{name}=", value)
+    rescue StandardError
+      next
+    end
+  end
+
+  private
+
+  def prefill_data
+    context.prefill_data
+  end
+
+  def filtered_data
+    prefill_data.to_h.stringify_keys.slice(*allowed_attribute_names)
+  end
+
+  def allowed_attribute_names
+    context.authorization_request.class.prefillable_attribute_names
+  end
+end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -308,6 +308,12 @@ class AuthorizationRequest < ApplicationRecord
     AuthorizationRequestPolicy
   end
 
+  def self.prefillable_attribute_names
+    names = extra_attributes.map(&:to_s)
+    names << 'scopes' if respond_to?(:scopes_enabled?) && scopes_enabled?
+    names
+  end
+
   def need_complete_validation?(step = nil)
     return true if %i[submit review].include?(validation_context)
     return false if already_been_refused_or_approved?

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -310,7 +310,7 @@ class AuthorizationRequest < ApplicationRecord
 
   def self.prefillable_attribute_names
     names = extra_attributes.map(&:to_s)
-    names << 'scopes' if respond_to?(:scopes_enabled?) && scopes_enabled?
+    names << 'scopes' if scopes_enabled?
     names
   end
 

--- a/app/organizers/build_authorization_request.rb
+++ b/app/organizers/build_authorization_request.rb
@@ -7,5 +7,6 @@ class BuildAuthorizationRequest < ApplicationOrganizer
     )
   end
 
-  organize AssignDefaultDataToAuthorizationRequest
+  organize AssignDefaultDataToAuthorizationRequest,
+    AssignQueryParamsDataToAuthorizationRequest
 end

--- a/app/organizers/create_authorization_request_model.rb
+++ b/app/organizers/create_authorization_request_model.rb
@@ -1,6 +1,7 @@
 class CreateAuthorizationRequestModel < ApplicationOrganizer
   organize AssignCreateParamsForCreateAuthorizationRequest,
     AssignDefaultDataToAuthorizationRequest,
+    AssignQueryParamsDataToAuthorizationRequest,
     AssignParamsToAuthorizationRequest,
     AssignFranceConnectDefaults,
     SaveAuthorizationRequest

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 * [Templates de messages pour l'instruction](./technique/templates_messages.md)
 * [Synchronisation DataGouv — habilitations](./technique/datagouv-habilitations-sync.md)
 * [Utiliser notre API](./technique/api.md)
+* [Pré-remplissage d'une demande via query params](./technique/pre_remplissage_query_params.md)
 * [Migration de l'ancienne stack (v1 -> v2)](./../app/migration/)
 
 ## Métier / Utilisateurs

--- a/docs/technique/pre_remplissage_query_params.md
+++ b/docs/technique/pre_remplissage_query_params.md
@@ -1,0 +1,97 @@
+# Pré-remplissage d'une demande via query params
+
+Un lien direct vers le formulaire de création d'une demande accepte des query
+params nommés d'après les attributs de la demande. Les valeurs sont
+pré-remplies dans le formulaire et persistées en base au premier submit.
+
+## Format d'URL
+
+```
+https://datapass.api.gouv.fr/formulaires/<form_uid>/demande/nouveau?<attribut>=<valeur>
+```
+
+Exemple :
+
+```
+https://datapass.api.gouv.fr/formulaires/api-entreprise-socle-de-base/demande/nouveau?intitule=Mon+projet&cadre_juridique_url=https%3A%2F%2Flegifrance.gouv.fr%2Ffoo
+```
+
+## Attributs pré-remplissables
+
+L'allowlist est calculée par `AuthorizationRequest.prefillable_attribute_names`
+et contient, pour la classe de demande du formulaire ciblé :
+
+- tous les attributs déclarés via `add_attributes` (strings, dates, etc.)
+- les attributs déclarés via `add_attribute(..., type: :array)` (passés en
+  format Rails standard : `?modalities[]=a&modalities[]=b`)
+- les checkboxes déclarées via `add_checkbox` (booleans, `?ma_case=1`)
+- `scopes` si le formulaire active les scopes (`add_scopes`)
+
+Sont volontairement **exclus** :
+
+- les champs de contacts (`contact_technique_email`, etc.) pour éviter
+  l'usurpation de l'instructeur via un lien malveillant
+- les colonnes ActiveRecord (`state`, `applicant_id`, `organization_id`…)
+- tout `store_accessor :data` qui ne passe pas par `add_attribute`,
+  `add_checkbox` ou `add_scopes`
+
+Tout query param qui ne matche pas l'allowlist est ignoré silencieusement.
+
+## Mécanisme
+
+Trois étapes :
+
+1. **Capture** (`AuthorizationRequestFormsController#new`) : filtre les query
+   params via `prefillable_attribute_names` et stocke le résultat en session,
+   keyé par `form_uid` :
+   ```ruby
+   session[:authorization_request_prefill] = { 'form_uid' => ..., 'data' => ... }
+   ```
+   Si l'URL n'a aucun query param prefillable, un éventuel prefill stale de
+   la même session pour ce form est nettoyé — visiter la page d'intro sans
+   params réinitialise.
+
+2. **Affichage** (`#start`) : `peek_prefill_data` lit la session sans la
+   supprimer, passe les valeurs à `BuildAuthorizationRequest`. Les champs de la
+   première étape (ou de la page unique) s'affichent pré-remplis via
+   l'interactor `AssignQueryParamsDataToAuthorizationRequest`.
+
+3. **Persistance** (`#create`) : `peek_prefill_data` est aussi utilisé ici,
+   les valeurs sont passées à `CreateAuthorizationRequest` où l'interactor
+   `AssignQueryParamsDataToAuthorizationRequest` les applique **entre les
+   defaults (`initialize_with` YAML) et les params soumis** — donc le prefill
+   écrase les defaults statiques, et les saisies utilisateur écrasent le
+   prefill. La session n'est nettoyée qu'après que l'organizer a réussi
+   (`clear_prefill_data`). Tant que le create renvoie 422, le prefill survit
+   pour le submit suivant.
+
+   Cette étape est critique pour les formulaires wicked multi-étapes : tous
+   les champs pré-remplis (y compris ceux des étapes ultérieures à l'étape
+   courante) sont persistés dès la soumission de la première étape. Sans
+   cela, la reconstruction de la demande à chaque submit ferait perdre les
+   prefill d'étapes non encore atteintes.
+
+## Sécurité
+
+- **XSS** : les setters générés par `add_attribute` / `add_attribute(..., type:
+  :array)` appliquent `sanitize_html` (Loofah strip + `CGI.unescapeHTML`).
+- **Mass assignment** : seuls les attributs de l'allowlist sont passés à
+  `assign_attributes`. Les colonnes critiques (`state`, `applicant_id`…) et
+  les contacts restent inaccessibles.
+- **Type confusion** : si un setter raise (ex. string passée à un array
+  attribute non parsable en JSON), l'interactor rescue et skip l'attribut.
+- **Scoping session** : un prefill capturé pour un `form_uid` est ignoré si
+  l'utilisateur consomme via un autre `form_uid`.
+
+## Étendre l'allowlist
+
+Ajouter un nouveau champ pré-remplissable :
+
+- via `add_attribute(:nom)` ou `add_checkbox(:nom)` dans la classe de demande
+  → automatiquement inclus
+- via `add_scopes(...)` → `scopes` automatiquement inclus
+
+Pour autoriser un autre `store_accessor` (déconseillé pour les contacts), il
+faut étendre `AuthorizationRequest.prefillable_attribute_names` et refaire
+une analyse de sécurité (en particulier sur les risques d'usurpation
+d'identité quand le champ pilote des notifications email).

--- a/features/habilitations/pre_remplissage_query_params.feature
+++ b/features/habilitations/pre_remplissage_query_params.feature
@@ -1,0 +1,25 @@
+# language: fr
+
+Fonctionnalité: Pré-remplissage des champs d'une demande d'habilitation via les query params
+
+  Un lien direct vers un formulaire accepte des query params nommés comme les
+  attributs de la demande, qui sont pré-remplis dans le formulaire.
+
+  Contexte:
+    Sachant que je suis un demandeur
+    Et que je me connecte
+
+  Scénario: Le champ intitulé est pré-rempli depuis un query param
+    Quand je visite le formulaire "api-indicateurs-sociaux" avec le paramètre "intitule" égal à "Mon projet pré-rempli"
+    Et que je clique sur "Débuter ma demande"
+
+    Alors le champ "Nom du projet" contient "Mon projet pré-rempli"
+
+  Scénario: Un champ d'une étape ultérieure est pré-rempli après soumission de l'étape précédente
+    Quand je visite le formulaire "api-indicateurs-sociaux" avec le paramètre "cadre_juridique_url" égal à "https://legifrance.gouv.fr/preremplie"
+    Et que je clique sur "Débuter ma demande"
+
+    * je renseigne les infos de bases du projet
+    * je clique sur "Suivant"
+
+    Alors le champ "URL du texte relatif au traitement" contient "https://legifrance.gouv.fr/preremplie"

--- a/features/step_definitions/authorization_requests_steps.rb
+++ b/features/step_definitions/authorization_requests_steps.rb
@@ -73,6 +73,10 @@ Quand("je démarre une nouvelle demande d'habilitation {string} avec le paramèt
   visit new_authorization_request_path(definition_id: find_authorization_definition_from_name(string).id, key => value)
 end
 
+Quand('je visite le formulaire {string} avec le paramètre {string} égal à {string}') do |form_uid, key, value|
+  visit new_authorization_request_form_path(form_uid:, key => value)
+end
+
 Quand('je remplis les informations du contact {string} avec :') do |string, table|
   contact_title_node = find('.contact-form-card__title', text: string)
   contact_node = contact_title_node.find(:xpath, '../../..')

--- a/spec/controllers/authorization_request_forms_controller_spec.rb
+++ b/spec/controllers/authorization_request_forms_controller_spec.rb
@@ -12,5 +12,42 @@ RSpec.describe AuthorizationRequestFormsController do
         expect(flash[:alert]).to eq("Le formulaire demandé n'existe pas")
       end
     end
+
+    context 'with prefill query parameters' do
+      let(:form_uid) { 'api-particulier' }
+      let(:user) { create(:user) }
+
+      before { sign_in(user) }
+
+      it 'stores filtered prefill data in session, scoped by form_uid' do
+        get :new, params: { form_uid:, intitule: 'Mon projet', not_an_attribute: 'noise' }
+
+        expect(session[:authorization_request_prefill]).to eq(
+          'form_uid' => form_uid,
+          'data' => { 'intitule' => 'Mon projet' },
+        )
+      end
+
+      it 'does not store anything when no params match an attribute' do
+        get :new, params: { form_uid:, not_an_attribute: 'noise' }
+
+        expect(session[:authorization_request_prefill]).to be_nil
+      end
+
+      it 'clears stale prefill for the same form on a bare revisit' do
+        get :new, params: { form_uid:, intitule: 'Premier passage' }
+        expect(session[:authorization_request_prefill]).to be_present
+
+        get :new, params: { form_uid: }
+        expect(session[:authorization_request_prefill]).to be_nil
+      end
+
+      it 'preserves prefill for another form on a bare revisit' do
+        get :new, params: { form_uid:, intitule: 'Premier passage' }
+
+        get :new, params: { form_uid: 'api-entreprise-socle-de-base' }
+        expect(session[:authorization_request_prefill]).to include('form_uid' => form_uid)
+      end
+    end
   end
 end

--- a/spec/interactors/assign_query_params_data_to_authorization_request_spec.rb
+++ b/spec/interactors/assign_query_params_data_to_authorization_request_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe AssignQueryParamsDataToAuthorizationRequest do
+  describe '#call' do
+    subject(:interactor) { described_class.call(authorization_request:, prefill_data:) }
+
+    let(:authorization_request) { build(:authorization_request, :api_particulier) }
+
+    context 'when prefill_data is nil' do
+      let(:prefill_data) { nil }
+
+      it { is_expected.to be_success }
+
+      it 'does not assign anything' do
+        expect { interactor }.not_to change(authorization_request, :intitule)
+      end
+    end
+
+    context 'when prefill_data is empty' do
+      let(:prefill_data) { {} }
+
+      it { is_expected.to be_success }
+    end
+
+    context 'with a string attribute declared via add_attributes' do
+      let(:prefill_data) { { 'intitule' => 'Mon super projet' } }
+
+      it 'assigns it on the authorization request' do
+        interactor
+
+        expect(authorization_request.intitule).to eq('Mon super projet')
+      end
+    end
+
+    context 'with an array attribute' do
+      let(:prefill_data) { { 'modalities' => %w[france_connect params] } }
+
+      it 'assigns it on the authorization request' do
+        interactor
+
+        expect(authorization_request.modalities).to match_array(%w[france_connect params])
+      end
+    end
+
+    context 'with scopes' do
+      let(:prefill_data) { { 'scopes' => %w[cnaf_quotient_familial cnaf_allocataires] } }
+
+      it 'assigns scopes on the authorization request' do
+        interactor
+
+        expect(authorization_request.scopes).to match_array(%w[cnaf_quotient_familial cnaf_allocataires])
+      end
+    end
+
+    context 'with scopes on a request that does not support them' do
+      let(:authorization_request) { build(:authorization_request, :api_captchetat) }
+      let(:prefill_data) { { 'scopes' => %w[whatever] } }
+
+      it 'ignores them' do
+        interactor
+
+        expect(authorization_request.data['scopes']).to be_nil
+      end
+    end
+
+    context 'with a boolean attribute (checkbox)' do
+      let(:authorization_request) { build(:authorization_request, :api_ficoba_sandbox) }
+      let(:prefill_data) { { 'dpd_homologation_checkbox' => '1' } }
+
+      it 'assigns it on the authorization request' do
+        interactor
+
+        expect(authorization_request.dpd_homologation_checkbox).to be(true)
+      end
+    end
+
+    context 'with a key that is not prefillable' do
+      let(:prefill_data) { { 'contact_technique_email' => 'attacker@evil.com', 'unknown_field' => 'foo' } }
+
+      it 'ignores the unknown keys' do
+        interactor
+
+        expect(authorization_request.contact_technique_email).to be_nil
+      end
+    end
+
+    context 'when default data was already assigned' do
+      let(:prefill_data) { { 'intitule' => 'Depuis query param' } }
+
+      before do
+        authorization_request.intitule = 'Depuis initialize_with'
+      end
+
+      it 'overwrites the default data' do
+        interactor
+
+        expect(authorization_request.intitule).to eq('Depuis query param')
+      end
+    end
+
+    context 'with a value whose setter raises' do
+      let(:prefill_data) { { 'modalities' => 'not-an-array', 'intitule' => 'still works' } }
+
+      it 'skips the offending attribute and keeps assigning the others' do
+        interactor
+
+        expect(authorization_request.intitule).to eq('still works')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Permet de partager des liens directs vers un formulaire de demande d'habilitation avec des champs pré-remplis, par exemple : https://datapass.api.gouv.fr/formulaires/api-entreprise-socle-de-base/demande/nouveau?intitule=Mon+projet&scopes[]=scope1

Mécanisme :
- AuthorizationRequestFormsController#new capture les query params, les filtre via AuthorizationRequest.prefillable_attribute_names (extra_attributes déclarés via add_attributes / add_checkbox, plus 'scopes' si le formulaire active les scopes), et stocke le résultat en session, keyé par form_uid.
- Le start lit le prefill en session (peek) pour afficher la première étape avec les valeurs pré-remplies.
- Le create consomme le prefill (delete) et l'applique via AssignQueryParamsDataToAuthorizationRequest dans CreateAuthorizationRequestModel, entre les defaults du formulaire et les params soumis par l'utilisateur. L'ordre garantit que les valeurs saisies par l'utilisateur écrasent le prefill, et que le prefill écrase les defaults statiques du YAML.

Persiste pour les formulaires multi-étapes : tous les champs prefill sont écrits en base dès la soumission de la première étape, même ceux dont le champ se trouve sur une étape ultérieure (sans cette persistance précoce, ils seraient perdus à la reconstruction de la demande au submit suivant).

Sécurité : seuls les attributs explicitement déclarés via add_attributes, add_checkbox et add_scopes sont prefillables. Les sous-champs de contacts (emails, téléphones) sont volontairement exclus pour empêcher l'usurpation d'identité.

Documentation dans docs/technique/pre_remplissage_query_params.md.