### PR TITLE
feat(organization): #legal_category mappant les codes INSEE

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,13 @@
 class Organization < ApplicationRecord
   self.ignored_columns += %w[siret]
 
+  LEGAL_CATEGORY_MAP = {
+    '7210' => :commune,
+    '7220' => :dept,
+    '7230' => :region,
+  }.freeze
+  private_constant :LEGAL_CATEGORY_MAP
+
   validates :legal_entity_id, presence: true, uniqueness: { scope: :legal_entity_registry }
   validates :legal_entity_id, siret: true, if: -> { legal_entity_registry == 'insee_sirene' }
 
@@ -43,6 +50,10 @@ class Organization < ApplicationRecord
 
   def personne_physique?
     unite_legale['categorieJuridiqueUniteLegale'] == '1000'
+  end
+
+  def legal_category
+    LEGAL_CATEGORY_MAP.fetch(unite_legale['categorieJuridiqueUniteLegale'], :other)
   end
 
   def insee_payload

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -66,4 +66,55 @@ RSpec.describe Organization do
       it { is_expected.not_to be_closed }
     end
   end
+
+  describe '#legal_category' do
+    subject { organization.legal_category }
+
+    let(:organization) do
+      build(:organization,
+        legal_entity_registry: 'insee_sirene',
+        legal_entity_id: '12345678900010',
+        insee_payload: {
+          'etablissement' => {
+            'uniteLegale' => unite_legale,
+          },
+        })
+    end
+
+    context 'when categorieJuridiqueUniteLegale is 7210 (commune)' do
+      let(:unite_legale) { { 'categorieJuridiqueUniteLegale' => '7210' } }
+
+      it { is_expected.to eq(:commune) }
+    end
+
+    context 'when categorieJuridiqueUniteLegale is 7220 (département)' do
+      let(:unite_legale) { { 'categorieJuridiqueUniteLegale' => '7220' } }
+
+      it { is_expected.to eq(:dept) }
+    end
+
+    context 'when categorieJuridiqueUniteLegale is 7230 (région)' do
+      let(:unite_legale) { { 'categorieJuridiqueUniteLegale' => '7230' } }
+
+      it { is_expected.to eq(:region) }
+    end
+
+    context 'when categorieJuridiqueUniteLegale is 7346 (EPCI, communauté de communes)' do
+      let(:unite_legale) { { 'categorieJuridiqueUniteLegale' => '7346' } }
+
+      it { is_expected.to eq(:other) }
+    end
+
+    context 'when categorieJuridiqueUniteLegale is absent from uniteLegale' do
+      let(:unite_legale) { { 'denominationUniteLegale' => 'ACME' } }
+
+      it { is_expected.to eq(:other) }
+    end
+
+    context 'when insee_payload is blank' do
+      let(:organization) { build(:organization, siret: '41040946000756') }
+
+      it { is_expected.to eq(:other) }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Ajoute `Organization#legal_category` retournant `:commune` / `:dept` / `:region` / `:other`, lu depuis `categorieJuridiqueUniteLegale` du payload INSEE Sirene déjà persisté.
- Constante `LEGAL_CATEGORY_MAP` en `private_constant` (3 codes : 7210/7220/7230) — aucun caller externe identifié, on relâchera à la visibilité publique si un consommateur en a besoin.
- Tous les cas dégénérés (payload absent, foreign, personne physique, EPCI 7340-7378, codes outre-mer 7225/7229) convergent vers `:other` via le `fetch(..., :other)`.

## Test plan

- [x] `bundle exec rspec spec/models/organization_spec.rb` — 14/14 vert (6 nouveaux examples couvrant les 4 mappings + 2 shadow paths)
- [x] `bundle exec rubocop app/models/organization.rb spec/models/organization_spec.rb` — 0 offense
- [ ] Sanity manuelle sur sandbox une fois mergé (CNOUS Boursiers reste en V2.1 saisie manuelle pour l'instant)

## Aval

Consommateur direct : [API-6831](https://linear.app/pole-api/issue/API-6831) (6.3 pré-fill UX). Les codes parqués `:other` (7225/7229 outre-mer, 7340-7378 EPCI/syndicats) sont à arbitrer V2.2 — [API-6833](https://linear.app/pole-api/issue/API-6833) (6.6) étudie le fichier Vincent pour décider du sort des EPCI.

Linear : https://linear.app/pole-api/issue/API-6829