### PR TITLE
Admins peuvent s'auto-éditer dans la gestion des droits (DP-1720)

### DIFF
--- a/app/components/atoms/color_badge_component.rb
+++ b/app/components/atoms/color_badge_component.rb
@@ -26,6 +26,7 @@ class Atoms::ColorBadgeComponent < ApplicationComponent
     'instructor' => 'pink-tuile',
     'reporter' => 'yellow-tournesol',
     'developer' => 'blue-ecume',
+    'admin' => 'pink-macaron',
   }.freeze
 
   def self.for_role(role_type, label:)

--- a/app/components/molecules/instruction/user_rights/readonly_rights_list_component.html.erb
+++ b/app/components/molecules/instruction/user_rights/readonly_rights_list_component.html.erb
@@ -4,7 +4,9 @@
   <ul role="list" class="fr-list--flat-flex">
     <% rights.each do |right| %>
       <li>
-        <strong><%= Instruction::Scope.new(right[:scope]).label %></strong>
+        <% if right[:scope].present? %>
+          <strong><%= Instruction::Scope.new(right[:scope]).label %></strong>
+        <% end %>
         <%= render Atoms::ColorBadgeComponent.for_role(right[:role_type], label: t("instruction.user_rights.roles.#{right[:role_type]}")) %>
       </li>
     <% end %>

--- a/app/components/molecules/instruction/user_rights/table_row_component.html.erb
+++ b/app/components/molecules/instruction/user_rights/table_row_component.html.erb
@@ -6,7 +6,9 @@
     <ul role="list" class="fr-list--flat-flex">
       <% visible_rights.each do |entry| %>
         <li>
-          <span class="fr-text--bold"><%= entry[:label] %></span>
+          <% if entry[:scope].present? %>
+            <span class="fr-text--bold"><%= entry[:label] %></span>
+          <% end %>
           <% entry[:role_types].each do |role_type| %>
             <%= render Atoms::ColorBadgeComponent.for_role(role_type, label: t("instruction.user_rights.roles.#{role_type}")) %>
           <% end %>

--- a/app/controllers/admin/user_rights_controller.rb
+++ b/app/controllers/admin/user_rights_controller.rb
@@ -71,7 +71,6 @@ class Admin::UserRightsController < AdminController
 
   def managed_users_scope
     User.with_any_role_on(@authority.managed_definitions.map(&:id))
-      .where.not(id: true_user.id)
   end
 
   def authorize_user_rights!

--- a/app/controllers/admin/user_rights_controller.rb
+++ b/app/controllers/admin/user_rights_controller.rb
@@ -71,6 +71,7 @@ class Admin::UserRightsController < AdminController
 
   def managed_users_scope
     User.with_any_role_on(@authority.managed_definitions.map(&:id))
+      .or(User.with_role_matching(['admin']))
   end
 
   def authorize_user_rights!

--- a/app/models/instruction/user_rights_view.rb
+++ b/app/models/instruction/user_rights_view.rb
@@ -34,6 +34,8 @@ class Instruction::UserRightsView
       next unless @authority.covers_role?(role_string)
 
       parsed = ParsedRole.parse(role_string)
+      next { scope: nil, role_type: parsed.role } if parsed.admin?
+
       { scope: "#{parsed.provider_slug}:#{parsed.definition_id}", role_type: parsed.role }
     end
   end

--- a/app/models/rights/admin_authority.rb
+++ b/app/models/rights/admin_authority.rb
@@ -21,8 +21,7 @@ class Rights::AdminAuthority < Rights::Authority
   end
 
   def covers_role?(role_string)
-    parsed = ParsedRole.parse(role_string)
-    !parsed.admin? && !parsed.role.nil?
+    !ParsedRole.parse(role_string).role.nil?
   end
 
   def audit_event_name

--- a/app/policies/admin/user_right_policy.rb
+++ b/app/policies/admin/user_right_policy.rb
@@ -4,6 +4,6 @@ class Admin::UserRightPolicy < Instruction::UserRightPolicy
   end
 
   def edit?
