### PR TITLE
fix(authorization_definition): trier les formulaires « Demande libre en dernier

### DIFF
--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -133,9 +133,10 @@ class AuthorizationDefinition < StaticApplicationRecord
   end
 
   def available_forms
-    AuthorizationRequestForm.where(authorization_request_class:).sort do |form|
-      form.default ? 1 : 0
-    end
+    AuthorizationRequestForm
+      .where(authorization_request_class:)
+      .partition { |form| !form.default }
+      .flatten
   end
 
   def public

--- a/config/authorization_request_forms/api_droits_cnam.yml
+++ b/config/authorization_request_forms/api_droits_cnam.yml
@@ -1,17 +1,20 @@
-api-droits-cnam: &api_droit_cnam_form_attributes
+api-droits-cnam:
   name: Demande libre
   default: true
   authorization_request: APIDroitsCNAM
-  steps:
+  steps: &api_droit_cnam_shared_steps
     - name: basic_infos
     - name: personal_data
     - name: legal
     - name: france_connect
     - name: contacts
-api-droits-cnam-etablissement-de-soin:
-  <<: *api_droit_cnam_form_attributes
-  name: Établissement de soin
-api-droits-cnam-organisme-complementaire:
-  <<: *api_droit_cnam_form_attributes
-  name: Organisme complémentaire
 
+api-droits-cnam-etablissement-de-soin:
+  name: Établissement de soin
+  authorization_request: APIDroitsCNAM
+  steps: *api_droit_cnam_shared_steps
+
+api-droits-cnam-organisme-complementaire:
+  name: Organisme complémentaire
+  authorization_request: APIDroitsCNAM
+  steps: *api_droit_cnam_shared_steps

--- a/config/authorization_request_forms/api_ficoba.yml
+++ b/config/authorization_request_forms/api_ficoba.yml
@@ -1,5 +1,6 @@
 api-ficoba-sandbox:
   name: Demande libre (Bac à sable)
+  default: true
   public: true
   description: Pour les utilisateurs ayant besoin de réaliser une recette fonctionnelle en environnement de bac à sable.
   introduction: |
@@ -41,6 +42,7 @@ api-ficoba-sandbox:
 
 api-ficoba-production:
   name: Demande libre (Production)
+  default: true
   public: false
   startable_by_applicant: false
   description: Pour les utilisateurs ayant déjà réalisé une recette fonctionnelle en bac à sable et souhaitant obtenir des accès en production.
@@ -81,6 +83,7 @@ api-ficoba-production:
 
 api-ficoba-production-editeur:
   name: Demande libre avec éditeur
+  default: true
   public: true
   description: Pour les utilisateurs travaillant avec un éditeur ayant déjà effectué une recette fonctionnelle.
   introduction: &api_ficoba_editor_form_introduction |

--- a/config/authorization_request_forms/api_impot_particulier.yml
+++ b/config/authorization_request_forms/api_impot_particulier.yml
@@ -45,6 +45,7 @@ api-impot-particulier-sandbox:
 
 api-impot-particulier-production:
   name: Demande libre (Production)
+  default: true
   public: false
   startable_by_applicant: false
   stage:

--- a/config/authorization_request_forms/api_indemnites_journalieres_cnam.yml
+++ b/config/authorization_request_forms/api_indemnites_journalieres_cnam.yml
@@ -1,5 +1,6 @@
 api-indemnites-journalieres-cnam:
   name: Demande libre
+  default: true
   authorization_request: APIIndemnitesJournalieresCNAM
   steps:
     - name: basic_infos

--- a/config/authorization_request_forms/api_infinoe.yml
+++ b/config/authorization_request_forms/api_infinoe.yml
@@ -40,6 +40,7 @@ api-infinoe-sandbox:
 
 api-infinoe-production:
   name: Demande libre (Production)
+  default: true
   startable_by_applicant: false
   description: *api_infinoe_description
   introduction: &api_infinoe_production_form_introduction |

