### PR TITLE
Feature/dp 1743 desinscription en 1 clic depuis lemail token chiffre page de

### DIFF
--- a/app/controllers/notification_unsubscriptions_controller.rb
+++ b/app/controllers/notification_unsubscriptions_controller.rb
@@ -1,0 +1,62 @@
+class NotificationUnsubscriptionsController < AuthenticatedUserController
+  allow_unauthenticated_access
+  layout 'notification_unsubscription'
+
+  before_action :decode_token
+
+  helper_method :authorization_definition, :kind_label
+
+  def show
+    return render 'invalid' if @user.blank?
+    return if still_has_role?
+
+    @already_unsubscribed = true
+    render 'success'
+  end
+
+  def create
+    return render 'invalid' if @user.blank?
+
+    @already_unsubscribed =
+      if still_has_role?
+        Notifications::Unsubscribe.call(user: @user, definition_id: @definition_id, kind: @kind).already_unsubscribed
+      else
+        true
+      end
+
+    render 'success'
+  end
+
+  private
+
+  def authorization_definition
+    @authorization_definition ||= AuthorizationDefinition.find(@definition_id)
+  end
+
+  def kind_label
+    t("notification_unsubscriptions.kinds.#{@kind}")
+  end
+
+  def decode_token
+    payload = NotificationUnsubscribeToken.decode(params[:token])
+    return unless payload
+
+    @user = User.find_by(id: payload[:user_id])
+    @definition_id = payload[:definition_id]
+    @kind = payload[:kind]
+  end
+
+  def still_has_role?
+    @kind == 'submit' ? @user.reporter?(@definition_id) : @user.instructor?(@definition_id)
+  end
+
+  def track_impersonation_action
+    return if @user.nil?
+
+    super
+  end
+
+  def model_to_track_for_impersonation
+    @user
+  end
+end

--- a/app/interactors/deliver_message_mail.rb
+++ b/app/interactors/deliver_message_mail.rb
@@ -1,20 +1,22 @@
 class DeliverMessageMail < ApplicationInteractor
   def call
-    MessageMailer.with(message:).public_send(mailer_method).deliver_later
+    recipients.each do |user|
+      MessageMailer.with(message:, user:).public_send(mailer_method).deliver_later
+    end
   end
 
   private
 
-  def message
-    context.message
-  end
-
   def mailer_method
     if authorization_request.reopening?
-      "reopening_#{context.mailer_method}"
+      "reopening_#{base_mailer_method}"
     else
-      context.mailer_method
+      base_mailer_method
     end
+  end
+
+  def message
+    context.message
   end
 
   def authorization_request

--- a/app/interactors/deliver_message_mail_to_applicant.rb
+++ b/app/interactors/deliver_message_mail_to_applicant.rb
@@ -1,0 +1,11 @@
+class DeliverMessageMailToApplicant < DeliverMessageMail
+  private
+
+  def recipients
+    [authorization_request.applicant]
+  end
+
+  def base_mailer_method
+    'to_applicant'
+  end
+end

--- a/app/interactors/deliver_message_mail_to_instructors.rb
+++ b/app/interactors/deliver_message_mail_to_instructors.rb
@@ -1,0 +1,11 @@
+class DeliverMessageMailToInstructors < DeliverMessageMail
+  private
+
+  def recipients
+    Instruction::NotificationRecipients.messages(authorization_request)
+  end
+
+  def base_mailer_method
+    'to_instructors'
+  end
+end

--- a/app/interactors/notifications/unsubscribe.rb
+++ b/app/interactors/notifications/unsubscribe.rb
@@ -1,0 +1,22 @@
+class Notifications::Unsubscribe < ApplicationInteractor
+  def call
+    context.user.with_lock { unsubscribe }
+  end
+
+  private
+
+  def unsubscribe
+    context.already_unsubscribed = !context.user.public_send(setting_key)
+    return if context.already_unsubscribed
+
+    context.user.update!(setting_key => '0')
+  end
+
+  def setting_key
+    "instruction_#{toggle}_for_#{context.definition_id.underscore}"
+  end
+
+  def toggle
+    context.kind == 'submit' ? 'submit_notifications' : 'messages_notifications'
+  end
+end

--- a/app/mailers/instruction/authorization_request_mailer.rb
+++ b/app/mailers/instruction/authorization_request_mailer.rb
@@ -1,29 +1,15 @@
 class Instruction::AuthorizationRequestMailer < AbstractInstructionMailer
-  attr_reader :authorization_request
-
   def submit
     @authorization_request = params[:authorization_request]
+    @user = params[:user]
 
-    return if instructors_or_reporters_to_notify.empty?
-
-    mail(
-      to: instructors_or_reporters_to_notify.pluck(:email),
-      subject: t(
-        '.subject',
-      )
-    )
+    mail(to: @user.email, subject: t('.subject'))
   end
 
   def reopening_submit
     @authorization_request = params[:authorization_request]
+    @user = params[:user]
 
-    return if instructors_or_reporters_to_notify.empty?
-
-    mail(
-      to: instructors_or_reporters_to_notify.pluck(:email),
-      subject: t(
-        '.subject',
-      )
-    )
+    mail(to: @user.email, subject: t('.subject'))
   end
 end

--- a/app/mailers/message_mailer.rb
+++ b/app/mailers/message_mailer.rb
@@ -19,32 +19,21 @@ class MessageMailer < ApplicationMailer
 
   def to_instructors
     @authorization_request = params[:message].authorization_request
+    @user = params[:user]
 
     mail(
-      to: instructors_to_notify(@authorization_request).pluck(:email),
+      to: @user.email,
       subject: t('.subject', authorization_request_name: @authorization_request.name),
     )
   end
 
   def reopening_to_instructors
     @authorization_request = params[:message].authorization_request
+    @user = params[:user]
 
     mail(
-      to: instructors_to_notify(@authorization_request).pluck(:email),
+      to: @user.email,
       subject: t('.subject', authorization_request_name: @authorization_request.name),
     )
-  end
-
-  private
-
-  def instructors_to_notify(authorization_request)
-    instructors(authorization_request.definition).reject do |instructor|
-      !instructor.public_send(:"instruction_messages_notifications_for_#{authorization_request.definition.id.underscore}") &&
-        instructor != authorization_request.applicant
-    end
-  end
-
-  def instructors(definition)
-    definition.instructors_and_managers
   end
 end

--- a/app/models/instruction/notification_recipients.rb
+++ b/app/models/instruction/notification_recipients.rb
@@ -1,0 +1,35 @@
+class Instruction::NotificationRecipients
+  def self.submit(authorization_request)
+    new(
+      authorization_request,
+      :submit_notifications,
+      authorization_request.definition.instructors_or_reporters,
+    ).to_notify
+  end
+
+  def self.messages(authorization_request)
+    new(
+      authorization_request,
+      :messages_notifications,
+      authorization_request.definition.instructors_and_managers,
+    ).to_notify
+  end
+
+  def initialize(authorization_request, toggle, candidates)
+    @authorization_request = authorization_request
+    @toggle = toggle
+    @candidates = candidates
+  end
+
+  def to_notify
+    @candidates.reject do |user|
+      !user.public_send(setting_key) && user != @authorization_request.applicant
+    end
+  end
+
+  private
+
+  def setting_key
+    "instruction_#{@toggle}_for_#{@authorization_request.definition.id.underscore}"
+  end
+end