-    enabled? && record != user
+    enabled?
   end
 end

--- a/app/views/instruction/user_rights/_page_header.html.erb
+++ b/app/views/instruction/user_rights/_page_header.html.erb
@@ -1,7 +1,7 @@
 <div class="fr-bg-grey fr-py-5w fr-mb-3w">
   <%= dsfr_breadcrumbs do |b|
         b.with_breadcrumb(label: t('layouts.header.menu.instruction.user_rights'),
-                          href: instruction_user_rights_path)
+                          href: user_rights_index_path)
         b.with_breadcrumb(label: breadcrumb_label)
       end %>
 

--- a/config/locales/instruction.fr.yml
+++ b/config/locales/instruction.fr.yml
@@ -556,6 +556,7 @@ fr:
         instructor: Instructeur
         reporter: Observateur
         developer: Développeur
+        admin: Admin
       new:
         title: Ajouter des droits à un utilisateur sans droits
         breadcrumb: Ajouter des droits

--- a/features/admin/gestion_des_droits/je_modifie_des_droits.feature
+++ b/features/admin/gestion_des_droits/je_modifie_des_droits.feature
@@ -39,11 +39,12 @@ Fonctionnalité: Admin — Gestion des droits — modifier les droits d’un uti
     Alors il y a un message de succès contenant "mis à jour"
     Et l'utilisateur "mixte@gouv.fr" a les rôles "dinum:api_particulier:manager,dinum:api_entreprise:instructor"
 
-  Scénario: Je peux modifier mes propres droits
+  Scénario: Je peux modifier mes propres droits, mon rôle admin reste affiché en lecture seule
     Quand il y a l'utilisateur "admin@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
     Et que je me rends sur la page de gestion des droits
     Et que je clique sur "Modifier les droits de admin@gouv.fr"
-    Et que je sélectionne "Instructeur" pour "Rôle"
+    Alors la section des droits non modifiables contient le badge "Admin"
+    Quand je sélectionne "Instructeur" pour "Rôle"
     Et que je clique sur "Valider les modifications"
     Alors il y a un message de succès contenant "mis à jour"
     Et l'utilisateur "admin@gouv.fr" a les rôles "admin,dinum:api_entreprise:instructor"
@@ -54,7 +55,7 @@ Fonctionnalité: Admin — Gestion des droits — modifier les droits d’un uti
     Et que j'impersonne l'utilisateur "user-x@gouv.fr"
     Et que je me rends sur la page de gestion des droits
     Alors le tableau des utilisateurs contient "user-x@gouv.fr"
-    Et le tableau des utilisateurs ne contient pas "admin@gouv.fr"
+    Et le tableau des utilisateurs contient "admin@gouv.fr"
     Quand je clique sur "Modifier les droits de cible@gouv.fr"
     Et que je sélectionne "Instructeur" pour "Rôle"
     Et que je clique sur "Valider les modifications"

--- a/features/admin/gestion_des_droits/je_modifie_des_droits.feature
+++ b/features/admin/gestion_des_droits/je_modifie_des_droits.feature
@@ -43,7 +43,8 @@ Fonctionnalité: Admin — Gestion des droits — modifier les droits d’un uti
     Quand il y a l'utilisateur "admin@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
     Et que je me rends sur la page de gestion des droits
     Et que je clique sur "Modifier les droits de admin@gouv.fr"
-    Alors la section des droits non modifiables contient le badge "Admin"
+    Alors le fil d’Ariane contient un lien "Gestion des droits" vers la page de gestion des droits admin
+    Et la section des droits non modifiables contient le badge "Admin"
     Quand je sélectionne "Instructeur" pour "Rôle"
     Et que je clique sur "Valider les modifications"
     Alors il y a un message de succès contenant "mis à jour"

--- a/features/admin/gestion_des_droits/je_modifie_des_droits.feature
+++ b/features/admin/gestion_des_droits/je_modifie_des_droits.feature
@@ -2,8 +2,8 @@
 
 Fonctionnalité: Admin — Gestion des droits — modifier les droits d’un utilisateur
   En tant qu’administrateur, je peux modifier les droits de n’importe quel