--- a/config/authorization_request_forms/api_r2p.yml
+++ b/config/authorization_request_forms/api_r2p.yml
@@ -1,5 +1,6 @@
 api-r2p-sandbox: &api-r2p-sandbox
   name: Demande libre (Bac à sable)
+  default: true
   public: true
   description: Pour les utilisateurs ayant besoin de réaliser une recette fonctionnelle en environnement de bac à sable.
   introduction: |
@@ -40,6 +41,7 @@ api-r2p-sandbox: &api-r2p-sandbox
 
 api-r2p-production: &api-r2p-production
   name: Demande libre (Production)
+  default: true
   public: false
   startable_by_applicant: false
   description: Pour les utilisateurs ayant déjà réalisé une recette fonctionnelle en bac à sable et souhaitant obtenir des accès en production.
@@ -126,6 +128,7 @@ api-r2p-appel-spi-production: &api-r2p-appel-spi-production
 
 api-r2p-production-editeur: &api-r2p-production-editeur
   name: Demande libre avec éditeur
+  default: true
   public: true
   description: Pour les utilisateurs travaillant avec un éditeur ayant déjà effectué une recette fonctionnelle.
   introduction: |

--- a/config/authorization_request_forms/api_sfip.yml
+++ b/config/authorization_request_forms/api_sfip.yml
@@ -42,6 +42,7 @@ api-sfip-sandbox:
 
 api-sfip-production:
   name: Demande libre (Production)
+  default: true
   public: false
   startable_by_applicant: false
   introduction: &api_sfip_production_form_introduction |

--- a/config/authorization_request_forms/france_connect.yml
+++ b/config/authorization_request_forms/france_connect.yml
@@ -1,5 +1,6 @@
 france-connect:
   name: Demande libre
+  default: true
   description: Demande libre
   introduction: |
     Ce formulaire est destiné aux administrations, collectivités et entreprises (sous réserve d'éligibilité) souhaitant intégrer FranceConnect à leur service en ligne.

--- a/spec/models/authorization_definition_spec.rb
+++ b/spec/models/authorization_definition_spec.rb
@@ -141,6 +141,25 @@ RSpec.describe AuthorizationDefinition do
           form.authorization_request_class == AuthorizationRequest::APIEntreprise
       end
     end
+
+    it 'returns the « Demande libre » forms last' do
+      default_forms, others = available_forms.partition(&:default)
+
+      expect(default_forms).not_to be_empty, 'fixture sans formulaire « default » — test tautologique'
+      expect(others).not_to be_empty, 'fixture sans formulaire non-default — test tautologique'
+      expect(available_forms).to eq(others + default_forms)
+    end
+
+    context 'with api_ficoba (multiple « Demande libre » variants)' do
+      let(:instance) { described_class.find('api_ficoba') }
+
+      it 'pushes all « Demande libre » variants to the end' do
+        forms = instance.available_forms
+        default_forms = forms.select(&:default)
+        expect(default_forms).not_to be_empty
+        expect(forms.last(default_forms.count).map(&:name)).to all(start_with('Demande libre'))
+      end
+    end
   end
 
   describe '#support_email' do
@@ -223,6 +242,22 @@ RSpec.describe AuthorizationDefinition do
 
       it 'takes the first one' do
         expect(subject).to eq(AuthorizationRequestForm.find('api-sfip-sandbox'))
+      end
+    end
+  end
+
+  describe '#default_form returns a « Demande libre » for the 7 APIs previously broken' do
+    %w[
+      api_ficoba
+      api_r2p
+      api_indemnites_journalieres_cnam
+      france_connect
+      api_impot_particulier
+      api_infinoe
+      api_sfip
+    ].each do |defn_id|
+      it "#{defn_id} has a « Demande libre » as default_form" do
+        expect(described_class.find(defn_id).default_form.name).to start_with('Demande libre')
       end
     end
   end


### PR DESCRIPTION
Le tri par flag default ne couvrait pas toutes les variantes (Ficoba, R2P, france_connect). Passage à un tri par nom du formulaire.