### PR TITLE
feat(api-particulier): ajoute le formulaire pré-rempli Andyvie (Recreo)

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -2694,3 +2694,31 @@ api-particulier-polycea:
     modalities:
       - params
       - france_connect
+
+api-particulier-andyvie:
+  name: Recreo
+  description: *api_particulier_form_description_tarification_qf
+  authorization_request: APIParticulier
+  use_case: tarification_municipale_enfance
+  service_provider_id: andyvie
+  introduction: *api_particulier_introduction_editor_with_editable_scopes
+  steps: *api_particulier_editor_steps_with_editable_scopes
+  static_blocks: *api_particulier_editor_static_blocks_with_editable_scopes
+  scopes_config:
+    disabled:
+      - cnaf_quotient_familial
+    displayed:
+      - cnaf_quotient_familial
+      - cnaf_allocataires
+      - cnaf_enfants
+      - cnaf_adresse
+  initialize_with:
+    intitule: Tarification des services municipaux à l’enfance
+    description: |
+      Recreo est une plateforme SaaS destinée aux collectivités territoriales et associations pour la gestion des Accueils Collectifs de Mineurs (centres de loisirs, périscolaire, colonies de vacances, mini-camps, accueils de jeunes). Le logiciel est utilisé directement par les citoyens via un portail famille et par les agents habilités via un backoffice
+    cadre_juridique_nature: *api_particulier_cadre_juridique_tarification_municipale_enfance
+    scopes:
+      - cnaf_quotient_familial
+      - cnaf_allocataires
+      - cnaf_enfants
+      - cnaf_adresse

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -49,6 +49,10 @@ shared:
     siret: "39825361700045"
     fc_certified: true
     apipfc_enabled: true
+  andyvie:
+    type: editor
+    name: Andyvie Association
+    siret: "38418745600023"
   familea:
     type: editor
     name: Familea

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -503,6 +503,7 @@ FactoryBot.define do
       api-particulier-abelium-petite-enfance
       api-particulier-familea
       api-particulier-familea-petite-enfance
+      api-particulier-andyvie
       api-particulier-polycea
     ].each do |form_uid|
       trait form_uid.tr('-', '_') do


### PR DESCRIPTION
Nouvel éditeur Andyvie Association sur le use_case tarification_municipale_enfance, scopes éditables (CNAF quotient familial, allocataires, enfants, adresse).