-  utilisateur sur n’importe quelle définition, y compris le rôle développeur,
-  mais je ne peux pas modifier mes propres droits.
+  utilisateur sur n’importe quelle définition, y compris le rôle développeur
+  et y compris mes propres droits.
 
   Contexte:
     Sachant que je suis un administrateur
@@ -39,9 +39,14 @@ Fonctionnalité: Admin — Gestion des droits — modifier les droits d’un uti
     Alors il y a un message de succès contenant "mis à jour"
     Et l'utilisateur "mixte@gouv.fr" a les rôles "dinum:api_particulier:manager,dinum:api_entreprise:instructor"
 
-  Scénario: Je ne peux pas modifier mes propres droits via URL forgée
-    Quand je tente de modifier mes propres droits via URL
-    Alors il y a un message d'erreur contenant "Vous n'avez pas le droit d'accéder à cette page"
+  Scénario: Je peux modifier mes propres droits
+    Quand il y a l'utilisateur "admin@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
+    Et que je me rends sur la page de gestion des droits
+    Et que je clique sur "Modifier les droits de admin@gouv.fr"
+    Et que je sélectionne "Instructeur" pour "Rôle"
+    Et que je clique sur "Valider les modifications"
+    Alors il y a un message de succès contenant "mis à jour"
+    Et l'utilisateur "admin@gouv.fr" a les rôles "admin,dinum:api_entreprise:instructor"
 
   Scénario: Pendant une impersonation, mes actions admin restent attribuées à mon vrai compte
     Quand il y a l'utilisateur "user-x@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"

--- a/features/admin/gestion_des_droits/liste_des_droits.feature
+++ b/features/admin/gestion_des_droits/liste_des_droits.feature
@@ -15,9 +15,10 @@ Fonctionnalité: Admin — Gestion des droits — lister les utilisateurs avec d
     Alors la page contient "user1@gouv.fr"
     Et la page contient "user2@gouv.fr"
 
-  Scénario: Je ne me vois pas dans ma propre liste
-    Quand je me rends sur la page de gestion des droits
-    Alors la page ne contient pas mon email
+  Scénario: Je me vois dans ma propre liste si j’ai un rôle non-admin sur une définition
+    Quand il y a l'utilisateur "admin@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
+    Et que je me rends sur la page de gestion des droits
+    Alors le tableau des utilisateurs contient "admin@gouv.fr"
 
   Scénario: Le menu admin contient un lien vers la gestion des droits
     Quand je me rends sur le chemin "/admin"

--- a/features/admin/gestion_des_droits/liste_des_droits.feature
+++ b/features/admin/gestion_des_droits/liste_des_droits.feature
@@ -15,10 +15,17 @@ Fonctionnalité: Admin — Gestion des droits — lister les utilisateurs avec d
     Alors la page contient "user1@gouv.fr"
     Et la page contient "user2@gouv.fr"
 
-  Scénario: Je me vois dans ma propre liste si j’ai un rôle non-admin sur une définition
+  Scénario: Je me vois dans ma propre liste avec mon badge d’admin
+    Quand je me rends sur la page de gestion des droits
+    Alors le tableau des utilisateurs contient "admin@gouv.fr"
+    Et le tableau des utilisateurs contient le badge "Admin"
+
+  Scénario: Je me vois dans ma propre liste avec mes autres rôles
     Quand il y a l'utilisateur "admin@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
     Et que je me rends sur la page de gestion des droits
     Alors le tableau des utilisateurs contient "admin@gouv.fr"
+    Et le tableau des utilisateurs contient le badge "Admin"
+    Et le tableau des utilisateurs contient le badge "Observateur"
 
   Scénario: Le menu admin contient un lien vers la gestion des droits
     Quand je me rends sur le chemin "/admin"

--- a/features/step_definitions/user_rights_steps.rb
+++ b/features/step_definitions/user_rights_steps.rb
@@ -65,6 +65,18 @@ Alors('le tableau des utilisateurs ne contient pas {string}') do |email|
   end
 end
 
