### PR TITLE
fix(instruction): recherche dashboard accepte le formatted_id (D/H)

### DIFF
--- a/app/controllers/instruction/dashboard_controller.rb
+++ b/app/controllers/instruction/dashboard_controller.rb
@@ -30,9 +30,11 @@ class Instruction::DashboardController < Instruction::AbstractAuthorizationReque
   def find_searched_record
     case params[:id]
     when 'demandes'
-      AuthorizationRequest.find_by(id: params[:search_query][Instruction::Search::DashboardSearch.key])
+      extracted_id = Instruction::Search::DashboardSearch.extract_id_from_search_terms(params, expected_prefix: 'D')
+      AuthorizationRequest.find_by(id: extracted_id) if extracted_id
     when 'habilitations'
-      Authorization.find_by(id: params[:search_query][Instruction::Search::DashboardSearch.key])
+      extracted_id = Instruction::Search::DashboardSearch.extract_id_from_search_terms(params, expected_prefix: 'H')
+      Authorization.find_by(id: extracted_id) if extracted_id
     end
   end
 

--- a/app/facades/instruction/search/dashboard_search.rb
+++ b/app/facades/instruction/search/dashboard_search.rb
@@ -24,6 +24,16 @@ class Instruction::Search::DashboardSearch
     /^\s*[DH]?\d{1,10}\s*$/i.match?(main_search_input)
   end
 
+  def self.extract_id_from_search_terms(params, expected_prefix:)
+    return nil unless search_terms_is_a_possible_id?(params)
+
+    input = params[:search_query][key].to_s.strip
+    return input.to_i if input.match?(/^\d+$/)
+
+    match = input.match(/^#{Regexp.escape(expected_prefix)}(\d+)$/i)
+    match[1].to_i if match
+  end
+
   def self.key
     'within_data_or_organization_name_or_organization_legal_entity_id_or_applicant_email_or_applicant_family_name_cont'
   end

--- a/spec/facades/instruction/search/dashboard_search_spec.rb
+++ b/spec/facades/instruction/search/dashboard_search_spec.rb
@@ -62,4 +62,52 @@ RSpec.describe Instruction::Search::DashboardSearch do
       expect(described_class.key).to eq expected_key
     end
   end
+
+  describe '.extract_id_from_search_terms' do
+    context 'when search input is a raw numeric ID' do
+      let(:params) { { search_query: { described_class.key => '123' } } }
+
+      it 'returns the integer for the demandes prefix' do
+        expect(described_class.extract_id_from_search_terms(params, expected_prefix: 'D')).to eq 123
+      end
+
+      it 'returns the integer for the habilitations prefix' do
+        expect(described_class.extract_id_from_search_terms(params, expected_prefix: 'H')).to eq 123
+      end
+    end
+
+    context 'when search input matches the expected prefix' do
+      let(:params) { { search_query: { described_class.key => 'D456' } } }
+
+      it 'returns the integer' do
+        expect(described_class.extract_id_from_search_terms(params, expected_prefix: 'D')).to eq 456
+      end
+
+      it 'accepts the lowercase prefix' do
+        params = { search_query: { described_class.key => 'd789' } }
+        expect(described_class.extract_id_from_search_terms(params, expected_prefix: 'D')).to eq 789
+      end
+
+      it 'accepts whitespace around the input' do
+        params = { search_query: { described_class.key => '  H42  ' } }
+        expect(described_class.extract_id_from_search_terms(params, expected_prefix: 'H')).to eq 42
+      end
+    end
+
+    context 'when search input has a non-matching prefix' do
+      let(:params) { { search_query: { described_class.key => 'H456' } } }
+
+      it 'returns nil' do
+        expect(described_class.extract_id_from_search_terms(params, expected_prefix: 'D')).to be_nil
+      end
+    end
+
+    context 'when search input is not a possible ID' do
+      let(:params) { { search_query: { described_class.key => 'some text' } } }
+
+      it 'returns nil' do
+        expect(described_class.extract_id_from_search_terms(params, expected_prefix: 'D')).to be_nil
+      end
+    end
+  end
 end

--- a/spec/features/instruction/search_demandes_spec.rb
+++ b/spec/features/instruction/search_demandes_spec.rb
@@ -173,6 +173,39 @@ RSpec.describe 'Instruction: demandes search' do
         expect(page).to have_css('.authorization-request', count: 0)
       end
     end
+
+    context 'when we use the formatted_id (D-prefixed)' do
+      let(:search_text) { valid_searched_authorization_request.formatted_id }
+
+      it 'redirects to the authorization request' do
+        search
+
+        expect(page).to have_current_path(instruction_authorization_request_path(valid_searched_authorization_request))
+      end
+    end
+
+    context 'when we use an H-prefixed id in the demandes tab' do
+      let(:search_text) { "H#{valid_searched_authorization_request.id}" }
+
+      it 'does not redirect and renders nothing' do
+        search
+
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'demandes'), ignore_query: true)
+        expect(page).to have_css('.authorization-request', count: 0)
+      end
+    end
+
+    context 'when we use the formatted_id of an unauthorized authorization request' do
+      let(:foreign_authorization_request) { create(:authorization_request, :hubee_dila, state: :validated) }
+      let(:search_text) { foreign_authorization_request.formatted_id }
+
+      it 'does not redirect and renders nothing' do
+        search
+
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'demandes'), ignore_query: true)
+        expect(page).to have_css('.authorization-request', count: 0)
+      end
+    end
   end
 
   context 'when we search with multiple states' do