--- a/app/models/notification_unsubscribe_token.rb
+++ b/app/models/notification_unsubscribe_token.rb
@@ -1,0 +1,26 @@
+class NotificationUnsubscribeToken
+  EXPIRES_IN = 30.days
+
+  def self.generate(user:, definition_id:, kind:)
+    encryptor.encrypt_and_sign(
+      { user_id: user.id, definition_id:, kind: },
+      expires_in: EXPIRES_IN,
+    )
+  end
+
+  def self.decode(token)
+    return if token.blank?
+
+    encryptor.decrypt_and_verify(token)&.symbolize_keys
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    nil
+  end
+
+  def self.encryptor
+    @encryptor ||= ActiveSupport::MessageEncryptor.new(
+      Rails.application.key_generator.generate_key(
+        'notification_unsubscribe', ActiveSupport::MessageEncryptor.key_len
+      )
+    )
+  end
+end

--- a/app/notifiers/application_notifier.rb
+++ b/app/notifiers/application_notifier.rb
@@ -38,4 +38,13 @@ class ApplicationNotifier
       ),
     ).public_send(event).deliver_later
   end
+
+  def notify_instructors_individually(base_event, params)
+    event = params[:within_reopening] ? "reopening_#{base_event}" : base_event
+
+    Instruction::NotificationRecipients.submit(authorization_request).each do |user|
+      Instruction::AuthorizationRequestMailer
+        .with(authorization_request:, user:).public_send(event).deliver_later
+    end
+  end
 end

--- a/app/notifiers/base_notifier.rb
+++ b/app/notifiers/base_notifier.rb
@@ -24,7 +24,7 @@ class BaseNotifier < ApplicationNotifier
   end
 
   def submit(params)
-    email_notification_with_reopening('submit', params, mailer: Instruction::AuthorizationRequestMailer)
+    notify_instructors_individually('submit', params)
     email_notification_with_reopening('submit', params)
   end
 

--- a/app/organizers/send_message_to_applicant.rb
+++ b/app/organizers/send_message_to_applicant.rb
@@ -5,13 +5,11 @@ class SendMessageToApplicant < ApplicationOrganizer
     context.event_name = :instructor_message
     context.event_entity = :message
 
-    context.mailer_method = :to_applicant
-
     context.unread_counter_target = :instructors
   end
 
   organize CreateMessageModel,
     CreateAuthorizationRequestEventModel,
-    DeliverMessageMail,
+    DeliverMessageMailToApplicant,
     IncrementAuthorizationRequestUnreadCounter
 end

--- a/app/organizers/send_message_to_instructors.rb
+++ b/app/organizers/send_message_to_instructors.rb
@@ -5,13 +5,11 @@ class SendMessageToInstructors < ApplicationOrganizer
     context.event_name = :applicant_message
     context.event_entity = :message
 
-    context.mailer_method = :to_instructors
-
     context.unread_counter_target = :applicant
   end
 
   organize CreateMessageModel,
     CreateAuthorizationRequestEventModel,
-    DeliverMessageMail,
+    DeliverMessageMailToInstructors,
     IncrementAuthorizationRequestUnreadCounter
 end

--- a/app/services/skip_links_implemented_checker.rb
+++ b/app/services/skip_links_implemented_checker.rb
@@ -24,6 +24,9 @@ class SkipLinksImplementedChecker
     claim_instructor_draft_requests#show
     claim_instructor_draft_requests#create
 
+    notification_unsubscriptions#show
+    notification_unsubscriptions#create
+
     authorization_request_events#index
     messages#index
     profile#edit

--- a/app/views/instruction/authorization_request_mailer/reopening_submit.text.erb
+++ b/app/views/instruction/authorization_request_mailer/reopening_submit.text.erb
@@ -10,6 +10,6 @@
   )
 %>
 
-<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
-
 <%= t('mailer.shared.instruction.footer.text') %>
+
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition, user: @user, kind: 'submit' %>

--- a/app/views/instruction/authorization_request_mailer/submit.text.erb
+++ b/app/views/instruction/authorization_request_mailer/submit.text.erb
@@ -15,6 +15,6 @@
   )
 %>
 
-<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
-
 <%= t('mailer.shared.instruction.footer.text') %>
+
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition, user: @user, kind: 'submit' %>

--- a/app/views/layouts/form_introduction.html.erb
+++ b/app/views/layouts/form_introduction.html.erb
@@ -2,7 +2,7 @@
   <div class="fr-container--fluid authorization-request-form-new fr-col">
     <div class="fr-grid-row fr-col">
       <div class="fr-col-sm-12 fr-col-md-3 logo-wrapper">
-        <%= image_tag('sign-document.svg', alt: 'Sign document') %>
+        <%= image_tag('sign-document.svg', alt: '') %>
       </div>
 
       <div class="fr-col-md-9 text-wrapper">

--- a/app/views/layouts/notification_unsubscription.html.erb
+++ b/app/views/layouts/notification_unsubscription.html.erb
@@ -1,0 +1,11 @@
+<%= content_for(:body) do %>
+  <div class="fr-container fr-my-8w">
+    <div class="fr-grid-row fr-grid-row--center">
+      <div class="fr-col-12 fr-col-md-8">
+        <%= yield %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: 'layouts/application' %>

--- a/app/views/mailer/shared/instruction/_unsubscribe_link.text.erb
+++ b/app/views/mailer/shared/instruction/_unsubscribe_link.text.erb
@@ -2,6 +2,10 @@
   t(
     'mailer.shared.instruction.unsubscribe_link.text',
     authorization_definition_name: authorization_definition.name_with_stage,
-    preferences_url: profile_url(anchor: 'notifications-section'),
+    unsubscribe_url: notification_unsubscriptions_url(
+      token: NotificationUnsubscribeToken.generate(
+        user:, definition_id: authorization_definition.id, kind:,
+      ),
+    ),
   )
 %>

--- a/app/views/message_mailer/reopening_to_instructors.text.erb
+++ b/app/views/message_mailer/reopening_to_instructors.text.erb
@@ -11,6 +11,6 @@
   )
 %>
 
-<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
-
 <%= t('mailer.shared.instruction.footer.text') %>
+
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition, user: @user, kind: 'messages' %>

--- a/app/views/message_mailer/to_instructors.text.erb
+++ b/app/views/message_mailer/to_instructors.text.erb
@@ -11,6 +11,6 @@
   )
 %>
 
-<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition %>
-
 <%= t('mailer.shared.instruction.footer.text') %>
+
+<%= render 'mailer/shared/instruction/unsubscribe_link', authorization_definition: @authorization_request.definition, user: @user, kind: 'messages' %>

--- a/app/views/notification_unsubscriptions/invalid.html.erb
+++ b/app/views/notification_unsubscriptions/invalid.html.erb
@@ -1,0 +1,9 @@
+<% set_title! t('page_titles.notification_unsubscription_invalid') %>
+
+<h1 class="fr-h2 fr-my-5w"><%= t('.title') %></h1>
+
+<%= dsfr_alert(type: :error, title: t('.description')) %>
+
+<p class="fr-mt-4w">
+  <%= link_to t('.manage_preferences'), profile_path(anchor: 'notifications-section'), class: 'fr-link' %>
+</p>