+Alors('le tableau des utilisateurs contient le badge {string}') do |label|
+  within('#user-rights-table') do
+    expect(page).to have_css('p.fr-badge', text: label)
+  end
+end
+
+Alors('la section des droits non modifiables contient le badge {string}') do |label|
+  within('#readonly-rights') do
+    expect(page).to have_css('p.fr-badge', text: label)
+  end
+end
+
 Quand('je tente de modifier mes propres droits via URL') do
   visit edit_user_right_path_for(current_user!, current_user!)
 end

--- a/features/step_definitions/user_rights_steps.rb
+++ b/features/step_definitions/user_rights_steps.rb
@@ -77,6 +77,12 @@ Alors('la section des droits non modifiables contient le badge {string}') do |la
   end
 end
 
+Alors('le fil d’Ariane contient un lien {string} vers la page de gestion des droits admin') do |label|
+  within('.fr-breadcrumb') do
+    expect(page).to have_link(label, href: admin_user_rights_path)
+  end
+end
+
 Quand('je tente de modifier mes propres droits via URL') do
   visit edit_user_right_path_for(current_user!, current_user!)
 end

--- a/spec/components/atoms/color_badge_component_spec.rb
+++ b/spec/components/atoms/color_badge_component_spec.rb
@@ -38,4 +38,13 @@ RSpec.describe Atoms::ColorBadgeComponent, type: :component do
       end
     end
   end
+
+  describe '.for_role' do
+    it 'returns a pink-macaron badge for admin' do
+      component = described_class.for_role('admin', label: 'Admin')
+      rendered = render_inline(component)
+
+      expect(rendered).to have_css('p.fr-badge.fr-badge--pink-macaron', text: 'Admin')
+    end
+  end
 end

--- a/spec/components/previews/molecules/instruction/user_rights/readonly_rights_list_component_preview.rb
+++ b/spec/components/previews/molecules/instruction/user_rights/readonly_rights_list_component_preview.rb
@@ -11,6 +11,7 @@ class Molecules::Instruction::UserRights::ReadonlyRightsListComponentPreview < V
 
   def sample_rights
     [
+      { scope: nil, role_type: 'admin' },
       { scope: 'dinum:api_entreprise', role_type: 'developer' },
       { scope: 'dinum:api_particulier', role_type: 'developer' }
     ]

--- a/spec/models/instruction/user_rights_view_spec.rb
+++ b/spec/models/instruction/user_rights_view_spec.rb
@@ -38,4 +38,42 @@ RSpec.describe Instruction::UserRightsView do
       end
     end
   end
+
+  describe '#grouped_visible (admin authority)' do
+    subject(:result) { described_class.new(authority: Rights::AdminAuthority.new(admin), user: target).grouped_visible }
+
+    let(:admin) { create(:user, :admin) }
+
+    context 'when target has only the admin role' do
+      let(:target) { create(:user, :admin) }
+
+      it 'returns a single entry with nil scope and admin role_type' do
+        expect(result.size).to eq(1)
+        expect(result.first[:scope]).to be_nil
+        expect(result.first[:role_types]).to eq(['admin'])
+      end
+    end
+
+    context 'when target has both admin and a non-admin role' do
+      let(:target) { create(:user, roles: %w[admin dinum:api_entreprise:reporter]) }
+
+      it 'returns one entry per scope (including the nil scope for admin)' do
+        expect(result.pluck(:scope)).to contain_exactly(nil, 'dinum:api_entreprise')
+      end
+    end
+  end
+
+  describe '#readonly (admin authority)' do
+    subject(:result) { described_class.new(authority: Rights::AdminAuthority.new(admin), user: target).readonly }
+
+    let(:admin) { create(:user, :admin) }
+
+    context 'when target has the admin role' do
+      let(:target) { create(:user, roles: %w[admin dinum:api_entreprise:reporter]) }
+
+      it 'contains the admin role as readonly (nil scope)' do
+        expect(result).to contain_exactly(scope: nil, role_type: 'admin')
+      end
+    end
+  end
 end

