### PR TITLE
feat(mailer): lien de gestion des notifications dans les emails d’instruction

### DIFF
--- a/app/views/instruction/authorization_request_mailer/reopening_submit.text.erb
+++ b/app/views/instruction/authorization_request_mailer/reopening_submit.text.erb
@@ -10,4 +10,6 @@
   )
 %>
 
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
+
 <%= t('mailer.shared.instruction.footer.text') %>

--- a/app/views/instruction/authorization_request_mailer/submit.text.erb
+++ b/app/views/instruction/authorization_request_mailer/submit.text.erb
@@ -15,4 +15,6 @@
   )
 %>
 
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
+
 <%= t('mailer.shared.instruction.footer.text') %>

--- a/app/views/mailer/shared/instruction/_unsubscribe_link.text.erb
+++ b/app/views/mailer/shared/instruction/_unsubscribe_link.text.erb
@@ -1,0 +1,7 @@
+<%=
+  t(
+    'mailer.shared.instruction.unsubscribe_link.text',
+    authorization_definition_name: authorization_definition.name_with_stage,
+    preferences_url: profile_url(anchor: 'notifications-section'),
+  )
+%>

--- a/app/views/message_mailer/reopening_to_instructors.text.erb
+++ b/app/views/message_mailer/reopening_to_instructors.text.erb
@@ -11,4 +11,6 @@
   )
 %>
 
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
+
 <%= t('mailer.shared.instruction.footer.text') %>

--- a/app/views/message_mailer/to_instructors.text.erb
+++ b/app/views/message_mailer/to_instructors.text.erb
@@ -11,4 +11,6 @@
   )
 %>
 
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
+
 <%= t('mailer.shared.instruction.footer.text') %>

--- a/config/locales/mailer.fr.yml
+++ b/config/locales/mailer.fr.yml
@@ -17,6 +17,13 @@ fr:
       instruction:
         footer:
           text: L'équipe DataPass
+        unsubscribe_link:
+          text: |-
+            ---
+            Vous recevez cet email car vous avez des droits relatifs à « %{authorization_definition_name} » sur DataPass.
+
+            Pour modifier vos préférences ou ne plus recevoir ces notifications, rendez-vous sur votre compte :
+            %{preferences_url}
 
   auto_generated_france_connect_mailer:
     approve:

--- a/spec/mailers/authorization_request_mailer_spec.rb
+++ b/spec/mailers/authorization_request_mailer_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe AuthorizationRequestMailer do
       expect(decoded_text_body(mail)).to match('a été validée')
     end
 
+    it 'does not include the unsubscribe footer' do
+      expect(decoded_text_body(mail)).not_to match('/compte#notifications-section')
+    end
+
     describe 'custom emails' do
       describe 'HubEE CertDC' do
         let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }

--- a/spec/mailers/instruction/authorization_request_mailer_spec.rb
+++ b/spec/mailers/instruction/authorization_request_mailer_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe Instruction::AuthorizationRequestMailer do
           expect(mail.body.encoded).not_to match('Cette demande fait suite à une demande de modification.')
         end
       end
+
+      context 'with the unsubscribe footer' do
+        it 'inclut le lien vers la page de préférences' do
+          expect(mail.body.encoded).to include('/compte#notifications-section')
+        end
+
+        it 'mentionne le nom de l’API' do
+          expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
+        end
+
+        it 'mentionne le texte de gestion des préférences' do
+          expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
+        end
+      end
     end
 
     context 'when there is no instructor nor reporter to notify' do
@@ -70,6 +84,20 @@ RSpec.describe Instruction::AuthorizationRequestMailer do
         expect(mail.body.encoded).to match('demande de réouverture')
         expect(mail.body.encoded).to match('a soumis')
         expect(mail.body.encoded).to match(authorization_request.applicant.email)
+      end
+
+      context 'with the unsubscribe footer' do
+        it 'inclut le lien vers la page de préférences' do
+          expect(mail.body.encoded).to include('/compte#notifications-section')
+        end
+
+        it 'mentionne le nom de l’API' do
+          expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
+        end
+
+        it 'mentionne le texte de gestion des préférences' do
+          expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
+        end
       end
     end
 