--- a/app/views/notification_unsubscriptions/show.html.erb
+++ b/app/views/notification_unsubscriptions/show.html.erb
@@ -1,0 +1,14 @@
+<% set_title! t('page_titles.notification_unsubscription_show') %>
+
+<h1 class="fr-h2 fr-my-5w"><%= t('.title') %></h1>
+
+<p><%= t('.description', kind_label:, api_name: authorization_definition.name_with_stage) %></p>
+
+<%= form_with url: notification_unsubscriptions_path, method: :post, data: { turbo: false } do |f| %>
+  <%= f.hidden_field :token, value: params[:token] %>
+  <%= f.button t('.cta'), type: 'submit', class: 'fr-btn' %>
+<% end %>
+
+<p class="fr-mt-4w">
+  <%= link_to t('.manage_preferences'), profile_path(anchor: 'notifications-section'), class: 'fr-link' %>
+</p>

--- a/app/views/notification_unsubscriptions/success.html.erb
+++ b/app/views/notification_unsubscriptions/success.html.erb
@@ -1,0 +1,13 @@
+<% set_title! t('page_titles.notification_unsubscription_success') %>
+
+<h1 class="fr-h2 fr-my-5w"><%= t('.title') %></h1>
+
+<% if @already_unsubscribed %>
+  <%= dsfr_alert(type: :info, title: t('.already_description', kind_label:, api_name: authorization_definition.name_with_stage)) %>
+<% else %>
+  <%= dsfr_alert(type: :success, title: t('.description', kind_label:, api_name: authorization_definition.name_with_stage)) %>
+<% end %>
+
+<p class="fr-mt-4w">
+  <%= link_to t('.manage_preferences'), profile_path(anchor: 'notifications-section'), class: 'fr-link' %>
+</p>

--- a/app/views/profile/_authorization_notifications.html.erb
+++ b/app/views/profile/_authorization_notifications.html.erb
@@ -1,27 +1,40 @@
-<div class="settings-block">
-  <h3 class="settings-block__title">
-    <%= authorization_definition.name_with_stage %>
-  </h3>
+<% legend_id = "notifications-#{authorization_definition.id.underscore}-legend" %>
 
-  <div class="settings-block__container">
-    <%= form_with(model: current_user, url: notifications_settings_path, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 0 }) do |f| %>
-      <% %w[submit_notifications messages_notifications].each do |notification_kind| %>
-        <div class="fr-toggle">
-          <%=
-            f.check_box "instruction_#{notification_kind}_for_#{authorization_definition.id.underscore}",
-              class: 'fr-toggle__input'
-          %>
-          <%=
-            f.label "instruction_#{notification_kind}_for_#{authorization_definition.id.underscore}",
-              t(".instruction_#{notification_kind}"),
-              class: 'fr-toggle__label',
-              data: {
-                fr_checked_label: 'Activées',
-                fr_unchecked_label: 'Désactivées',
-              }
-          %>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
+<div class="settings-block">
+  <%= form_with(model: current_user, url: notifications_settings_path, data: { controller: 'auto-submit-form', 'auto-submit-form-debounce-interval-value' => 0 }) do |f| %>
+    <fieldset class="fr-fieldset" aria-labelledby="<%= legend_id %>">
+      <legend class="fr-fieldset__legend fr-h6 fr-mb-1w" id="<%= legend_id %>">
+        <%= authorization_definition.name_with_stage %>
+      </legend>
+
+      <div class="fr-fieldset__element">
+        <ul class="fr-toggle__list">
+          <% %w[submit_notifications messages_notifications].each do |notification_kind| %>
+            <% field = "instruction_#{notification_kind}_for_#{authorization_definition.id.underscore}" %>
+            <li>
+              <div class="fr-toggle">
+                <%=
+                  f.check_box field,
+                    class: 'fr-toggle__input',
+                    id: field,
+                    aria: { describedby: "#{field}-messages" }
+                %>
+                <%=
+                  f.label field,
+                    t(".instruction_#{notification_kind}"),
+                    class: 'fr-toggle__label',
+                    for: field,
+                    data: {
+                      fr_checked_label: 'Activées',
+                      fr_unchecked_label: 'Désactivées',
+                    }
+                %>
+                <div class="fr-messages-group" id="<%= field %>-messages" aria-live="polite"></div>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </fieldset>
+  <% end %>
 </div>

--- a/app/views/shared/_matomo.html.erb
+++ b/app/views/shared/_matomo.html.erb
@@ -1,4 +1,4 @@
-<% if Rails.application.config.matomo_id.present? %>
+<% if Rails.application.config.matomo_id.present? && controller_name != 'notification_unsubscriptions' %>
   <script>
     var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -852,6 +852,25 @@ fr:
       description: Pour créer puis compléter cette demande d'habilitation, cliquez sur le bouton ci-dessous
       cta: Créer cette demande
 
+  notification_unsubscriptions:
+    kinds:
+      submit: les nouvelles demandes à instruire
+      messages: les nouveaux messages
+    show:
+      title: Désinscription des notifications
+      description: "Vous êtes sur le point de ne plus recevoir les emails concernant %{kind_label} pour « %{api_name} ». Vos autres notifications ne sont pas affectées."
+      cta: Confirmer la désinscription
+      manage_preferences: Gérer toutes mes préférences de notification
+    success:
+      title: Préférence enregistrée
+      description: "Vous ne recevrez plus d’email concernant %{kind_label} pour « %{api_name} »."
+      already_description: "Vous ne receviez déjà plus d’email concernant %{kind_label} pour « %{api_name} »."
+      manage_preferences: Gérer toutes mes préférences de notification
+    invalid:
+      title: Lien invalide ou expiré
+      description: Ce lien de désinscription n’est plus valide. Il a peut-être expiré.
+      manage_preferences: Gérer mes préférences sur mon compte
+
   errors:
     messages:
       form_errors:

--- a/config/locales/mailer.fr.yml
+++ b/config/locales/mailer.fr.yml
@@ -22,8 +22,8 @@ fr:
             ---
             Vous recevez cet email car vous avez des droits relatifs à « %{authorization_definition_name} » sur DataPass.
 
-            Pour modifier vos préférences ou ne plus recevoir ces notifications, rendez-vous sur votre compte :
-            %{preferences_url}
+            Pour ne plus recevoir ces notifications, désinscrivez-vous en un clic :
+            %{unsubscribe_url}
 
   auto_generated_france_connect_mailer:
     approve:

--- a/config/locales/page_titles.fr.yml
+++ b/config/locales/page_titles.fr.yml
@@ -41,3 +41,7 @@ fr:
     instruction_edit_request: "Nouvelle demande instructeur %{definition_name} - %{project_name}"
     instruction_user_rights: Gestion des droits
     admin_habilitation_types: "Types d’habilitation"
+
+    notification_unsubscription_show: Désinscription des notifications
+    notification_unsubscription_success: Préférence enregistrée
+    notification_unsubscription_invalid: Lien invalide ou expiré

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
   get '/demandes-instructeurs/:id/creer', to: 'claim_instructor_draft_requests#show', as: :claim_instructor_draft_request
   post '/demandes-instructeurs/:id/creer', to: 'claim_instructor_draft_requests#create'
 