--- a/spec/models/rights/admin_authority_spec.rb
+++ b/spec/models/rights/admin_authority_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe Rights::AdminAuthority do
   end
 
   describe '#covers_role?' do
-    it 'returns false for the admin role' do
-      expect(authority.covers_role?('admin')).to be false
+    it 'returns true for the admin role (visible but non-manageable)' do
+      expect(authority.covers_role?('admin')).to be true
     end
 
     it 'returns true for any non-admin role (regardless of role_type)' do

--- a/spec/policies/admin/user_right_policy_spec.rb
+++ b/spec/policies/admin/user_right_policy_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Admin::UserRightPolicy do
       let(:user) { create(:user, :admin) }
       let(:target) { user }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
 
     context 'when user is admin and target has only roles under another provider' do
@@ -84,7 +84,7 @@ RSpec.describe Admin::UserRightPolicy do
       let(:user) { create(:user, :admin) }
       let(:target) { user }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
   end
 end


### PR DESCRIPTION
## Contexte

Suite à [DP-1692](https://linear.app/pole-api/issue/DP-1692), un admin ne pouvait pas modifier ses propres rôles depuis `/admin/gestion-des-droits` et devait passer par un autre admin. Cette PR lève cette restriction côté **espace admin uniquement** (l'espace manager reste inchangé) et améliore l'affichage du rôle `admin` sur cette interface.

Linear : [DP-1720](https://linear.app/pole-api/issue/DP-1720)

## Summary

- **Auto-édition admin** ([1d8481a1](../commit/1d8481a1))
  - `Admin::UserRightPolicy#edit?` → retire `record != user`
  - `Admin::UserRightsController#managed_users_scope` → retire `.where.not(id: true_user.id)` (l'admin apparaît dans le tableau s'il possède un rôle non-admin sur une définition)
- **Affichage du rôle admin** ([0dbe2aa7](../commit/0dbe2aa7))
  - Badge `Admin` pink-macaron dans le tableau de la liste
  - Section « Droits non modifiables » sur l'écran d'édition (même pattern que `developer` chez un manager FD)
  - Implémenté en passant `admin` de la zone *non couverte* à *couverte mais non manageable* dans `AdminAuthority` ; templates adaptés pour gérer le scope nil
- **Fix breadcrumb** ([15f1a447](../commit/15f1a447))
  - `_page_header.html.erb` codait `instruction_user_rights_path` en dur → bascule sur le helper namespacé `user_rights_index_path`

## Garde-fous conservés

Les invariants posés en DP-1692 restent en place :

- `AdminAuthority#can_manage_role?` continue de refuser le rôle `admin` (impossible de se l'attribuer ou de se le retirer via cette UI)
- `MergeManagedRoles#preserved_roles` préserve les rôles non couverts par `can_manage_role?` → un admin qui « supprime tous ses droits » garde son rôle `admin`
- Le select « Rôle » du formulaire n'expose pas `admin` (`ALLOWED_ROLE_TYPES = [reporter, instructor, manager, developer]`)
- Les actions admin pendant impersonation restent attribuées à `true_user`

## Test plan

- [x] `bundle exec rspec` : 2661/0
- [x] `bundle exec rubocop` : 0 offense
- [x] `bundle exec cucumber features/admin/gestion_des_droits/` : 13/13
- [x] `bundle exec cucumber features/instructeurs/gestion_des_droits/` : 28/28 (non-régression)
- [x] Smoke manuel : admin se rend sur `/admin/gestion-des-droits`, se voit dans le tableau avec son badge `Admin`, clique « Modifier les droits de admin@… », observe le badge `Admin` en lecture seule, modifie un rôle non-admin, valide, vérifie que le rôle admin est conservé.
- [x] Smoke manuel : sur l'écran d'édition admin, vérifier que le lien « Gestion des droits » du fil d'Ariane pointe bien vers `/admin/gestion-des-droits` (et non `/instruction/gestion-des-droits`).