### PR TITLE
Retire la redirection vers la demande lors d'une recherche par ID

### DIFF
--- a/app/controllers/instruction/dashboard_controller.rb
+++ b/app/controllers/instruction/dashboard_controller.rb
@@ -1,5 +1,4 @@
 class Instruction::DashboardController < Instruction::AbstractAuthorizationRequestsController
-  before_action :redirect_to_searched_record
   before_action :save_or_load_search_params
 
   skip_before_action :extract_authorization_request
@@ -27,32 +26,8 @@ class Instruction::DashboardController < Instruction::AbstractAuthorizationReque
 
   private
 
-  def find_searched_record
-    case params[:id]
-    when 'demandes'
-      extracted_id = Instruction::Search::DashboardSearch.extract_id_from_search_terms(params, expected_prefix: 'D')
-      AuthorizationRequest.find_by(id: extracted_id) if extracted_id
-    when 'habilitations'
-      extracted_id = Instruction::Search::DashboardSearch.extract_id_from_search_terms(params, expected_prefix: 'H')
-      Authorization.find_by(id: extracted_id) if extracted_id
-    end
-  end
-
   def load_search_params
     params[:search_query] = JSON.parse(cookies[search_key] || '{}') if params[:search_query].blank?
-  end
-
-  def redirect_to_searched_record
-    return unless search_terms_is_a_possible_id?
-
-    candidate = find_searched_record
-    return unless candidate
-
-    authorize [:instruction, candidate], :show?
-
-    redirect_to search_record_path(candidate)
-  rescue Pundit::NotAuthorizedError
-    nil
   end
 
   def save_or_load_search_params
@@ -66,18 +41,5 @@ class Instruction::DashboardController < Instruction::AbstractAuthorizationReque
 
   def search_key
     :"#{controller_name}_#{action_name}_#{params[:id]}_search"
-  end
-
-  def search_record_path(record)
-    case params[:id]
-    when 'demandes'
-      instruction_authorization_request_path(record)
-    when 'habilitations'
-      authorization_path(record)
-    end
-  end
-
-  def search_terms_is_a_possible_id?
-    Instruction::Search::DashboardSearch.search_terms_is_a_possible_id?(params)
   end
 end

--- a/app/facades/instruction/search/dashboard_demandes_search.rb
+++ b/app/facades/instruction/search/dashboard_demandes_search.rb
@@ -5,8 +5,11 @@ class Instruction::Search::DashboardDemandesSearch < Instruction::Search::Dashbo
     base_scope = super
     base_scope = base_scope.not_validated
     base_scope = base_scope.not_archived if state_filter_blank?
-    base_scope = base_scope.none if search_terms_is_a_possible_id?
     base_scope
+  end
+
+  def id_search_prefix
+    'D'
   end
 
   def default_sort

--- a/app/facades/instruction/search/dashboard_habilitations_search.rb
+++ b/app/facades/instruction/search/dashboard_habilitations_search.rb
@@ -5,10 +5,8 @@ class Instruction::Search::DashboardHabilitationsSearch < Instruction::Search::D
     super + %i[request]
   end
 
-  def base_relation
-    base_scope = super
-    base_scope = base_scope.none if search_terms_is_a_possible_id?
-    base_scope
+  def id_search_prefix
+    'H'
   end
 
   def default_sort

--- a/app/facades/instruction/search/dashboard_search.rb
+++ b/app/facades/instruction/search/dashboard_search.rb
@@ -56,9 +56,30 @@ class Instruction::Search::DashboardSearch
   end
 
   def build_search_engine
-    search = base_relation.ransack(params[:search_query])
-    search.sorts = default_sort if search.sorts.empty?
+    if search_terms_is_a_possible_id?
+      build_id_search_engine
+    else
+      search = base_relation.ransack(params[:search_query])
+      search.sorts = default_sort if search.sorts.empty?
+      search
+    end
+  end
+
+  def build_id_search_engine
+    search = id_matching_relation.ransack(nil)
+    search.sorts = default_sort
     search
+  end
+
+  def id_matching_relation
+    extracted_id = self.class.extract_id_from_search_terms(params, expected_prefix: id_search_prefix)
+    return base_relation.none unless extracted_id
+
+    base_relation.where('CAST(id AS TEXT) LIKE ?', "#{extracted_id}%")
+  end
+
+  def id_search_prefix
+    raise NotImplementedError, 'Subclasses must implement #id_search_prefix'
   end
 
   def build_search_results

