### PR TITLE
fix(cucumber): éliminer deux scénarios flaky (race nav + ouverture modale)

### DIFF
--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -19,6 +19,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
     * je remplis "Première date de transmission" avec "2026-09-01"
     * je clique sur "Suivant"
+    * la page contient "Contact technique"
 
     * je clique sur "Précédent"
     * le bouton de suppression de la commune "75056" est annoncé par son code aux lecteurs d’écran

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -36,12 +36,17 @@ rescue Capybara::ElementNotFound
 end
 
 Quand('je clique sur {string} et confirme dans la modale') do |label|
-  click_link_or_button label
-  within('turbo-frame#main-modal-content', wait: 5) do
-    find(:link_or_button, label, wait: 5)
+  modal_content = 'turbo-frame#main-modal-content'
+  3.times do
+    break if has_css?(modal_content, visible: true, wait: false)
+
+    find('a[aria-controls="main-modal"]', text: label).click
+    break if has_css?(modal_content, visible: true, wait: 2)
+  end
+  within(modal_content) do
     click_link_or_button label
   end
-  expect(page).to have_no_css('turbo-frame#main-modal-content', wait: 5)
+  expect(page).to have_no_css(modal_content, wait: 5)
 end
 
 Alors('la page contient {string}') do |content|


### PR DESCRIPTION
## Contexte

Deux scénarios `@javascript` échouaient par intermittence sur `develop` (verts en PR, rouges après merge — flakiness confirmée, reproduite localement). Ce sont des **races**, pas des tests lents : augmenter un `wait:` ne ferait qu'élargir le pari. Chaque correctif synchronise sur le bon signal déterministe.

## Correctifs

**1. `boursiers_test_cnous_data_extraction_criteria_block.feature` (~3/4 d'échecs en local)**
La step générique `je clique sur "…"` fait `trigger('click')` et rend la main **avant** que la navigation Turbo n'aboutisse. Le `Suivant` suivi immédiatement de `Précédent` partait en course : `Précédent` cliquait le bouton retour de l'étape *communes* (encore affichée) → atterrissage sur `basic_infos`, l'assertion aria tournait sur la mauvaise page. Ajout d'un point de synchro déterministe (`la page contient "Contact technique"`) entre les deux → happens-before.

**2. step `… et confirme dans la modale` (`web_steps.rb`) (~12 % d'échecs en local)**
Le clic sur le bouton d'ouverture de modale DSFR+Turbo est **parfois perdu** : ni le `<dialog>` ne s'ouvre, ni le `turbo-frame#main-modal-content` ne se charge, alors que l'élément est entièrement prêt (`dsfr` chargé, `data-fr-js-modal-button` présent, `document.readyState === 'complete'`). Diagnostic : un `trigger('click')` synthétique ne l'ouvre **jamais** (DSFR/Turbo exigent un clic « trusted »), donc ce n'est pas un raté de coordonnées ; un vrai clic perdu ne se rattrape pas en attendant. La step **re-clique** jusqu'à ce que la modale soit réellement visible.

Retry **sans nouvelle race** :
- opener ciblé par `a[aria-controls="main-modal"]` → un re-clic ne peut jamais toucher le bouton de confirmation homonyme (pas de `Capybara::Ambiguous`) ;
- garde en tête de boucle → on ne re-clique jamais une modale déjà ouverte (pas de fermeture par toggle).

Aucune modification d'`app/` — uniquement de la synchronisation côté tests. Aucun `wait:` arbitraire ajouté.

## Test plan

- `boursiers …feature:6` : **20/20** verts (avant : ~3/4 rouges)
- `gestion_des_documents.feature:75` : **30/30** verts (avant : 3/24 rouges)
- Non-régression : boursiers (53 steps), `admin/data_providers` (Supprimer, modale — 5/5), `gestion_des_documents` (98 steps) — verts. Les 2 utilisateurs de la step modale sont couverts.
- `rubocop features/step_definitions/web_steps.rb` : 0 offense.

## Approches écartées (recherche)

- `trigger('click')` synthétique sur l'opener : **0/30** (DSFR/Turbo ignorent le clic non-trusted).
- `page.document.synchronize` : même risque d'ambiguïté (`Capybara::Ambiguous` ⊂ `ElementNotFound`).
- `capybara-lockstep` : attend l'idle JS/AJAX, mais la page était déjà idle au moment du clic et le gem ne couvre pas `setTimeout`/animations → coût (dépendance + middleware) sans bénéfice probable ici.

## Hors périmètre

Backstop `cucumber --retry 1` dans la CI → PR séparée #1609.