+  get '/desabonnement-notifications', to: 'notification_unsubscriptions#show', as: :notification_unsubscriptions
+  post '/desabonnement-notifications', to: 'notification_unsubscriptions#create'
+
   get '/stats', to: 'stats#index', as: :stats
   get '/stats/filters', to: 'stats#filters', as: :stats_filters
   get '/stats/data', to: 'stats#data', as: :stats_data

--- a/features/desabonnement_notifications.feature
+++ b/features/desabonnement_notifications.feature
@@ -1,0 +1,55 @@
+# language: fr
+
+Fonctionnalité: Désinscription des notifications en 1 clic depuis l’email
+  Un instructeur peut se désinscrire d’une notification en cliquant sur un lien
+  signé présent dans le footer des emails d’instruction, sans se reconnecter.
+
+  Scénario: Un instructeur peut voir la page de confirmation via un token valide
+    Sachant que je suis un instructeur "API Entreprise"
+    Et qu'il existe un token de désinscription valide pour cet instructeur
+    Quand je me rends sur la page de désinscription avec ce token
+    Alors je suis sur la page "Désinscription des notifications"
+    Et la page contient "Confirmer la désinscription"
+
+  Scénario: La confirmation GET n’effectue aucune désactivation
+    Sachant que je suis un instructeur "API Entreprise"
+    Et qu'il existe un token de désinscription valide pour cet instructeur
+    Quand je me rends sur la page de désinscription avec ce token
+    Alors la préférence de notification n’a pas changé
+
+  Scénario: Un instructeur peut désactiver ses notifications via le POST
+    Sachant que je suis un instructeur "API Entreprise"
+    Et qu'il existe un token de désinscription valide pour cet instructeur
+    Quand je me rends sur la page de désinscription avec ce token
+    Et que je clique sur "Confirmer la désinscription"
+    Alors je suis sur la page "Préférence enregistrée"
+    Et la page contient "Vous ne recevrez plus d’email concernant"
+    Et la notification de soumission est désactivée pour cet instructeur
+
+  Scénario: La désactivation est idempotente
+    Sachant que je suis un instructeur "API Entreprise"
+    Et qu'il existe un token de désinscription valide pour cet instructeur
+    Quand je me rends sur la page de désinscription avec ce token
+    Et que je clique sur "Confirmer la désinscription"
+    Et que je me rends sur la page de désinscription avec ce token
+    Et que je clique sur "Confirmer la désinscription"
+    Alors je suis sur la page "Préférence enregistrée"
+
+  Scénario: Un token invalide affiche une page d’erreur
+    Quand je me rends sur le chemin "/desabonnement-notifications?token=token_invalide"
+    Alors je suis sur la page "Lien invalide ou expiré"
+    Et la page contient "Gérer mes préférences sur mon compte"
+
+  Scénario: Un token expiré affiche une page d’erreur
+    Sachant que je suis un instructeur "API Entreprise"
+    Et qu'il existe un token de désinscription expiré pour cet instructeur
+    Quand je me rends sur la page de désinscription avec ce token
+    Alors je suis sur la page "Lien invalide ou expiré"
+
+  Scénario: Un token valide mais un rôle révoqué confirme la désinscription
+    Sachant que je suis un instructeur "API Entreprise"
+    Et qu'il existe un token de désinscription valide pour cet instructeur
+    Et que cet instructeur a perdu son rôle sur API Entreprise
+    Quand je me rends sur la page de désinscription avec ce token
+    Alors je suis sur la page "Préférence enregistrée"
+    Et la page contient "Vous ne receviez déjà plus d’email"

--- a/features/step_definitions/notification_unsubscription_steps.rb
+++ b/features/step_definitions/notification_unsubscription_steps.rb
@@ -1,0 +1,40 @@
+Sachantque('il existe un token de désinscription valide pour cet instructeur') do
+  user = User.find_by(email: @current_user_email)
+  definition = AuthorizationDefinition.find('api_entreprise')
+  @unsubscribe_token = NotificationUnsubscribeToken.generate(
+    user:,
+    definition_id: definition.id,
+    kind: 'submit',
+  )
+end
+
+Sachantque('il existe un token de désinscription expiré pour cet instructeur') do
+  user = User.find_by(email: @current_user_email)
+  definition = AuthorizationDefinition.find('api_entreprise')
+  travel_to((NotificationUnsubscribeToken::EXPIRES_IN + 1.day).ago) do
+    @unsubscribe_token = NotificationUnsubscribeToken.generate(
+      user:,
+      definition_id: definition.id,
+      kind: 'submit',
+    )
+  end
+end
+
+Sachantque('cet instructeur a perdu son rôle sur API Entreprise') do
+  user = User.find_by(email: @current_user_email)
+  user.update!(roles: [])
+end
+
+Quand('je me rends sur la page de désinscription avec ce token') do
+  visit notification_unsubscriptions_path(token: @unsubscribe_token)
+end
+
+Alors('la préférence de notification n’a pas changé') do
+  user = User.find_by(email: @current_user_email)
+  expect(user.instruction_submit_notifications_for_api_entreprise).to be_truthy
+end
+
+Alors('la notification de soumission est désactivée pour cet instructeur') do
+  user = User.find_by(email: @current_user_email)
+  expect(user.reload.instruction_submit_notifications_for_api_entreprise).to be(false)
+end

--- a/features/step_definitions/settings.rb
+++ b/features/step_definitions/settings.rb
@@ -1,5 +1,5 @@
 def setting_block_testing(block_title, &)
-  settings_block = find('.settings-block__title', text: block_title).ancestor('.settings-block')
+  settings_block = find('.fr-fieldset__legend', text: block_title).ancestor('.settings-block')
 
   within(settings_block, &)
 end

--- a/spec/interactors/notifications/unsubscribe_spec.rb
+++ b/spec/interactors/notifications/unsubscribe_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Notifications::Unsubscribe do
+  subject(:organizer) { described_class.call(user:, definition_id:, kind:) }
+
+  let(:user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise api_particulier]) }
+  let(:definition_id) { 'api_entreprise' }
+  let(:kind) { 'submit' }
+
+  describe 'when kind is submit' do
+    it 'disables the submit notification for the given API' do
+      expect { organizer }.to change {
+        user.reload.instruction_submit_notifications_for_api_entreprise
+      }.to(false)
+    end
+
+    it 'does not affect the messages notification for the same API' do
+      organizer
+      expect(user.reload.instruction_messages_notifications_for_api_entreprise).to be_truthy
+    end
+
+    it 'does not affect the submit notification for another API' do
+      organizer
+      expect(user.reload.instruction_submit_notifications_for_api_particulier).to be_truthy
+    end
+  end
+
+  describe 'when kind is messages' do
+    let(:kind) { 'messages' }
+
+    it 'disables the messages notification for the given API' do
+      expect { organizer }.to change {
+        user.reload.instruction_messages_notifications_for_api_entreprise
+      }.to(false)
+    end
+
+    it 'does not affect the submit notification for the same API' do
+      organizer
+      expect(user.reload.instruction_submit_notifications_for_api_entreprise).to be_truthy
+    end
+  end
+
+  describe 'when the user is already unsubscribed' do
+    before { user.update!('instruction_submit_notifications_for_api_entreprise' => '0') }
+
+    it 'flags already_unsubscribed' do
+      expect(organizer.already_unsubscribed).to be(true)
+    end
+  end
+end

