### PR TITLE
fix(lint): prefer have_text over have_content in user_rights steps

### DIFF
--- a/features/step_definitions/user_rights_steps.rb
+++ b/features/step_definitions/user_rights_steps.rb
@@ -55,13 +55,13 @@ end
 
 Alors('le tableau des utilisateurs contient {string}') do |email|
   within('#user-rights-table') do
-    expect(page).to have_content(email)
+    expect(page).to have_text(email)
   end
 end
 
 Alors('le tableau des utilisateurs ne contient pas {string}') do |email|
   within('#user-rights-table') do
-    expect(page).to have_no_content(email)
+    expect(page).to have_no_text(email)
   end
 end
 


### PR DESCRIPTION
## Summary
- Corrige les 2 offenses `Capybara/RSpec/HaveContent` dans `features/step_definitions/user_rights_steps.rb` qui cassent le run Rubocop sur `develop`.
- Auto-correction suggérée par le cop : `have_content` → `have_text`, `have_no_content` → `have_no_text`.

## Test plan
- [ ] CI Rubocop passe au vert