### PR TITLE
ci: retry integration scenarios once to absorb browser flakiness

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -185,7 +185,7 @@ jobs:
             -v ${{ github.workspace }}:/app \
             --rm data_pass bundle exec parallel_cucumber \
             -n 6 --only-group ${{ matrix.group }} \
-            -o '--format progress' features/
+            -o '--format progress --retry 1' features/
       - name: Stop Chrome
         if: always()
         run: docker stop chrome || true


### PR DESCRIPTION
## Contexte

Suivi de #1608 (qui corrige deux flakies à la source). Ce PR ajoute un **filet de sécurité** pour la longue traîne de flakiness navigateur non encore identifiée : `--retry 1` sur le job d'intégration cucumber.

Un clic perdu / une race navigateur ponctuelle ne devrait pas faire rougir `develop` (verts en PR, rouges après merge). `--retry 1` ré-exécute **uniquement les scénarios échoués**, une fois.

## Anti-masquage

Conforme à la position de l'équipe (DP-1714 : retry opt-in en local pour ne pas masquer les flakies). Ici en CI uniquement, et **cucumber signale** tout scénario qui ne passe qu'au retry comme « flaky » dans le résumé (`N scenarios (M flaky)`). La CI reste verte mais le flake reste **visible** dans les logs — pas de masquage silencieux. Un test réellement cassé échoue aux deux tentatives → toujours rouge.

## Validation locale

Sur un scénario réellement flaky (`gestion_des_documents.feature:75`, ~12 % d'échec au 1er essai), `--retry 1` ×15 :
- 11 verts propres
- 4 « flaky-but-green » : 1er essai échoué, retry passé → `1 scenario (1 flaky)`, exit 0
- 0 échec dur

## Changement

Une ligne, job `integration-tests` uniquement (le job `unit-tests` est du RSpec, non touché) :
`-o '--format progress'` → `-o '--format progress --retry 1'` dans `.github/workflows/test.yaml`.