--- a/spec/mailers/instruction/authorization_request_mailer_spec.rb
+++ b/spec/mailers/instruction/authorization_request_mailer_spec.rb
@@ -2,63 +2,51 @@ RSpec.describe Instruction::AuthorizationRequestMailer do
   describe '#submit' do
     subject(:mail) do
       described_class.with(
-        authorization_request:
+        authorization_request:,
+        user: valid_instructor,
       ).submit
     end
 
     let(:authorization_request) { create(:authorization_request, :api_entreprise, :submitted) }
+    let(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
-    context 'when there is instructors and reporters to notify' do
-      let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise api_particulier], instruction_submit_notifications_for_api_particulier: false) }
-      let!(:instructor_without_notification) { create(:user, :instructor, authorization_request_types: %w[api_entreprise], instruction_submit_notifications_for_api_entreprise: false) }
-      let!(:valid_reporter) { create(:user, :reporter, authorization_request_types: %w[api_entreprise api_particulier], instruction_submit_notifications_for_api_particulier: false) }
-      let!(:reporter_without_notification) { create(:user, :reporter, authorization_request_types: %w[api_entreprise], instruction_submit_notifications_for_api_entreprise: false) }
-      let!(:instructor_for_another_authorization) { create(:user, :instructor, authorization_request_types: %w[api_particulier]) }
+    it 'sends the email to the given user' do
+      expect(mail.to).to eq([valid_instructor.email])
+    end
 
-      it 'sends the email to the instructors and reporters with notification on' do
-        expect(mail.to).to contain_exactly(valid_instructor.email, valid_reporter.email)
+    it 'renders valid template' do
+      expect(mail.body.encoded).to match("demande d'habilitation")
+      expect(mail.body.encoded).to match('a soumis')
+      expect(mail.body.encoded).to match(authorization_request.applicant.email)
+    end
+
+    context 'when the authorization request has a modification request' do
+      before do
+        create(:instructor_modification_request, authorization_request: authorization_request)
       end
 
-      it 'renders valid template' do
-        expect(mail.body.encoded).to match("demande d'habilitation")
-        expect(mail.body.encoded).to match('a soumis')
-        expect(mail.body.encoded).to match(authorization_request.applicant.email)
-      end
-
-      context 'when the authorization request has a modification request' do
-        before do
-          create(:instructor_modification_request, authorization_request: authorization_request)
-        end
-
-        it 'includes the changes_requested_submit message' do
-          expect(mail.body.encoded).to match('Cette demande fait suite à une demande de modification.')
-        end
-      end
-
-      context 'when the authorization request does not have a modification request' do
-        it 'does not include the changes_requested_submit message' do
-          expect(mail.body.encoded).not_to match('Cette demande fait suite à une demande de modification.')
-        end
-      end
-
-      context 'with the unsubscribe footer' do
-        it 'inclut le lien vers la page de préférences' do
-          expect(mail.body.encoded).to include('/compte#notifications-section')
-        end
-
-        it 'mentionne le nom de l’API' do
-          expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
-        end
-
-        it 'mentionne le texte de gestion des préférences' do
-          expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
-        end
+      it 'includes the changes_requested_submit message' do
+        expect(mail.body.encoded).to match('Cette demande fait suite à une demande de modification.')
       end
     end
 
-    context 'when there is no instructor nor reporter to notify' do
-      it 'does not render any email' do
-        expect(mail.body).to be_blank
+    context 'when the authorization request does not have a modification request' do
+      it 'does not include the changes_requested_submit message' do
+        expect(mail.body.encoded).not_to match('Cette demande fait suite à une demande de modification.')
+      end
+    end
+
+    context 'with the unsubscribe footer' do
+      it "mentionne le nom de l'API" do
+        expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
+      end
+
+      it 'mentionne le texte de gestion des préférences' do
+        expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
+      end
+
+      it 'inclut le lien de désinscription 1 clic' do
+        expect(mail.body.encoded).to include('/desabonnement-notifications?token=')
       end
     end
   end
@@ -66,44 +54,35 @@ RSpec.describe Instruction::AuthorizationRequestMailer do
   describe '#reopening_submit' do
     subject(:mail) do
       described_class.with(
-        authorization_request:
+        authorization_request:,
+        user: valid_instructor,
       ).reopening_submit
     end
 
     let(:authorization_request) { create(:authorization_request, :api_entreprise, :submitted) }
+    let(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
-    context 'when there is instructors to notify' do
-      let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
-      let!(:valid_reporter) { create(:user, :reporter, authorization_request_types: %w[api_entreprise api_particulier], instruction_submit_notifications_for_api_particulier: false) }
-
-      it 'sends the email to the instructors with notification on' do
-        expect(mail.to).to contain_exactly(valid_instructor.email, valid_reporter.email)
-      end
-
-      it 'renders valid template' do
-        expect(mail.body.encoded).to match('demande de réouverture')
-        expect(mail.body.encoded).to match('a soumis')
-        expect(mail.body.encoded).to match(authorization_request.applicant.email)
-      end
-
-      context 'with the unsubscribe footer' do
-        it 'inclut le lien vers la page de préférences' do
-          expect(mail.body.encoded).to include('/compte#notifications-section')
-        end
-
-        it 'mentionne le nom de l’API' do
-          expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
-        end
-
-        it 'mentionne le texte de gestion des préférences' do
-          expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
-        end
-      end
+    it 'sends the email to the given user' do
+      expect(mail.to).to eq([valid_instructor.email])
     end
 
-    context 'when there is no instructor nor reporter to notify' do
-      it 'does not render any email' do
-        expect(mail.body).to be_blank
+    it 'renders valid template' do
+      expect(mail.body.encoded).to match('demande de réouverture')
+      expect(mail.body.encoded).to match('a soumis')
+      expect(mail.body.encoded).to match(authorization_request.applicant.email)
+    end
+
+    context 'with the unsubscribe footer' do
+      it "mentionne le nom de l'API" do
+        expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
+      end
+
+      it 'mentionne le texte de gestion des préférences' do
+        expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
+      end
+
+      it 'inclut le lien de désinscription 1 clic' do
+        expect(mail.body.encoded).to include('/desabonnement-notifications?token=')
       end
     end
   end

--- a/spec/mailers/message_mailer_spec.rb
+++ b/spec/mailers/message_mailer_spec.rb
@@ -28,19 +28,14 @@ RSpec.describe MessageMailer do
   end
 
   describe '#to_instructors' do
-    let(:mail) { described_class.with(message:).to_instructors }
-    let(:message) { create(:message, authorization_request:) }
     let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+    let(:message) { create(:message, authorization_request:) }
+    let(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
-    let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise api_particulier], instruction_messages_notifications_for_api_particulier: false) }
-    let!(:instructor_without_notification) { create(:user, :instructor, authorization_request_types: %w[api_entreprise], instruction_messages_notifications_for_api_entreprise: false) }
-    let!(:instructor_for_another_authorization) { create(:user, :instructor, authorization_request_types: %w[api_particulier]) }
-    let!(:valid_manager) { create(:user, :manager, authorization_request_types: %w[api_entreprise]) }
-    let!(:manager_without_notification) { create(:user, :manager, authorization_request_types: %w[api_entreprise], instruction_messages_notifications_for_api_entreprise: false) }
-    let!(:manager_for_another_authorization) { create(:user, :manager, authorization_request_types: %w[api_particulier]) }
+    let(:mail) { described_class.with(message:, user: valid_instructor).to_instructors }
 