--- a/spec/facades/instruction/search/dashboard_demandes_search_spec.rb
+++ b/spec/facades/instruction/search/dashboard_demandes_search_spec.rb
@@ -21,4 +21,55 @@ RSpec.describe Instruction::Search::DashboardDemandesSearch do
       expect(search.send(:default_sort)).to eq 'last_submitted_at desc'
     end
   end
+
+  describe 'ID search' do
+    let(:search_key) { described_class.key }
+
+    context 'with an exact numeric ID' do
+      let(:params) { { search_query: { search_key => authorization_request.id.to_s } } }
+
+      it 'returns the matching request' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(authorization_request)
+      end
+    end
+
+    context 'with a partial numeric ID' do
+      let!(:authorization_request) { create(:authorization_request, id: 12_345) }
+      let(:params) { { search_query: { search_key => '123' } } }
+
+      it 'returns requests whose ID starts with the partial input' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(authorization_request)
+      end
+    end
+
+    context 'with a partial ID that is not a prefix of the record ID' do
+      let!(:authorization_request) { create(:authorization_request, id: 12_345) }
+      let(:params) { { search_query: { search_key => '234' } } }
+
+      it 'does not return the record' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).not_to include(authorization_request)
+      end
+    end
+
+    context 'with a D-prefixed ID' do
+      let(:params) { { search_query: { search_key => "D#{authorization_request.id}" } } }
+
+      it 'returns the matching request' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(authorization_request)
+      end
+    end
+
+    context 'with an H-prefixed ID' do
+      let(:params) { { search_query: { search_key => "H#{authorization_request.id}" } } }
+
+      it 'returns no results' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to be_empty
+      end
+    end
+  end
 end

--- a/spec/facades/instruction/search/dashboard_habilitations_search_spec.rb
+++ b/spec/facades/instruction/search/dashboard_habilitations_search_spec.rb
@@ -21,4 +21,55 @@ RSpec.describe Instruction::Search::DashboardHabilitationsSearch do
       expect(search.send(:default_sort)).to eq 'created_at desc'
     end
   end
+
+  describe 'ID search' do
+    let(:search_key) { described_class.key }
+
+    context 'with an exact numeric ID' do
+      let(:params) { { search_query: { search_key => authorization.id.to_s } } }
+
+      it 'returns the matching authorization' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(authorization)
+      end
+    end
+
+    context 'with a partial numeric ID' do
+      let!(:authorization) { create(:authorization, id: 12_345) }
+      let(:params) { { search_query: { search_key => '123' } } }
+
+      it 'returns authorizations whose ID starts with the partial input' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(authorization)
+      end
+    end
+
+    context 'with a partial ID that is not a prefix of the record ID' do
+      let!(:authorization) { create(:authorization, id: 12_345) }
+      let(:params) { { search_query: { search_key => '234' } } }
+
+      it 'does not return the record' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).not_to include(authorization)
+      end
+    end
+
+    context 'with an H-prefixed ID' do
+      let(:params) { { search_query: { search_key => "H#{authorization.id}" } } }
+
+      it 'returns the matching authorization' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(authorization)
+      end
+    end
+
+    context 'with a D-prefixed ID' do
+      let(:params) { { search_query: { search_key => "D#{authorization.id}" } } }
+
+      it 'returns no results' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to be_empty
+      end
+    end
+  end
 end

--- a/spec/features/instruction/search_demandes_spec.rb
+++ b/spec/features/instruction/search_demandes_spec.rb
@@ -155,10 +155,11 @@ RSpec.describe 'Instruction: demandes search' do
     context 'when we can see this authorization request' do
       let(:search_text) { valid_searched_authorization_request.id.to_s }
 
-      it 'redirects to the authorization request' do
+      it 'shows the authorization request in the list' do
         search
 
-        expect(page).to have_current_path(instruction_authorization_request_path(valid_searched_authorization_request))
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'demandes'), ignore_query: true)
+        expect(page).to have_css(css_id(valid_searched_authorization_request))
       end
     end
 
@@ -166,7 +167,7 @@ RSpec.describe 'Instruction: demandes search' do
       let(:foreign_authorization_request) { create(:authorization_request, :hubee_dila, state: :validated) }
       let(:search_text) { foreign_authorization_request.id.to_s }
 
-      it 'does not redirects to the authorization request, and renders nothing' do
+      it 'renders nothing' do
         search
 
         expect(page).to have_current_path(instruction_dashboard_show_path(id: 'demandes'), ignore_query: true)
