### PR TITLE
feat(cnous_data_extraction_criteria): retirer le champ recurrence

### DIFF
--- a/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
+++ b/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
@@ -1,25 +1,18 @@
 module AuthorizationExtensions::CnousDataExtractionCriteria
   extend ActiveSupport::Concern
 
-  RECURRENCE_VALUES = %w[annually biannually].freeze
   ECHELONS = %w[0Bis 1 2 3 4 5 6 7].freeze
 
   included do
     add_attribute :communes_codes_insee, type: :array
     add_attribute :echelon_bourse
     add_attribute :premiere_date_transmission
-    add_attribute :recurrence
 
     with_options if: -> { need_complete_validation?(:cnous_data_extraction_criteria) } do
       validates :communes_codes_insee, presence: true
       validates :echelon_bourse, presence: true, inclusion: { in: ECHELONS }
       validates :premiere_date_transmission, presence: true
-      validates :recurrence, presence: true, inclusion: { in: RECURRENCE_VALUES }
     end
-  end
-
-  def available_recurrences
-    self.class::RECURRENCE_VALUES
   end
 
   def available_echelons

--- a/app/views/authorization_request_forms/blocks/default/_cnous_data_extraction_criteria.html.erb
+++ b/app/views/authorization_request_forms/blocks/default/_cnous_data_extraction_criteria.html.erb
@@ -1,4 +1,4 @@
-<% if @authorization_request.display_prefilled_banner_for_each_block? && @authorization_request.prefilled_data?(%i[communes_codes_insee echelon_bourse premiere_date_transmission recurrence]) %>
+<% if @authorization_request.display_prefilled_banner_for_each_block? && @authorization_request.prefilled_data?(%i[communes_codes_insee echelon_bourse premiere_date_transmission]) %>
   <%= render partial: "authorization_request_forms/shared/prefilled_banner" %>
 <% end %>
 
@@ -63,17 +63,5 @@
 
   <div class="fr-fieldset__element">
     <%= f.dsfr_date_field :premiere_date_transmission, required: true %>
-  </div>
-
-  <div class="fr-fieldset__element">
-    <%=
-      f.dsfr_select :recurrence,
-        options_for_select(
-          @authorization_request.available_recurrences.map { |value| [t("authorization_request_forms.default.cnous_data_extraction_criteria.recurrences.#{value}"), value] },
-          selected: @authorization_request.recurrence
-        ),
-        required: true,
-        include_blank: 'Veuillez choisir une récurrence'
-    %>
   </div>
 </fieldset>

--- a/app/views/authorization_requests/blocks/default/_cnous_data_extraction_criteria.html.erb
+++ b/app/views/authorization_requests/blocks/default/_cnous_data_extraction_criteria.html.erb
@@ -28,14 +28,4 @@
   <% else %>
     <p><%= t('authorization_requests.shared.not_filled') %></p>
   <% end %>
-
-  <p>
-    <strong><%= f.label_value(:recurrence) %></strong>
-  </p>
-
-  <% if authorization_request.recurrence.present? %>
-    <p><%= t("authorization_request_forms.default.cnous_data_extraction_criteria.recurrences.#{authorization_request.recurrence}", default: authorization_request.recurrence) %></p>
-  <% else %>
-    <p><%= t('authorization_requests.shared.not_filled') %></p>
-  <% end %>
 <% end %>

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -134,7 +134,6 @@ fr:
         communes_codes_insee: Communes (codes INSEE)
         echelon_bourse: Échelon de bourse minimum
         premiere_date_transmission: Première date de transmission
-        recurrence: Récurrence
 
         france_connect:
           alternative_connexion: Attestation de connexion alternative à FranceConnect
@@ -205,7 +204,6 @@ fr:
         communes_codes_insee: "Saisissez un code INSEE par commune (ex : 75056 pour Paris). Cliquez sur « Ajouter une commune » pour en ajouter plusieurs."
         echelon_bourse: "L’extraction inclura tous les boursiers d’échelon supérieur ou égal à la valeur sélectionnée."
         premiere_date_transmission: "Date à laquelle vous souhaitez recevoir la première extraction CNOUS."
-        recurrence: "Fréquence des extractions CNOUS suivantes."
       message_template:
         title: "Privilégiez un titre court et explicite"
         content: "Variables disponibles : %{demande_url}, %{demande_intitule}, %{demande_id}"

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -130,15 +130,12 @@ fr:
 
       cnous_data_extraction_criteria:
         title: Quelles données souhaitez-vous extraire de la base CNOUS ?