-    it 'sends the email to instructors and managers with notification on' do
-      expect(mail.to).to contain_exactly(valid_instructor.email, valid_manager.email)
+    it 'sends the email to the given user' do
+      expect(mail.to).to eq([valid_instructor.email])
     end
 
     it 'renders valid template' do
@@ -49,30 +44,29 @@ RSpec.describe MessageMailer do
     end
 
     context 'with the unsubscribe footer' do
-      it 'inclut le lien vers la page de préférences' do
-        expect(mail.body.encoded).to include('/compte#notifications-section')
-      end
-
-      it 'mentionne le nom de l’API' do
+      it "mentionne le nom de l'API" do
         expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
       end
 
       it 'mentionne le texte de gestion des préférences' do
         expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
       end
+
+      it 'inclut le lien de désinscription 1 clic' do
+        expect(mail.body.encoded).to include('/desabonnement-notifications?token=')
+      end
     end
   end
 
   describe '#reopening_to_instructors' do
-    let(:mail) { described_class.with(message:).reopening_to_instructors }
-    let(:message) { create(:message, authorization_request:) }
     let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+    let(:message) { create(:message, authorization_request:) }
+    let(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
-    let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise api_particulier], instruction_messages_notifications_for_api_particulier: false) }
-    let!(:valid_manager) { create(:user, :manager, authorization_request_types: %w[api_entreprise]) }
+    let(:mail) { described_class.with(message:, user: valid_instructor).reopening_to_instructors }
 
-    it 'sends the email to instructors and managers with notification on' do
-      expect(mail.to).to contain_exactly(valid_instructor.email, valid_manager.email)
+    it 'sends the email to the given user' do
+      expect(mail.to).to eq([valid_instructor.email])
     end
 
     it 'renders valid template' do
@@ -81,16 +75,16 @@ RSpec.describe MessageMailer do
     end
 
     context 'with the unsubscribe footer' do
-      it 'inclut le lien vers la page de préférences' do
-        expect(mail.body.encoded).to include('/compte#notifications-section')
-      end
-
-      it 'mentionne le nom de l’API' do
+      it "mentionne le nom de l'API" do
         expect(mail.body.encoded).to include(authorization_request.definition.name_with_stage)
       end
 
       it 'mentionne le texte de gestion des préférences' do
         expect(mail.body.encoded).to include('ne plus recevoir ces notifications')
+      end
+
+      it 'inclut le lien de désinscription 1 clic' do
+        expect(mail.body.encoded).to include('/desabonnement-notifications?token=')
       end
     end
   end

--- a/spec/mailers/previews/instruction/authorization_request_mailer_preview.rb
+++ b/spec/mailers/previews/instruction/authorization_request_mailer_preview.rb
@@ -1,13 +1,15 @@
 class Instruction::AuthorizationRequestMailerPreview < ActionMailer::Preview
   def submit
     Instruction::AuthorizationRequestMailer.with(
-      authorization_request: authorization_request
+      authorization_request:,
+      user: instructor,
     ).submit
   end
 
   def reopening_submit
     Instruction::AuthorizationRequestMailer.with(
-      authorization_request: reopened_authorization_request
+      authorization_request: reopened_authorization_request,
+      user: instructor,
     ).reopening_submit
   end
 
@@ -20,5 +22,10 @@ class Instruction::AuthorizationRequestMailerPreview < ActionMailer::Preview
   def reopened_authorization_request
     AuthorizationRequest.where(state: :submitted).where.not(reopened_at: nil).first ||
       authorization_request
+  end
+
+  def instructor
+    authorization_request.definition.instructors_or_reporters.first ||
+      User.with_role_for_definition(:reporter, authorization_request.definition).first
   end
 end

--- a/spec/mailers/previews/message_mailer_preview.rb
+++ b/spec/mailers/previews/message_mailer_preview.rb
@@ -4,12 +4,16 @@ class MessageMailerPreview < ActionMailer::Preview
   end
 
   def to_instructors
-    MessageMailer.with(message:).to_instructors
+    MessageMailer.with(message:, user: instructor).to_instructors
   end
 
   private
 
   def message
     Message.first
+  end
+
+  def instructor
+    message.authorization_request.definition.instructors_and_managers.first
   end
 end

--- a/spec/models/instruction/notification_recipients_spec.rb
+++ b/spec/models/instruction/notification_recipients_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe Instruction::NotificationRecipients do
+  let(:authorization_request) { create(:authorization_request, :api_entreprise) }
+
+  describe '.submit' do
+    subject(:recipients) { described_class.submit(authorization_request) }
+
+    let!(:instructor_with_notif) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+    let!(:instructor_without_notif) { create(:user, :instructor, authorization_request_types: %w[api_entreprise], instruction_submit_notifications_for_api_entreprise: false) }
+    let!(:reporter_with_notif) { create(:user, :reporter, authorization_request_types: %w[api_entreprise]) }
+    let!(:reporter_without_notif) { create(:user, :reporter, authorization_request_types: %w[api_entreprise], instruction_submit_notifications_for_api_entreprise: false) }
+    let!(:instructor_other_api) { create(:user, :instructor, authorization_request_types: %w[api_particulier]) }
+
+    it 'includes instructors with notification on' do
+      expect(recipients).to include(instructor_with_notif)
+    end
+
+    it 'excludes instructors with notification off' do
+      expect(recipients).not_to include(instructor_without_notif)
+    end
+
+    it 'includes reporters with notification on' do
+      expect(recipients).to include(reporter_with_notif)
+    end
+
+    it 'excludes reporters with notification off' do
+      expect(recipients).not_to include(reporter_without_notif)
+    end
+
+    it 'excludes instructors for another API' do
+      expect(recipients).not_to include(instructor_other_api)
+    end
+
+    context 'when the applicant is also an instructor with notification off' do
+      let!(:applicant_instructor) do
+        applicant = authorization_request.applicant
+        applicant.grant_role(:instructor, 'api_entreprise')
+        applicant.update!(instruction_submit_notifications_for_api_entreprise: false)
+        applicant
+      end
+
+      it 'still includes the applicant (exception rule)' do
+        expect(recipients).to include(applicant_instructor)
+      end
+    end
+  end
+
+  describe '.messages' do
+    subject(:recipients) { described_class.messages(authorization_request) }
+
+    let!(:instructor_with_notif) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+    let!(:instructor_without_notif) { create(:user, :instructor, authorization_request_types: %w[api_entreprise], instruction_messages_notifications_for_api_entreprise: false) }
+    let!(:manager_with_notif) { create(:user, :manager, authorization_request_types: %w[api_entreprise]) }
+    let!(:manager_without_notif) { create(:user, :manager, authorization_request_types: %w[api_entreprise], instruction_messages_notifications_for_api_entreprise: false) }
+    let!(:instructor_other_api) { create(:user, :instructor, authorization_request_types: %w[api_particulier]) }
+
+    it 'includes instructors with notification on' do
+      expect(recipients).to include(instructor_with_notif)
+    end
+
+    it 'excludes instructors with notification off' do
+      expect(recipients).not_to include(instructor_without_notif)
+    end
+
+    it 'includes managers with notification on' do
+      expect(recipients).to include(manager_with_notif)
+    end
+
+    it 'excludes managers with notification off' do
+      expect(recipients).not_to include(manager_without_notif)
+    end
+
+    it 'excludes instructors for another API' do
+      expect(recipients).not_to include(instructor_other_api)
+    end
+
+    context 'when the applicant is also an instructor with notification off' do
+      let!(:applicant_instructor) do
+        applicant = authorization_request.applicant
+        applicant.grant_role(:instructor, 'api_entreprise')
+        applicant.update!(instruction_messages_notifications_for_api_entreprise: false)
+        applicant
+      end
+
+      it 'still includes the applicant (exception rule)' do
+        expect(recipients).to include(applicant_instructor)
+      end
+    end
+  end
+
+  describe 'parity with legacy filters' do
+    let!(:instructor_with_notif) { create(:user, :instructor, authorization_request_types: %w[api_entreprise api_particulier], instruction_submit_notifications_for_api_particulier: false) }
+    let!(:instructor_without_notif) { create(:user, :instructor, authorization_request_types: %w[api_entreprise], instruction_submit_notifications_for_api_entreprise: false) }
+    let!(:reporter_with_notif) { create(:user, :reporter, authorization_request_types: %w[api_entreprise api_particulier], instruction_submit_notifications_for_api_particulier: false) }
+    let!(:reporter_without_notif) { create(:user, :reporter, authorization_request_types: %w[api_entreprise], instruction_submit_notifications_for_api_entreprise: false) }
+
+    it 'submit returns same recipients as the legacy AbstractInstructionMailer filter' do
+      legacy_result = authorization_request.definition.instructors_or_reporters.reject do |user|
+        !user.public_send(:"instruction_submit_notifications_for_#{authorization_request.definition.id.underscore}") &&
+          user != authorization_request.applicant
+      end
+
+      expect(described_class.submit(authorization_request)).to match_array(legacy_result)
+    end
+
+    it 'messages returns same recipients as the legacy MessageMailer filter' do
+      legacy_result = authorization_request.definition.instructors_and_managers.reject do |instructor|
+        !instructor.public_send(:"instruction_messages_notifications_for_#{authorization_request.definition.id.underscore}") &&
+          instructor != authorization_request.applicant
+      end
+
+      expect(described_class.messages(authorization_request)).to match_array(legacy_result)
+    end
+  end
+end

