### PR TITLE
Fix dashboard N+1 (15 issues Sentry) + stop rails_pulse N+1 noise

### DIFF
--- a/app/facades/dashboard_demandes_facade.rb
+++ b/app/facades/dashboard_demandes_facade.rb
@@ -1,20 +1,22 @@
 class DashboardDemandesFacade < AbstractDashboardFacade
   def data
-    builder = search_builder
-    relation = builder.build_relation(scoped_relation.where(state: displayed_states))
-    requests_by_state = relation.to_a.group_by(&:state)
+    @data ||= begin
+      builder = search_builder
+      relation = builder.build_relation(scoped_relation.where(state: displayed_states))
+      requests_by_state = relation.to_a.group_by(&:state)
 
-    {
-      highlighted_categories: {
-        changes_requested: requests_by_state.fetch('changes_requested', []),
-      },
-      categories: {
-        pending: requests_by_state.fetch('submitted', []),
-        draft: requests_by_state.fetch('draft', []),
-        refused: requests_by_state.fetch('refused', []),
-      },
-      search_engine: builder.search_engine
-    }
+      {
+        highlighted_categories: {
+          changes_requested: requests_by_state.fetch('changes_requested', []),
+        },
+        categories: {
+          pending: requests_by_state.fetch('submitted', []),
+          draft: requests_by_state.fetch('draft', []),
+          refused: requests_by_state.fetch('refused', []),
+        },
+        search_engine: builder.search_engine
+      }
+    end
   end
 
   def model_class

--- a/app/facades/dashboard_habilitations_facade.rb
+++ b/app/facades/dashboard_habilitations_facade.rb
@@ -1,17 +1,19 @@
 class DashboardHabilitationsFacade < AbstractDashboardFacade
   def data
-    builder = search_builder
-    relation = builder.build_relation(scoped_relation.where(state: displayed_states))
-    authorizations_by_state = relation.to_a.group_by(&:state)
+    @data ||= begin
+      builder = search_builder
+      relation = builder.build_relation(scoped_relation.where(state: displayed_states))
+      authorizations_by_state = relation.to_a.group_by(&:state)
 
-    {
-      highlighted_categories: {},
-      categories: {
-        active: authorizations_by_state.fetch('active', []),
-        revoked: authorizations_by_state.fetch('revoked', []),
-      },
-      search_engine: builder.search_engine
-    }
+      {
+        highlighted_categories: {},
+        categories: {
+          active: authorizations_by_state.fetch('active', []),
+          revoked: authorizations_by_state.fetch('revoked', []),
+        },
+        search_engine: builder.search_engine
+      }
+    end
   end
 
   def model_class

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,4 +4,13 @@ Sentry.init do |config|
   config.enabled_environments = %w[staging production]
 
   config.traces_sample_rate = 1.0
+
+  config.before_send_transaction = lambda do |event, _hint|
+    event.spans&.reject! do |span|
+      span[:op] == 'db.sql.active_record' &&
+        span[:description].to_s.include?('rails_pulse_')
+    end
+
+    event
+  end
 end

--- a/spec/facades/dashboard_demandes_facade_spec.rb
+++ b/spec/facades/dashboard_demandes_facade_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe DashboardDemandesFacade, type: :facade do
     end
   end
 
+  describe 'query efficiency' do
+    before do
+      create_list(:authorization_request, 3, :api_entreprise, organization:, applicant: current_user, state: :draft)
+    end
+
+    it 'loads the authorization_requests relation once across the reads performed while rendering' do
+      facade
+
+      queries = count_queries(/FROM "authorization_requests"/) do
+        facade.empty?
+        facade.highlighted_categories
+        facade.categories
+        facade.total_count
+      end
+
+      expect(queries).to eq(1)
+    end
+  end
+
   describe 'service integration' do
     it 'uses AuthorizationRequestsSearchEngineBuilder' do
       builder = facade.send(:search_builder)

--- a/spec/facades/dashboard_habilitations_facade_spec.rb
+++ b/spec/facades/dashboard_habilitations_facade_spec.rb
@@ -48,6 +48,26 @@ RSpec.describe DashboardHabilitationsFacade, type: :facade do
     end
   end
 
+  describe 'query efficiency' do
+    before do
+      authorization_request = create(:authorization_request, organization:, applicant: current_user, state: :validated)
+      create_list(:authorization, 3, request: authorization_request, state: :active)
+    end
+
+    it 'loads the authorizations relation once across the reads performed while rendering' do
+      facade
+
+      queries = count_queries(/FROM "authorizations"/) do
+        facade.empty?
+        facade.highlighted_categories
+        facade.categories
+        facade.total_count
+      end
+
+      expect(queries).to eq(1)
+    end
+  end
+
   describe 'service integration' do
     it 'uses AuthorizationsSearchEngineBuilder' do
       builder = facade.send(:search_builder)

