### PR TITLE
feat(hubee-dila): déprécie le scope DHTOUR (hébergement touristique)

### DIFF
--- a/config/authorization_definitions/hubee.yml
+++ b/config/authorization_definitions/hubee.yml
@@ -37,6 +37,8 @@ hubee_dila:
     - name: "DHTOUR - Déclaration d’hébergement touristique"
       value: "hebergement_tourisme"
       group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+      deprecated:
+        since: '2026-05-20'
     - name: "JCC - Déclaration de Changement de Coordonnées"
       value: "je_change_de_coordonnees"
       group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"

--- a/config/authorization_request_forms/others.yml
+++ b/config/authorization_request_forms/others.yml
@@ -19,8 +19,6 @@ hubee-dila:
     <br />
     ● RCO - Recensement Citoyen Obligatoire
     <br />
-    ● DHTOUR - Déclaration d’hébergement touristique
-    <br />
     ● JCC - Déclaration de Changement de Coordonnées
   authorization_request: "HubEEDila"
   service_provider_id: hubee

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -270,12 +270,6 @@ fr:
               Baccalauréat, permis de conduire, etc.).
             </p>
             <p>
-              <strong>DHTOUR - Déclaration d’hébergement touristique</strong> : Ce service permet aux particuliers et professionnels de déclarer en
-              ligne un meublé de tourisme ou une chambre d’hôtes. Ce service peut être
-              proposé par les municipalités qui collectent la taxe de séjour
-              uniquement (métropoles de droit commun).
-            </p>
-            <p>
               <strong>JCC - Déclaration de Changement de Coordonnées</strong> : Ce service permet à un usager de déclarer rapidement et facilement un
               changement d’adresse postale lors d’un déménagement ou d’une
               modification administrative. Via ce service, l’usager peut également

--- a/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
+++ b/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
@@ -5,12 +5,11 @@ Fonctionnalité: Soumission d'une demande d'habilitation Démarches du bouquet d
     Sachant que je suis un demandeur
     Et que je me connecte
 
-  Scénario: Je soumets une demande d'habilitation valide
-    Quand je démarre une nouvelle demande d'habilitation "Démarches du bouquet de services (service-public.fr)"
+  Scénario: Je soumets une demande d’habilitation valide
+    Quand je démarre une nouvelle demande d’habilitation "Démarches du bouquet de services (service-public.fr)"
     * je coche "AEC - Acte d’Etat Civil"
     * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
     * je coche "RCO - Recensement Citoyen Obligatoire"
-    * je coche "DHTOUR - Déclaration d’hébergement touristique"
     * je coche "JCC - Déclaration de Changement de Coordonnées"
 
     * je remplis les informations du contact "Administrateur local" avec :
@@ -33,12 +32,11 @@ Fonctionnalité: Soumission d'une demande d'habilitation Démarches du bouquet d
     Et il y a un message d'erreur contenant "Les données ne sont pas cochées"
     Et je suis sur la page "Démarches du bouquet de services (service-public.fr)"
 
-  Scénario: Je remplis une demande d'habilitation avec un champ du contact manquant
-    Quand je démarre une nouvelle demande d'habilitation "Démarches du bouquet de services (service-public.fr)"
+  Scénario: Je remplis une demande d’habilitation avec un champ du contact manquant
+    Quand je démarre une nouvelle demande d’habilitation "Démarches du bouquet de services (service-public.fr)"
     * je coche "AEC - Acte d’Etat Civil"
     * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
     * je coche "RCO - Recensement Citoyen Obligatoire"
-    * je coche "DHTOUR - Déclaration d’hébergement touristique"
     * je coche "JCC - Déclaration de Changement de Coordonnées"
 
     * je remplis les informations du contact "Administrateur local" avec :


### PR DESCRIPTION
La DILA retire la démarche DHTOUR du formulaire service-public.gouv.fr. Le scope hebergement_tourisme reste dans la config pour préserver les demandes existantes (rétrocompatibilité via le mécanisme générique deprecated.since), mais devient indisponible pour toute nouvelle demande créée après le 2026-05-20.

Aligne également le texte d'introduction et la bulle d'aide pour retirer la mention DHTOUR côté demandeur.