--- a/spec/models/notification_unsubscribe_token_spec.rb
+++ b/spec/models/notification_unsubscribe_token_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe NotificationUnsubscribeToken do
+  let(:user) { create(:user) }
+  let(:definition_id) { 'api_entreprise' }
+  let(:kind) { 'submit' }
+
+  describe '.generate and .decode round-trip' do
+    it 'decodes a generated token with correct payload' do
+      token = described_class.generate(user:, definition_id:, kind:)
+      payload = described_class.decode(token)
+
+      expect(payload[:user_id]).to eq(user.id)
+      expect(payload[:definition_id]).to eq(definition_id)
+      expect(payload[:kind]).to eq(kind)
+    end
+  end
+
+  describe '.decode' do
+    it 'returns nil for a falsified token' do
+      expect(described_class.decode('invalide.token.falsifie')).to be_nil
+    end
+
+    it 'returns nil for an expired token' do
+      token = described_class.generate(user:, definition_id:, kind:)
+
+      travel_to(described_class::EXPIRES_IN.from_now + 1.day) do
+        expect(described_class.decode(token)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/notifiers/base_notifier_spec.rb
+++ b/spec/notifiers/base_notifier_spec.rb
@@ -65,16 +65,28 @@ RSpec.describe BaseNotifier, type: :notifier do
   end
 
   describe '#submit to Instruction::AuthorizationRequestMailer' do
-    it 'enqueues the submit email to instruction mailer without reopening' do
-      expect {
-        notifier.submit({})
-      }.to have_enqueued_mail(Instruction::AuthorizationRequestMailer, :submit)
+    context 'without instructors' do
+      it 'does not enqueue the submit email to instruction mailer' do
+        expect {
+          notifier.submit({})
+        }.not_to have_enqueued_mail(Instruction::AuthorizationRequestMailer, :submit)
+      end
     end
 
-    it 'enqueues the reopening_submit email to instruction mailer when reopening' do
-      expect {
-        notifier.submit({ within_reopening: true })
-      }.to have_enqueued_mail(Instruction::AuthorizationRequestMailer, :reopening_submit)
+    context 'with an instructor to notify' do
+      let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+
+      it 'enqueues the submit email to instruction mailer without reopening' do
+        expect {
+          notifier.submit({})
+        }.to have_enqueued_mail(Instruction::AuthorizationRequestMailer, :submit)
+      end
+
+      it 'enqueues the reopening_submit email to instruction mailer when reopening' do
+        expect {
+          notifier.submit({ within_reopening: true })
+        }.to have_enqueued_mail(Instruction::AuthorizationRequestMailer, :reopening_submit)
+      end
     end
   end
 
@@ -93,8 +105,8 @@ RSpec.describe BaseNotifier, type: :notifier do
   end
 
   describe '#submit email in case of changes requested' do
-    let(:authorization_request) { create(:authorization_request, :api_entreprise, last_submitted_at: 1.day.ago) }
     let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: ['api_entreprise'], instruction_submit_notifications_for_api_entreprise: true) }
+    let(:authorization_request) { create(:authorization_request, :api_entreprise, last_submitted_at: 1.day.ago) }
 
     before do
       ActiveJob::Base.queue_adapter = :inline
@@ -107,7 +119,7 @@ RSpec.describe BaseNotifier, type: :notifier do
     context 'when there is a changes requested' do
       before { create(:instructor_modification_request, authorization_request:) }
 
-      it 'delivers an email that contains the modification sentence' do
+      it 'delivers one instruction email and one applicant email' do
         expect {
           notifier.submit({})
         }.to change { ActionMailer::Base.deliveries.count }.by(2)
@@ -118,7 +130,7 @@ RSpec.describe BaseNotifier, type: :notifier do
     end
 
     context 'when there is no changes requested' do
-      it 'delivers an email that does not contain the modification sentence' do
+      it 'delivers one instruction email and one applicant email' do
         expect {
           notifier.submit({})
         }.to change { ActionMailer::Base.deliveries.count }.by(2)

--- a/spec/organizers/send_message_to_instructors_spec.rb
+++ b/spec/organizers/send_message_to_instructors_spec.rb
@@ -3,9 +3,11 @@ RSpec.describe SendMessageToInstructors do
 
   let(:message_params) { attributes_for(:message) }
   let(:user) { create(:user) }
-  let(:authorization_request) { create(:authorization_request) }
+  let(:authorization_request) { create(:authorization_request, :api_entreprise) }
 
   context 'with valid attributes' do
+    let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+
     it { is_expected.to be_success }
 
     it 'creates a message for authorization request' do
@@ -26,7 +28,7 @@ RSpec.describe SendMessageToInstructors do
     end
 
     context 'when it is a reopening' do