--- a/spec/initializers/sentry_spec.rb
+++ b/spec/initializers/sentry_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe 'Sentry initializer' do
+  describe 'before_send_transaction' do
+    subject(:filtered_event) { filter.call(event, nil) }
+
+    let(:filter) { Sentry.get_current_client.configuration.before_send_transaction }
+
+    let(:rails_pulse_span) do
+      { op: 'db.sql.active_record', description: 'INSERT INTO "rails_pulse_operations" ("request_id") VALUES ($1)' }
+    end
+    let(:application_span) do
+      { op: 'db.sql.active_record', description: 'SELECT * FROM "authorization_requests"' }
+    end
+    let(:render_span) do
+      { op: 'view.render.template', description: 'dashboard/show.html.erb' }
+    end
+
+    let(:event) { Struct.new(:spans).new([rails_pulse_span, application_span, render_span]) }
+
+    it 'drops rails_pulse instrumentation spans' do
+      expect(filtered_event.spans).not_to include(rails_pulse_span)
+    end
+
+    it 'keeps application spans' do
+      expect(filtered_event.spans).to contain_exactly(application_span, render_span)
+    end
+
+    context 'when the event has no spans' do
+      let(:event) { Struct.new(:spans).new(nil) }
+
+      it 'returns the event untouched' do
+        expect(filtered_event.spans).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/sql_query_counter.rb
+++ b/spec/support/sql_query_counter.rb
@@ -1,0 +1,21 @@
+module SqlQueryCounter
+  def count_queries(pattern)
+    matched = 0
+
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+      next if payload[:cached]
+
+      matched += 1 if payload[:sql].match?(pattern)
+    end
+
+    yield
+
+    matched
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+end
+
+RSpec.configure do |config|
+  config.include SqlQueryCounter
+end


### PR DESCRIPTION
## Contexte

Diagnostic mené via le MCP Sentry (`datapass-reborn`, prod). 21 issues unresolved, dont **16 N+1** :
- **15** sur `DashboardController#show`
- **1** (`PagesController#home`) = bruit de la gem de monitoring `rails_pulse`, pas notre code

Deux commits indépendants.

## Commit 1 — Mémoïsation des facades dashboard (15 N+1 d'un coup)

`DashboardDemandesFacade#data` et `DashboardHabilitationsFacade#data` redéfinissaient `#data` **sans la mémoïsation** sur laquelle s'appuie leur parent `AbstractDashboardFacade`. Chaque appel (`empty?`, `highlighted_categories`, `categories`, `total_count`) rechargeait donc la relation complète → **~6 rechargements par rendu** de la vue.

Les builders préchargent déjà les associations (`.preload(:applicant, :organization, :authorizations)`), donc **Bullet ne voyait rien** (preload présent) — seul Sentry détectait le bloc de requêtes répété.

Fix : `@data ||= begin … end`. Test de régression via un helper de comptage de SELECT (`spec/support/sql_query_counter.rb`) : **6 → 1**.

Issues fermées : `DATAPASS-REBORN-BZ BY C5 C4 C3 C1 C2 C7 CM CJ CB CF CZ CR D0`.

## Commit 2 — Filtre des spans rails_pulse côté Sentry (issue `PagesController#home`)

L'auto-instrumentation ActiveRecord de Sentry capturait les INSERT que rails_pulse écrit dans ses propres tables (`rails_pulse_operations`…) ; le détecteur N+1 groupait les INSERT répétés.

Les options `ignored_queries`/`ignored_requests` de rails_pulse ne couvrent pas ce cas (elles gèrent ce que rails_pulse *surveille*, pas ce que Sentry voit). Fix déclaratif côté SDK : `config.before_send_transaction` retire les spans `db.sql.active_record` touchant `rails_pulse_*` avant l'envoi → plus aucune issue de ce type créée.

Issue fermée : `DATAPASS-REBORN-CS`.

## Tests

- `spec/facades/dashboard_demandes_facade_spec.rb`, `…habilitations_facade_spec.rb` — query efficiency (6→1)
- `spec/initializers/sentry_spec.rb` — filtrage des spans rails_pulse
- Vert + rubocop clean sur les fichiers touchés.

## Note

Le poids de rails_pulse sur le request-path (INSERT synchrones) reste un sujet à part — discussion en cours, hors de ce PR.