-        subtitle: Précisez les communes concernées, le seuil d’échelon de bourse, et la fréquence d’extraction souhaitée.
+        subtitle: Précisez les communes concernées et le seuil d’échelon de bourse.
         communes_codes_insee:
           add: Ajouter une commune
           remove: Retirer
           remove_aria: Retirer la commune %{code}
           remove_aria_blank: Retirer cette commune
-        recurrences:
-          annually: Annuelle
-          biannually: Semestrielle
         echelons:
           "0Bis": Échelon 0bis et au-dessus
           "1": Échelon 1 et au-dessus

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -18,7 +18,6 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     * je remplis "Communes (codes INSEE) n°2" avec "69123"
     * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
     * je remplis "Première date de transmission" avec "2026-09-01"
-    * je sélectionne "Annuelle" pour "Récurrence"
     * je clique sur "Suivant"
 
     * je clique sur "Précédent"
@@ -54,7 +53,6 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Et je remplis "Communes (codes INSEE) n°2" avec "01001"
     Et je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
     Et je remplis "Première date de transmission" avec "2026-09-01"
-    Et je sélectionne "Annuelle" pour "Récurrence"
     Et je clique sur "Suivant"
 
     * je renseigne les informations du contact technique

--- a/features/step_definitions/cnous_data_extraction_criteria_steps.rb
+++ b/features/step_definitions/cnous_data_extraction_criteria_steps.rb
@@ -17,7 +17,6 @@ Alors("la demande contient les conditions d'extraction CNOUS attendues") do
   expect(authorization_request.communes_codes_insee).to match_array(%w[75056 69123])
   expect(authorization_request.echelon_bourse).to eq('5')
   expect(authorization_request.premiere_date_transmission).to eq('2026-09-01')
-  expect(authorization_request.recurrence).to eq('annually')
 end
 
 Alors('les champs de codes INSEE acceptent les caractères alphanumériques de longueur 5') do

--- a/spec/services/dynamic_authorization_request_registrar_spec.rb
+++ b/spec/services/dynamic_authorization_request_registrar_spec.rb
@@ -126,7 +126,6 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
           :communes_codes_insee,
           :echelon_bourse,
           :premiere_date_transmission,
-          :recurrence,
         )
       end
 
@@ -144,7 +143,6 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
           it { expect(demande.errors[:communes_codes_insee]).to be_present }
           it { expect(demande.errors[:echelon_bourse]).to be_present }
           it { expect(demande.errors[:premiere_date_transmission]).to be_present }
-          it { expect(demande.errors[:recurrence]).to be_present }
         end
 
         context 'with all fields filled correctly' do
@@ -153,26 +151,12 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
               communes_codes_insee: %w[75056 69123],
               echelon_bourse: '5',
               premiere_date_transmission: '2026-09-01',
-              recurrence: 'annually',
             }
           end
 
           it { expect(demande.errors[:communes_codes_insee]).to be_empty }
           it { expect(demande.errors[:echelon_bourse]).to be_empty }
           it { expect(demande.errors[:premiere_date_transmission]).to be_empty }
-          it { expect(demande.errors[:recurrence]).to be_empty }
-        end
-
-        context 'with an invalid recurrence value' do
-          let(:params) { { recurrence: 'monthly' } }
-
-          it { expect(demande.errors[:recurrence]).to be_present }
-        end
-
-        context 'with biannually recurrence' do
-          let(:params) { { recurrence: 'biannually' } }
-
-          it { expect(demande.errors[:recurrence]).to be_empty }
         end
 
         context 'with an invalid echelon_bourse value' do


### PR DESCRIPTION
## Summary

- Suppression définitive de `recurrence` dans le bloc `cnous_data_extraction_criteria` (concern + constante + validation + helper, vue formulaire, vue résumé, i18n label/hint/options/sous-titre, spec registrar, feature + step Cucumber).
- Décision actée [API-6700](https://linear.app/pole-api/issue/API-6700) §5 : chaque demande Proactivité = un fetch ponctuel, plus de périodicité côté DataPass.
- Pas de migration : les hstores existants conservent la clé orpheline `recurrence`, désormais ignorée par le code.

## Test plan

- [x] `bundle exec rspec spec/services/dynamic_authorization_request_registrar_spec.rb` — 33 examples vert
- [x] `bundle exec cucumber features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature` — 3 scénarios vert
- [x] `bundle exec rubocop` sur les fichiers Ruby touchés — 0 offense
- [x] `grep -rn "recurrence" app/ config/ spec/ features/` — 0 résidu

## Coordination

Sous-ticket `relais` (drop colonne `captured_campaign` + arrêt lecture `data['recurrence']`) à séquencer **après** le merge de cette PR pour la propreté du diff.

Linear : https://linear.app/pole-api/issue/API-6826