--- a/spec/mailers/message_mailer_spec.rb
+++ b/spec/mailers/message_mailer_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe MessageMailer do
       expect(mail.body.encoded).to match('un nouveau message')
       expect(mail.body.encoded).to match('demande d\'habilitation')
     end
+
+    context 'with the unsubscribe footer' do
+      it 'inclut le lien vers la page de préférences' do
+        expect(mail.body.encoded).to include('/compte#notifications-section')
+      end
+
+      it 'mentionne le nom de l’API' do
+        expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
+      end
+
+      it 'mentionne le texte de gestion des préférences' do
+        expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
+      end
+    end
   end
 
   describe '#reopening_to_instructors' do
@@ -64,6 +78,20 @@ RSpec.describe MessageMailer do
     it 'renders valid template' do
       expect(mail.body.encoded).to match('un nouveau message')
       expect(mail.body.encoded).to match('demande de réouverture de l\'habilitation')
+    end
+
+    context 'with the unsubscribe footer' do
+      it 'inclut le lien vers la page de préférences' do
+        expect(mail.body.encoded).to include('/compte#notifications-section')
+      end
+
+      it 'mentionne le nom de l’API' do
+        expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
+      end
+
+      it 'mentionne le texte de gestion des préférences' do
+        expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
+      end
     end
   end
 end

--- a/spec/mailers/previews/instruction/authorization_request_mailer_preview.rb
+++ b/spec/mailers/previews/instruction/authorization_request_mailer_preview.rb
@@ -1,0 +1,24 @@
+class Instruction::AuthorizationRequestMailerPreview < ActionMailer::Preview
+  def submit
+    Instruction::AuthorizationRequestMailer.with(
+      authorization_request: authorization_request
+    ).submit
+  end
+
+  def reopening_submit
+    Instruction::AuthorizationRequestMailer.with(
+      authorization_request: reopened_authorization_request
+    ).reopening_submit
+  end
+
+  private
+
+  def authorization_request
+    AuthorizationRequest.where(state: :submitted).first
+  end
+
+  def reopened_authorization_request
+    AuthorizationRequest.where(state: :submitted).where.not(reopened_at: nil).first ||
+      authorization_request
+  end
+end


### PR DESCRIPTION
### DP-1705 — Lien de gestion des notifications dans les emails d'instruction                                                             
                                                                                                                                        
Les reporters / instructeurs / managers sont notifiés par défaut dès qu'on leur attribue un rôle sur une définition, sans moyen visible de s'en désinscrire. Cette PR ajoute un footer pointant vers /compte#notifications-section (où les toggles existent déjà) dans les 4 emails de notification d'instruction.                                                                                           

Couvre tous les rôles destinataires excepté les  demandeurs qui sont volontairement exclus. Décisions de périmètre détaillées en commentaire du ticket.                                                    
                                                                                                                                        
### Comment tester                                                                                                                        
                                                                                                                                        
  Pré-requis : base de dev avec au moins une demande soumise (bin/rails db:seed si besoin), serveur lancé (bin/local_run.sh). Port = 3000 par défaut (vérifier .env.local).                                                                                                
                                                                                                                                        
  1. Tests automatisés                                                                                                                  
  bundle exec rspec spec/mailers/instruction/authorization_request_mailer_spec.rb \                                                     
    spec/mailers/message_mailer_spec.rb \                                                                                               
    spec/mailers/authorization_request_mailer_spec.rb                                                                                   
  → vérifie présence du footer (lien + nom d'API + « ne plus recevoir ces notifications ») sur les 4 méthodes, et absence côté applicant.                                                                                                                            
                                                                                                                                        
  2. Rendu visuel (previews Rails — http://localhost:3000/rails/mailers/...)                                                            
  - instruction/authorization_request_mailer/submit                                                                                     
  - instruction/authorization_request_mailer/reopening_submit                                                                           
  - message_mailer/to_instructors                                                                                                       
                                                                                                                                        
  Vérifier : footer présent, nom d'API entre « », URL …/compte#notifications-section sur sa propre ligne.                               
                                                                                                                                        
  À comparer avec un email applicant (ex. authorization_request_mailer) → aucun footer.                                                 
                                                                                                                                        
  3. Bout en bout (optionnel)                                                                                                           
  Se connecter en local comme instructeur, cliquer le lien dans l'email → atterrir sur /compte section « Notifications par emails », désactiver le toggle de l'API.                                                                                   