--- a/spec/features/instruction/search_habilitations_spec.rb
+++ b/spec/features/instruction/search_habilitations_spec.rb
@@ -222,6 +222,44 @@ RSpec.describe 'Instruction: habilitations search' do
         expect(page).to have_css('.authorization', count: 0)
       end
     end
+
+    context 'when we use the formatted_id (H-prefixed)' do
+      let!(:valid_request) { create(:authorization_request, :api_entreprise, :submitted, intitule: intitule, organization: organization) }
+      let!(:valid_searched_authorization) { create(:authorization, request: valid_request, state: :active) }
+      let(:search_text) { valid_searched_authorization.formatted_id }
+
+      it 'redirects to the authorization' do
+        search
+
+        expect(page).to have_current_path(authorization_path(valid_searched_authorization))
+      end
+    end
+
+    context 'when we use a D-prefixed id in the habilitations tab' do
+      let!(:valid_request) { create(:authorization_request, :api_entreprise, :submitted, intitule: intitule, organization: organization) }
+      let!(:valid_searched_authorization) { create(:authorization, request: valid_request, state: :active) }
+      let(:search_text) { "D#{valid_searched_authorization.id}" }
+
+      it 'does not redirect and renders nothing' do
+        search
+
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'habilitations'), ignore_query: true)
+        expect(page).to have_css('.authorization', count: 0)
+      end
+    end
+
+    context 'when we use the formatted_id of an unauthorized authorization' do
+      let!(:foreign_request) { create(:authorization_request, :hubee_dila, :submitted) }
+      let!(:foreign_authorization) { create(:authorization, request: foreign_request, state: :active) }
+      let(:search_text) { foreign_authorization.formatted_id }
+
+      it 'does not redirect and renders nothing' do
+        search
+
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'habilitations'), ignore_query: true)
+        expect(page).to have_css('.authorization', count: 0)
+      end
+    end
   end
 
   context 'when we search with multiple states' do


### PR DESCRIPTION
Avant : `D1234` ou `H5678` étaient détectés comme « possible id » mais la string brute partait dans `find_by(id:)` → aucun match. Désormais on extrait l’entier en validant le préfixe par tab (`D` pour les demandes, `H` pour les habilitations). Un id avec le « mauvais » préfixe reste ignoré.