@@ -177,17 +178,18 @@ RSpec.describe 'Instruction: demandes search' do
     context 'when we use the formatted_id (D-prefixed)' do
       let(:search_text) { valid_searched_authorization_request.formatted_id }
 
-      it 'redirects to the authorization request' do
+      it 'shows the authorization request in the list' do
         search
 
-        expect(page).to have_current_path(instruction_authorization_request_path(valid_searched_authorization_request))
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'demandes'), ignore_query: true)
+        expect(page).to have_css(css_id(valid_searched_authorization_request))
       end
     end
 
     context 'when we use an H-prefixed id in the demandes tab' do
       let(:search_text) { "H#{valid_searched_authorization_request.id}" }
 
-      it 'does not redirect and renders nothing' do
+      it 'renders nothing' do
         search
 
         expect(page).to have_current_path(instruction_dashboard_show_path(id: 'demandes'), ignore_query: true)
@@ -199,7 +201,7 @@ RSpec.describe 'Instruction: demandes search' do
       let(:foreign_authorization_request) { create(:authorization_request, :hubee_dila, state: :validated) }
       let(:search_text) { foreign_authorization_request.formatted_id }
 
-      it 'does not redirect and renders nothing' do
+      it 'renders nothing' do
         search
 
         expect(page).to have_current_path(instruction_dashboard_show_path(id: 'demandes'), ignore_query: true)

--- a/spec/features/instruction/search_habilitations_spec.rb
+++ b/spec/features/instruction/search_habilitations_spec.rb
@@ -203,10 +203,11 @@ RSpec.describe 'Instruction: habilitations search' do
       let!(:valid_searched_authorization) { create(:authorization, request: valid_request, state: :active) }
       let(:search_text) { valid_searched_authorization.id.to_s }
 
-      it 'redirects to the authorization' do
+      it 'shows the authorization in the list' do
         search
 
-        expect(page).to have_current_path(authorization_path(valid_searched_authorization))
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'habilitations'), ignore_query: true)
+        expect(page).to have_css(css_id(valid_searched_authorization))
       end
     end
 
@@ -215,7 +216,7 @@ RSpec.describe 'Instruction: habilitations search' do
       let!(:foreign_authorization) { create(:authorization, request: foreign_request, state: :active) }
       let(:search_text) { foreign_authorization.id.to_s }
 
-      it 'does not redirect to the authorization, and renders nothing' do
+      it 'renders nothing' do
         search
 
         expect(page).to have_current_path(instruction_dashboard_show_path(id: 'habilitations'), ignore_query: true)
@@ -228,10 +229,11 @@ RSpec.describe 'Instruction: habilitations search' do
       let!(:valid_searched_authorization) { create(:authorization, request: valid_request, state: :active) }
       let(:search_text) { valid_searched_authorization.formatted_id }
 
-      it 'redirects to the authorization' do
+      it 'shows the authorization in the list' do
         search
 
-        expect(page).to have_current_path(authorization_path(valid_searched_authorization))
+        expect(page).to have_current_path(instruction_dashboard_show_path(id: 'habilitations'), ignore_query: true)
+        expect(page).to have_css(css_id(valid_searched_authorization))
       end
     end
 
@@ -240,7 +242,7 @@ RSpec.describe 'Instruction: habilitations search' do
       let!(:valid_searched_authorization) { create(:authorization, request: valid_request, state: :active) }
       let(:search_text) { "D#{valid_searched_authorization.id}" }
 
-      it 'does not redirect and renders nothing' do
+      it 'renders nothing' do
         search
 
         expect(page).to have_current_path(instruction_dashboard_show_path(id: 'habilitations'), ignore_query: true)
@@ -253,7 +255,7 @@ RSpec.describe 'Instruction: habilitations search' do
       let!(:foreign_authorization) { create(:authorization, request: foreign_request, state: :active) }
       let(:search_text) { foreign_authorization.formatted_id }
 
-      it 'does not redirect and renders nothing' do
+      it 'renders nothing' do
         search
 
         expect(page).to have_current_path(instruction_dashboard_show_path(id: 'habilitations'), ignore_query: true)


### PR DESCRIPTION
ref https://linear.app/pole-api/issue/DP-1753/etq-i-quand-je-tape-un-numero-de-demande-je-ne-dois-pas-etre-redirige

https://github.com/user-attachments/assets/dbb609c8-dcd1-40cd-a7e9-5a0ba87fc222



