### PR TITLE
Bugfix: ne rend plus de html générique si il existe un modèle au format txt personnalisé

### DIFF
--- a/app/mailers/authorization_request_mailer.rb
+++ b/app/mailers/authorization_request_mailer.rb
@@ -41,6 +41,7 @@ class AuthorizationRequestMailer < ApplicationMailer
 
   def html_template_path_for(kind, action)
     return "authorization_request_mailer/#{kind}/#{action}" if html_template_exists?(kind, action)
+    return nil if text_template_exists?(kind, action)
     return "authorization_request_mailer/#{action}" if generic_html_template_exists?(action)
 
     nil

--- a/spec/mailers/authorization_request_mailer_spec.rb
+++ b/spec/mailers/authorization_request_mailer_spec.rb
@@ -17,8 +17,16 @@ RSpec.describe AuthorizationRequestMailer do
       end
     end
 
-    context 'when there is no custom HTML template for the kind' do
+    context 'when there is a custom text template but no custom HTML template' do
       let(:authorization_request) { create(:authorization_request, :hubee_cert_dc, :validated) }
+
+      it 'does not render an HTML part so the custom text is not shadowed by a generic HTML body' do
+        expect(mail.html_part).to be_nil
+      end
+    end
+
+    context 'when there is neither a custom text nor a custom HTML template' do
+      let(:authorization_request) { create(:authorization_request, :api_entreprise, :validated) }
 
       it 'renders the generic HTML template' do
         html = decoded_html_body(mail)

--- a/spec/organizers/approve_authorization_request_spec.rb
+++ b/spec/organizers/approve_authorization_request_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ApproveAuthorizationRequest do
+  include ActiveJob::TestHelper
+
   describe '.call' do
     subject(:approve_authorization_request) { described_class.call(authorization_request:, user:) }
 
@@ -117,6 +119,36 @@ RSpec.describe ApproveAuthorizationRequest do
           auto_generate_event = AuthorizationRequestEvent.find_by(name: 'auto_generate')
 
           expect(auto_generate_event.entity).to eq(fc_authorization)
+        end
+      end
+
+      context 'when authorization request has a custom text-only mailer view (FranceConnect)' do
+        subject(:approve_authorization_request) do
+          described_class.call(
+            authorization_request:,
+            user:,
+            authorization_message: 'Habilitation validée par l’instructeur.'
+          )
+        end
+
+        let(:user) { create(:user, :instructor, authorization_request_types: %w[france_connect]) }
+        let(:authorization_request) { create(:authorization_request, :france_connect, :submitted) }
+
+        let(:delivered_mail) do
+          ActionMailer::Base.deliveries.find { |m| m.to.include?(authorization_request.applicant.email) }
+        end
+
+        before do
+          perform_enqueued_jobs { approve_authorization_request }
+        end
+
+        it 'delivers the custom FranceConnect text view' do
+          text_body = delivered_mail.text_part&.body&.decoded || delivered_mail.body.decoded
+          expect(text_body).to match('espace.partenaires.franceconnect.gouv.fr')
+        end
+
+        it 'does not deliver an HTML part when only the text view is customised' do
+          expect(delivered_mail.html_part).to be_nil
         end
       end
     end


### PR DESCRIPTION
Bug introduit comme une feature par 44ec61b5 (car testé en tant que tel dans spec/mailers/authorization_request_mailer_spec.rb)

Closes https://linear.app/pole-api/issue/DP-1749