-      let(:authorization_request) { create(:authorization_request, :reopened) }
+      let(:authorization_request) { create(:authorization_request, :api_entreprise, :reopened) }
 
       it 'delivers an email specific to reopening to instructors' do
         expect { send_message_to_instructors }.to have_enqueued_mail(MessageMailer, :reopening_to_instructors)

--- a/spec/organizers/submit_authorization_request_spec.rb
+++ b/spec/organizers/submit_authorization_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe SubmitAuthorizationRequest do
       context 'with valid authorization request' do
         let(:authorization_request) { create(:authorization_request, authorization_request_kind, :draft, fill_all_attributes: true) }
         let(:authorization_request_kind) { :api_entreprise }
+        let!(:valid_instructor) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
 
         it { is_expected.to be_success }
 

--- a/spec/requests/notification_unsubscriptions_spec.rb
+++ b/spec/requests/notification_unsubscriptions_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'Notification unsubscriptions' do
+  describe 'POST /desabonnement-notifications with an invalid token while impersonating' do
+    let(:admin) { create(:user, :admin) }
+    let(:impersonated_user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+
+    before do
+      sign_in(admin)
+      post admin_impersonate_path(impersonation: { email: impersonated_user.email, reason: 'Support #12345' })
+    end
+
+    it 'renders the invalid page instead of raising' do
+      post notification_unsubscriptions_path, params: { token: 'invalid-token' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Lien invalide ou expiré')
+    end
+  end
+
+  describe 'GET /desabonnement-notifications when Matomo is configured' do
+    around do |example|
+      original_matomo_id = Rails.application.config.matomo_id
+      Rails.application.config.matomo_id = '307'
+      example.run
+      Rails.application.config.matomo_id = original_matomo_id
+    end
+
+    it 'does not load the Matomo tracker on the unsubscription pages' do
+      get notification_unsubscriptions_path, params: { token: 'invalid-token' }
+
+      expect(response.body).not_to include('setTrackerUrl')
+    end
+  end
+end


### PR DESCRIPTION
# DP-1743 — Désinscription en un clic depuis les emails d’instruction

## Contexte

Les emails d’instruction (soumission d’une demande, nouveau message) sont envoyés aux instructeurs et reporters d’une définition d’habilitation. Jusqu’ici, le seul moyen de ne plus les recevoir était de modifier ses préférences depuis son compte.

Cette PR ajoute un lien de désinscription en un clic dans le footer de ces emails, via un token chiffré, avec une page de confirmation.


https://github.com/user-attachments/assets/43844c0d-5460-44a7-bd3d-3f9d1fcfcb2e

Et en générant directement le token en console :


https://github.com/user-attachments/assets/869f356e-fc2a-437e-8ec8-c4b6a7f9d30d


## Ce que fait la PR

- Ajoute un lien « se désinscrire en un clic » dans le footer des emails d’instruction, à côté du lien « gérer toutes mes préférences ».
- Le lien porte un token chiffré, signé et expirant après 30 jours (`NotificationUnsubscribeToken`), qui encode l’utilisateur, la définition et le type de notification (`submit` / `messages`).
- Le `GET /desabonnement-notifications` affiche une page de confirmation sans rien modifier ; le `POST` désactive effectivement la préférence.
- Envoi individuel : un destinataire par email.

## Corrections apportées suite à la review

- **Fuite du token vers Matomo** : le layout de désinscription rendait le layout global, donc Matomo envoyait l’URL complète — token compris — vers `stats.data.gouv.fr`. Matomo n’est plus chargé sur ce contrôleur.
- **Token dans les logs** : le token passe désormais par un champ caché du formulaire plutôt que par l’URL.
- **Désinscription idempotente** : si le rôle a déjà été retiré ou la préférence déjà désactivée, la page de confirmation s’affiche quand même (« vous ne receviez déjà plus ») au lieu de renvoyer une erreur.
- **Erreur 500 en impersonation** : sur un token invalide, l’`after_action` de suivi d’impersonation levait une `NoMethodError`. La trace n’est désormais enregistrée que lorsqu’un utilisateur a bien été décodé.
- **Retrait de la table d’audit** : la table `NotificationPreferenceChange` ne traçait que la désinscription via email_token (pas le toggle manuel) et ses colonnes étaient spéculatives. Retirée ; un audit complet est porté par DP-1801.

## Test manuel bout-en-bout

Scénario à dérouler en local avant de pousser sur GitHub.

Comptes seeds : `datapass@yopmail.com` (instructeur/admin), `user@yopmail.com` (demandeur). Bypass login : `/local-sign-in?email=…`. Emails en dev consultables sur `/letter_opener`. Vérifier `PORT` dans `.env.local` (défaut 3000).

### 0. Préparer

```sh
make up            # ou bin/local_run.sh
make db-migrate    # ou bin/rails db:migrate
```

### 1. Générer un vrai email avec le lien

**Voie A — email « messages » (le plus simple)**

- Se connecter en demandeur : `http://localhost:PORT/local-sign-in?email=user@yopmail.com`
- Ouvrir une demande existante (ou en créer une) et poster un message.
- Déclenche `MessageMailer#to_instructors` → un mail par instructeur.

**Voie B — email « submit »**

- En demandeur, soumettre une demande d’habilitation → déclenche `submit` aux instructeurs/reporters.

### 2. Inspecter l’email

- Aller sur `http://localhost:PORT/letter_opener`
- Ouvrir le dernier mail d’instruction, vérifier le footer :
  - lien 1 clic : `…/desabonnement-notifications?token=…`
  - lien « gérer toutes mes préférences » vers `/compte#notifications-section` (les deux coexistent)
  - un seul destinataire dans le `To:` (envoi individuel)

### 3. Tester le GET (ne doit RIEN changer)

- Copier l’URL du lien 1 clic, l’ouvrir dans le navigateur.
- Page « Désinscription des notifications » avec bouton « Confirmer ».
- Vérifier qu’aucune préférence n’a changé :

```ruby
bin/rails console
u = User.find_by(email: 'datapass@yopmail.com')   # destinataire du mail
u.instruction_messages_notifications_for_api_entreprise   # => true
```

### 4. Tester le POST (désinscription effective)

- Cliquer « Confirmer la désinscription ».
- Page « Préférence enregistrée » + « Vous ne recevrez plus ces notifications. »
- Vérifier en console :

```ruby
u.reload.instruction_messages_notifications_for_api_entreprise   # => false
```

### 5. Cas limites

| Cas | Comment | Attendu |
| --- | --- | --- |
| Idempotence | Re-cliquer « Confirmer » sur la même URL | Page succès (pas d’erreur) |
| Token bidon | Visiter `…/desabonnement-notifications?token=nimportequoi` | Page « Lien invalide ou expiré » |
| Rôle révoqué | Console : `u.update!(roles: [])` puis re-visiter l’URL | Page « Préférence enregistrée » (vous ne receviez déjà plus) |
| Réactivation | `/compte#notifications-section`, réactiver le toggle | Préf repasse à `true` |

### Raccourci — générer un token sans envoyer d’email

```ruby
bin/rails console
u = User.find_by(email: 'datapass@yopmail.com')
include Rails.application.routes.url_helpers
notification_unsubscriptions_url(
  token: NotificationUnsubscribeToken.generate(user: u, definition_id: 'api_entreprise', kind: 'messages'),
  host: 'localhost:3000',
)
```

Copier l’URL retournée dans le navigateur.
