### PR TITLE
DP-1765 — Fix recherche utilisateurs + améliorations UX gestion des droits

### DIFF
--- a/app/components/molecules/instruction/user_rights/readonly_rights_list_component.html.erb
+++ b/app/components/molecules/instruction/user_rights/readonly_rights_list_component.html.erb
@@ -1,14 +1,14 @@
-<div class="fr-panel--soft fr-mb-3w fr-p-3w" id="readonly-rights">
-  <h3 class="fr-h6 fr-mb-1w"><%= t('instruction.user_rights.edit.readonly_section') %></h3>
-  <p class="fr-hint-text fr-mb-2w"><%= t('instruction.user_rights.edit.readonly_hint') %></p>
-  <ul role="list" class="fr-list--flat-flex">
-    <% rights.each do |right| %>
-      <li>
-        <% if right[:scope].present? %>
-          <strong><%= Instruction::Scope.new(right[:scope]).label %></strong>
-        <% end %>
-        <%= render Atoms::ColorBadgeComponent.for_role(right[:role_type], label: t("instruction.user_rights.roles.#{right[:role_type]}")) %>
-      </li>
+<div class="fr-mb-3w" id="readonly-rights">
+  <h3 class="fr-h6 fr-mb-2w"><%= t('instruction.user_rights.edit.readonly_section') %></h3>
+  <% grouped_rights.each do |role_type, role_type_rights| %>
+    <% labels = scope_labels(role_type_rights) %>
+    <%= helpers.dsfr_alert type: :info,
+                           title: alert_message(role_type),
+                           header_level: 4,
+                           html_attributes: { class: 'fr-mb-2w' } do %>
+      <% if labels.any? %>
+        <p class="fr-mb-0"><%= t('instruction.user_rights.edit.readonly_scopes', scopes: labels.to_sentence) %></p>
+      <% end %>
     <% end %>
-  </ul>
+  <% end %>
 </div>

--- a/app/components/molecules/instruction/user_rights/readonly_rights_list_component.rb
+++ b/app/components/molecules/instruction/user_rights/readonly_rights_list_component.rb
@@ -10,4 +10,21 @@ class Molecules::Instruction::UserRights::ReadonlyRightsListComponent < Applicat
   private
 
   attr_reader :rights
+
+  def grouped_rights
+    rights.group_by { |right| right[:role_type] }
+  end
+
+  def alert_message(role_type)
+    t(
+      "instruction.user_rights.edit.readonly_alerts.#{role_type}",
+      default: t('instruction.user_rights.edit.readonly_alerts.default')
+    )
+  end
+
+  def scope_labels(role_type_rights)
+    role_type_rights.filter_map do |right|
+      Instruction::Scope.new(right[:scope]).label if right[:scope].present?
+    end
+  end
 end

--- a/app/components/molecules/instruction/user_rights/table_row_component.html.erb
+++ b/app/components/molecules/instruction/user_rights/table_row_component.html.erb
@@ -17,16 +17,18 @@
     </ul>
   </td>
   <td>
-    <div class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm">
-      <%= link_to helpers.edit_user_right_path(user),
-            class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-edit-line',
-            aria: { label: t('instruction.user_rights.index.table.edit_aria', email: user.email) } do %>
-        <span class="fr-sr-only"><%= t('instruction.user_rights.index.table.edit_aria', email: user.email) %></span>
-      <% end %>
-      <%= dsfr_main_modal_button '',
-            helpers.confirm_destroy_user_right_path(user),
-            class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-delete-line',
-            'aria-label': t('instruction.user_rights.index.table.destroy_aria', email: user.email) %>
-    </div>
+    <% if editable? %>
+      <div class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm">
+        <%= link_to helpers.edit_user_right_path(user),
+              class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-edit-line',
+              aria: { label: t('instruction.user_rights.index.table.edit_aria', email: user.email) } do %>
+          <span class="fr-sr-only"><%= t('instruction.user_rights.index.table.edit_aria', email: user.email) %></span>
+        <% end %>
+        <%= dsfr_main_modal_button '',
+              helpers.confirm_destroy_user_right_path(user),
+              class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-delete-line',
+              'aria-label': t('instruction.user_rights.index.table.destroy_aria', email: user.email) %>
+      </div>
+    <% end %>
   </td>
 </tr>

--- a/app/components/molecules/instruction/user_rights/table_row_component.rb
+++ b/app/components/molecules/instruction/user_rights/table_row_component.rb
@@ -1,14 +1,23 @@
 class Molecules::Instruction::UserRights::TableRowComponent < ApplicationComponent
-  def initialize(user:, authority:)
+  def initialize(user:, authority:, current_user:)
     @user = user
     @authority = authority
+    @current_user = current_user
   end
 
   private
 
-  attr_reader :user, :authority
+  attr_reader :user, :authority, :current_user
 
   def visible_rights
     Instruction::UserRightsView.new(authority: authority, user: user).grouped_visible
+  end
+
+  def own_row?
+    user.id == current_user.id
+  end
+
+  def editable?
+    !own_row? || authority.can_self_edit?
   end
 end

--- a/app/components/organisms/instruction/user_rights/table_component.html.erb
+++ b/app/components/organisms/instruction/user_rights/table_component.html.erb
@@ -3,7 +3,7 @@
     <div class="fr-table__content">
       <table class="fr-table--align-middle" id="user-rights-table">
         <caption class="fr-sr-only">
-          <%= t('instruction.user_rights.index.title') %> — <%= t('instruction.user_rights.index.users_count', count: users.size) %>
+          <%= t('instruction.user_rights.index.title') %> — <%= t('instruction.user_rights.index.users_count', count: total_count) %>
         </caption>
         <thead>
           <tr>
@@ -14,7 +14,7 @@
         </thead>
         <tbody>
           <% users.each do |user| %>
-            <%= render Molecules::Instruction::UserRights::TableRowComponent.new(user: user, authority: authority) %>
+            <%= render Molecules::Instruction::UserRights::TableRowComponent.new(user: user, authority: authority, current_user: current_user) %>
           <% end %>
         </tbody>
       </table>

--- a/app/components/organisms/instruction/user_rights/table_component.rb
+++ b/app/components/organisms/instruction/user_rights/table_component.rb
@@ -1,12 +1,14 @@
 class Organisms::Instruction::UserRights::TableComponent < ApplicationComponent
   HEADERS = %w[email family_name given_name rights actions].freeze
 
-  def initialize(users:, authority:)
+  def initialize(users:, authority:, current_user:, total_count:)
     @users = users
     @authority = authority
+    @current_user = current_user
+    @total_count = total_count
   end
 
   private
 
-  attr_reader :users, :authority
+  attr_reader :users, :authority, :current_user, :total_count
 end

--- a/app/controllers/admin/user_rights_controller.rb
+++ b/app/controllers/admin/user_rights_controller.rb
@@ -4,9 +4,10 @@ class Admin::UserRightsController < AdminController
   before_action :set_target_user, only: %i[edit update destroy confirm_destroy]
 
   def index
-    @search_term = params.dig(:search_query, :email_or_given_name_or_family_name_cont)
-    @search_engine = managed_users_scope.ransack(params[:search_query])
-    @users = @search_engine.result.order(:email).page(params[:page]).per(50)
+    search = Instruction::UserRightsSearch.new(scope: managed_users_scope, params:)
+    @search_engine = search.engine
+    @search_term = search.term
+    @users = search.results.page(params[:page]).per(50)
     render template: 'instruction/user_rights/index'
   end
 

--- a/app/controllers/instruction/user_rights_controller.rb
+++ b/app/controllers/instruction/user_rights_controller.rb
@@ -4,9 +4,10 @@ class Instruction::UserRightsController < InstructionController
   before_action :set_target_user, only: %i[edit update destroy confirm_destroy]
 
   def index
-    @search_term = params.dig(:search_query, :email_or_given_name_or_family_name_cont)
-    @search_engine = managed_users_scope.ransack(params[:search_query])
-    @users = @search_engine.result.order(:email).page(params[:page]).per(50)
+    search = Instruction::UserRightsSearch.new(scope: managed_users_scope, params:)
+    @search_engine = search.engine
+    @search_term = search.term
+    @users = search.results.page(params[:page]).per(50)
   end
 
   def new
@@ -60,7 +61,6 @@ class Instruction::UserRightsController < InstructionController
 
   def managed_users_scope
     User.with_any_role_on(@authority.managed_definitions.map(&:id))
-      .where.not(id: current_user.id)
   end
 
   def authorize_user_rights!

--- a/app/helpers/user_rights_helper.rb
+++ b/app/helpers/user_rights_helper.rb
@@ -1,0 +1,11 @@
+module UserRightsHelper
+  def user_rights_search_status_message(users, search_term)
+    return t('instruction.user_rights.index.users_count', count: users.total_count) unless users.empty?
+
+    if search_term.present?
+      t('instruction.user_rights.index.no_results')
+    else
+      t('instruction.user_rights.index.empty_state')
+    end
+  end
+end

--- a/app/javascript/controllers/search_status_controller.js
+++ b/app/javascript/controllers/search_status_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['liveRegion', 'message', 'frame']
+
+  connect () {
+    this.boundAnnounce = this.announce.bind(this)
+    this.frameTarget.addEventListener('turbo:frame-load', this.boundAnnounce)
+  }
+
+  disconnect () {
+    this.frameTarget.removeEventListener('turbo:frame-load', this.boundAnnounce)
+  }
+
+  announce () {
+    if (!this.hasMessageTarget || !this.hasLiveRegionTarget) {
+      return
+    }
+
+    const message = this.messageTarget.textContent.trim()
+
+    if (message === this.liveRegionTarget.textContent.trim()) {
+      return
+    }
+
+    this.liveRegionTarget.textContent = message
+  }
+}

--- a/app/models/instruction/user_rights_search.rb
+++ b/app/models/instruction/user_rights_search.rb
@@ -1,0 +1,37 @@
+class Instruction::UserRightsSearch
+  SEARCH_ATTRIBUTE = :email_or_given_name_or_family_name_cont
+
+  def initialize(scope:, params:)
+    @scope = scope
+    @params = params
+  end
+
+  def term
+    return @term if defined?(@term)
+
+    raw = raw_term
+    @term = raw.strip.presence if raw.is_a?(String)
+  end
+
+  def engine
+    @engine ||= scope.ransack(ransack_params)
+  end
+
+  def results
+    engine.result.order(:email)
+  end
+
+  private
+
+  attr_reader :scope, :params
+
+  def raw_term
+    params.dig(:search_query, SEARCH_ATTRIBUTE)
+  end
+
+  def ransack_params
+    return {} if term.blank?
+
+    { SEARCH_ATTRIBUTE => term }
+  end
+end

--- a/app/models/rights/admin_authority.rb
+++ b/app/models/rights/admin_authority.rb
@@ -24,6 +24,10 @@ class Rights::AdminAuthority < Rights::Authority
     !ParsedRole.parse(role_string).role.nil?
   end
 
+  def can_self_edit?
+    true
+  end
+
   def audit_event_name
     'user_rights_changed_by_admin'
   end

--- a/app/models/rights/authority.rb
+++ b/app/models/rights/authority.rb
@@ -17,6 +17,10 @@ class Rights::Authority
     raise NotImplementedError
   end
 
+  def can_self_edit?
+    raise NotImplementedError
+  end
+
   def authorized_scopes
     @authorized_scopes ||= definition_scopes + fd_scopes
   end

--- a/app/models/rights/manager_authority.rb
+++ b/app/models/rights/manager_authority.rb
@@ -26,6 +26,10 @@ class Rights::ManagerAuthority < Rights::Authority
     user.manages_role?(role_string)
   end
 
+  def can_self_edit?
+    false
+  end
+
   def audit_event_name
     'user_rights_changed_by_manager'
   end

--- a/app/views/instruction/user_rights/index.html.erb
+++ b/app/views/instruction/user_rights/index.html.erb
@@ -13,48 +13,56 @@
     </div>
   </div>
 
-  <turbo-frame id="user_rights_table">
-    <div class="fr-grid-row fr-mb-3w">
-      <div class="fr-col-12 fr-col-md-6">
-        <%= search_form_for @search_engine,
-                            url: instruction_user_rights_path,
-                            html: {
-                              method: :get,
-                              data: {
-                                controller: 'auto-submit-form',
-                                'auto-submit-form-debounce-interval-value' => 500,
-                                'auto-submit-form-event-mode-value' => 'input'
-                              }
-                            } do |f| %>
-          <div class="fr-search-bar" role="search">
-            <%= f.label :email_or_given_name_or_family_name_cont,
-                        t('instruction.user_rights.index.search.label'),
-                        class: 'fr-label fr-sr-only' %>
-            <%= f.search_field :email_or_given_name_or_family_name_cont,
-                               class: 'fr-input',
-                               placeholder: t('instruction.user_rights.index.search.placeholder') %>
-            <button type="submit" class="fr-btn" title="<%= t('instruction.user_rights.index.search.submit') %>">
-              <%= t('instruction.user_rights.index.search.submit') %>
-            </button>
-          </div>
-        <% end %>
-      </div>
-    </div>
+  <% search_status_message = user_rights_search_status_message(@users, @search_term) %>
+  <div data-controller="search-status">
+    <p role="status" aria-atomic="true" class="fr-sr-only" data-search-status-target="liveRegion"><%= search_status_message %></p>
 
-    <% if @users.empty? %>
-      <div class="fr-py-6w fr-text--center" id="user-rights-empty-state">
-        <% if @search_term.present? %>
-          <p class="fr-text--lg fr-mb-0"><%= t('instruction.user_rights.index.no_results') %></p>
-        <% else %>
-          <p class="fr-text--lg fr-mb-4w"><%= t('instruction.user_rights.index.empty_state') %></p>
-          <%= link_to t('instruction.user_rights.index.add_cta'),
-            new_user_right_path,
-            class: 'fr-btn fr-btn--icon-left fr-icon-user-add-line' %>
-        <% end %>
+    <turbo-frame id="user_rights_table" data-search-status-target="frame">
+      <span hidden data-search-status-target="message"><%= search_status_message %></span>
+
+      <div class="fr-grid-row fr-mb-3w">
+        <div class="fr-col-12 fr-col-md-6">
+          <%= search_form_for @search_engine,
+                              url: user_rights_index_path,
+                              html: {
+                                method: :get,
+                                data: {
+                                  controller: 'auto-submit-form',
+                                  'auto-submit-form-debounce-interval-value' => 800,
+                                  'auto-submit-form-event-mode-value' => 'input'
+                                }
+                              } do |f| %>
+            <div class="fr-search-bar" role="search">
+              <%= f.label :email_or_given_name_or_family_name_cont,
+                          t('instruction.user_rights.index.search.label'),
+                          class: 'fr-label fr-sr-only' %>
+              <%= f.search_field :email_or_given_name_or_family_name_cont,
+                                 class: 'fr-input',
+                                 autofocus: true,
+                                 placeholder: t('instruction.user_rights.index.search.placeholder') %>
+              <button type="submit" class="fr-btn" title="<%= t('instruction.user_rights.index.search.submit') %>">
+                <%= t('instruction.user_rights.index.search.submit') %>
+              </button>
+            </div>
+          <% end %>
+        </div>
       </div>
-    <% else %>
-      <%= render Organisms::Instruction::UserRights::TableComponent.new(users: @users, authority: @authority) %>
-      <%= paginate @users %>
-    <% end %>
-  </turbo-frame>
+
+      <% if @users.empty? %>
+        <div class="fr-py-6w fr-text--center" id="user-rights-empty-state">
+          <% if @search_term.present? %>
+            <p class="fr-text--lg fr-mb-0"><%= t('instruction.user_rights.index.no_results') %></p>
+          <% else %>
+            <p class="fr-text--lg fr-mb-4w"><%= t('instruction.user_rights.index.empty_state') %></p>
+            <%= link_to t('instruction.user_rights.index.add_cta'),
+              new_user_right_path,
+              class: 'fr-btn fr-btn--icon-left fr-icon-user-add-line' %>
+          <% end %>
+        </div>
+      <% else %>
+        <%= render Organisms::Instruction::UserRights::TableComponent.new(users: @users, authority: @authority, current_user: current_user, total_count: @users.total_count) %>
+        <%= paginate @users %>
+      <% end %>
+    </turbo-frame>
+  </div>
 </div>

--- a/config/locales/instruction.fr.yml
+++ b/config/locales/instruction.fr.yml
@@ -591,7 +591,11 @@ fr:
         breadcrumb: Modifier un utilisateur
         submit: Valider les modifications
         readonly_section: Droits non modifiables depuis cette interface
-        readonly_hint: Les droits ci-dessous sont conservés tels quels car ils ne sont pas gérés par les managers.
+        readonly_alerts:
+          default: Ce droit n’est pas modifiable depuis cette interface.
+          admin: Contactez un tech de l’équipe pour modifier un droit admin.
+          developer: Contactez l’équipe DataPass pour modifier le droit développeur.
+        readonly_scopes: "Concerné : %{scopes}"
         destroy_cta: Supprimer tous les droits
       update:
         success: Les droits de %{email} ont été mis à jour

--- a/features/admin/gestion_des_droits/je_modifie_des_droits.feature
+++ b/features/admin/gestion_des_droits/je_modifie_des_droits.feature
@@ -44,7 +44,7 @@ Fonctionnalité: Admin — Gestion des droits — modifier les droits d’un uti
     Et que je me rends sur la page de gestion des droits
     Et que je clique sur "Modifier les droits de admin@gouv.fr"
     Alors le fil d’Ariane contient un lien "Gestion des droits" vers la page de gestion des droits admin
-    Et la section des droits non modifiables contient le badge "Admin"
+    Et la section des droits non modifiables indique "Contactez un tech de l’équipe pour modifier un droit admin."
     Quand je sélectionne "Instructeur" pour "Rôle"
     Et que je clique sur "Valider les modifications"
     Alors il y a un message de succès contenant "mis à jour"

--- a/features/admin/gestion_des_droits/liste_des_droits.feature
+++ b/features/admin/gestion_des_droits/liste_des_droits.feature
@@ -27,6 +27,28 @@ Fonctionnalité: Admin — Gestion des droits — lister les utilisateurs avec d
     Et le tableau des utilisateurs contient le badge "Admin"
     Et le tableau des utilisateurs contient le badge "Observateur"
 
+  Scénario: Je peux filtrer la liste avec une recherche
+    Quand il y a l'utilisateur "alice@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
+    Et qu'il y a l'utilisateur "bob@gouv.fr" avec le rôle "Instructeur" pour "API Particulier"
+    Et que je me rends sur la page de gestion des droits
+    Et que je remplis "Rechercher un utilisateur" avec "alice"
+    Et que je clique sur "Rechercher"
+    Alors la page contient "alice@gouv.fr"
+    Et la page ne contient pas "bob@gouv.fr"
+
+  Scénario: Une recherche vide affiche tous les utilisateurs
+    Quand il y a l'utilisateur "user1@gouv.fr" avec le rôle "Instructeur" pour "API Entreprise"
+    Et qu'il y a l'utilisateur "user2@gouv.fr" avec le rôle "Rapporteur" pour "API Particulier"
+    Et que je me rends sur la page de gestion des droits
+    Et que je remplis "Rechercher un utilisateur" avec ""
+    Et que je clique sur "Rechercher"
+    Alors la page contient "user1@gouv.fr"
+    Et la page contient "user2@gouv.fr"
+
+  Scénario: Je peux éditer mes propres droits depuis ma ligne
+    Quand je me rends sur la page de gestion des droits
+    Alors ma ligne affiche un bouton de modification
+
   Scénario: Le menu admin contient un lien vers la gestion des droits
     Quand je me rends sur le chemin "/admin"
     Alors la page contient "Gestion des droits"

--- a/features/instructeurs/gestion_des_droits/je_modifie_des_droits.feature
+++ b/features/instructeurs/gestion_des_droits/je_modifie_des_droits.feature
@@ -51,7 +51,7 @@ Fonctionnalité: Instruction — Gestion des droits — modifier les droits d’
     Et que je me rends sur la page de gestion des droits
     Et que je clique sur "Modifier les droits de dev@gouv.fr"
     Alors la page contient "Droits non modifiables depuis cette interface"
-    Et la page contient "Développeur"
+    Et la section des droits non modifiables indique "Contactez l’équipe DataPass pour modifier le droit développeur."
     Quand je sélectionne "Instructeur" pour "Rôle"
     Et que je clique sur "Valider les modifications"
     Alors il y a un message de succès contenant "mis à jour"

--- a/features/instructeurs/gestion_des_droits/je_supprime_tous_les_droits.feature
+++ b/features/instructeurs/gestion_des_droits/je_supprime_tous_les_droits.feature
@@ -16,7 +16,8 @@ Fonctionnalité: Instruction — Gestion des droits — supprimer tous les droit
     Alors la page contient "Supprimer tous les droits de eva@gouv.fr ?"
     Quand je clique sur "Supprimer tous les droits de l’utilisateur"
     Alors il y a un message de succès contenant "ont été supprimés"
-    Et la page contient "Aucun utilisateur ne possède de droits pour l’instant"
+    Et le tableau des utilisateurs ne contient pas "eva@gouv.fr"
+    Et le tableau des utilisateurs contient mon email
 
   Scénario: Les rôles hors de mon périmètre sont préservés lors d’une suppression
     Quand il y a l'utilisateur "mixte@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"

--- a/features/instructeurs/gestion_des_droits/liste_des_droits.feature
+++ b/features/instructeurs/gestion_des_droits/liste_des_droits.feature
@@ -15,14 +15,19 @@ Fonctionnalité: Instruction — Gestion des droits — lister les utilisateurs 
     Alors la page contient "user1@gouv.fr"
     Et la page ne contient pas "user2@gouv.fr"
 
-  Scénario: Empty state lorsque personne n'a de droits
+  Scénario: Lorsque personne d’autre n’a de droits, je ne vois que ma propre ligne
     Quand je me rends sur la page de gestion des droits
-    Alors la page contient "Aucun utilisateur ne possède de droits pour l’instant"
+    Alors le tableau des utilisateurs contient mon email
     Et la page contient "Ajouter des droits à un utilisateur sans droits"
 
-  Scénario: Je ne me vois pas dans ma propre liste
+  Scénario: Je me vois dans ma propre liste, sans bouton d’édition
     Quand je me rends sur la page de gestion des droits
-    Alors la page ne contient pas mon email
+    Alors le tableau des utilisateurs contient mon email
+    Et ma ligne n’affiche aucun bouton de modification ni de suppression
+
+  Scénario: Le champ de recherche est prêt à la saisie et auto-soumis
+    Quand je me rends sur la page de gestion des droits
+    Alors le champ de recherche porte les attributs de focus et d’auto-soumission
 
   Scénario: Un reporter n'a pas accès à la gestion des droits
     Étant donné que je suis un rapporteur "API Entreprise"
@@ -37,6 +42,7 @@ Fonctionnalité: Instruction — Gestion des droits — lister les utilisateurs 
     Et que je clique sur "Rechercher"
     Alors la page contient "alice@gouv.fr"
     Et la page ne contient pas "bob@gouv.fr"
+    Et la zone de statut de recherche annonce "1 utilisateur"
 
   Scénario: Empty state lorsque la recherche ne renvoie aucun résultat
     Quand il y a l'utilisateur "alice@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
@@ -44,4 +50,15 @@ Fonctionnalité: Instruction — Gestion des droits — lister les utilisateurs 
     Et que je remplis "Rechercher un utilisateur" avec "introuvable"
     Et que je clique sur "Rechercher"
     Alors la page contient "Aucun utilisateur ne correspond à votre recherche"
+    Et la zone de statut de recherche annonce "Aucun utilisateur ne correspond à votre recherche"
     Et la page ne contient pas "alice@gouv.fr"
+
+  Scénario: Une recherche vide affiche la liste scopée complète
+    Quand il y a l'utilisateur "alice@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
+    Et qu'il y a l'utilisateur "zoe@gouv.fr" avec le rôle "Instructeur" pour "API Particulier"
+    Et que je me rends sur la page de gestion des droits
+    Et que je remplis "Rechercher un utilisateur" avec ""
+    Et que je clique sur "Rechercher"
+    Alors la page contient "alice@gouv.fr"
+    Et la page ne contient pas "zoe@gouv.fr"
+    Et la page ne contient pas "Aucun utilisateur ne correspond à votre recherche"

--- a/features/step_definitions/user_rights_steps.rb
+++ b/features/step_definitions/user_rights_steps.rb
@@ -71,9 +71,9 @@ Alors('le tableau des utilisateurs contient le badge {string}') do |label|
   end
 end
 
-Alors('la section des droits non modifiables contient le badge {string}') do |label|
+Alors('la section des droits non modifiables indique {string}') do |message|
   within('#readonly-rights') do
-    expect(page).to have_css('p.fr-badge', text: label)
+    expect(page).to have_text(message)
   end
 end
 
@@ -125,4 +125,32 @@ end
 Alors("la page contient l'accordéon {string} replié par défaut") do |title|
   button = find('.fr-accordion__btn', text: title)
   expect(button['aria-expanded']).to eq('false')
+end
+
+Alors('le champ de recherche porte les attributs de focus et d’auto-soumission') do
+  expect(page).to have_css('input[type="search"][autofocus]')
+  expect(page).to have_css("form[data-auto-submit-form-debounce-interval-value='800']")
+end
+
+Alors('le tableau des utilisateurs contient mon email') do
+  within('#user-rights-table') do
+    expect(page).to have_text(current_user!.email)
+  end
+end
+
+Alors('la zone de statut de recherche annonce {string}') do |message|
+  expect(page).to have_css('[role="status"]', text: message)
+end
+
+Alors('ma ligne n’affiche aucun bouton de modification ni de suppression') do
+  within("##{ActionView::RecordIdentifier.dom_id(current_user!)}") do
+    expect(page).to have_no_css('.fr-icon-edit-line')
+    expect(page).to have_no_css('.fr-icon-delete-line')
+  end
+end
+
+Alors('ma ligne affiche un bouton de modification') do
+  within("##{ActionView::RecordIdentifier.dom_id(current_user!)}") do
+    expect(page).to have_css('.fr-icon-edit-line')
+  end
 end

--- a/spec/components/molecules/instruction/user_rights/readonly_rights_list_component_spec.rb
+++ b/spec/components/molecules/instruction/user_rights/readonly_rights_list_component_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Molecules::Instruction::UserRights::ReadonlyRightsListComponent, type: :component do
+  def render_component(rights)
+    render_inline(described_class.new(rights:))
+  end
+
+  it 'does not render when there is no readonly right' do
+    render_component([])
+
+    expect(page).to have_no_css('#readonly-rights')
+  end
+
+  it 'renders an info alert with the admin wording for an admin right' do
+    render_component([{ scope: nil, role_type: 'admin' }])
+
+    expect(page).to have_css('.fr-alert--info')
+    expect(page).to have_text('Contactez un tech de l’équipe pour modifier un droit admin.')
+  end
+
+  it 'renders the alert title as an h4 (nested under the h3 readonly section)' do
+    render_component([{ scope: nil, role_type: 'admin' }])
+
+    expect(page).to have_css('h4.fr-alert__title')
+  end
+
+  it 'renders an info alert with the developer wording and lists the concerned scopes' do
+    render_component([{ scope: 'dinum:api_entreprise', role_type: 'developer' }])
+
+    expect(page).to have_css('.fr-alert--info')
+    expect(page).to have_text('Contactez l’équipe DataPass pour modifier le droit développeur.')
+    expect(page).to have_text(Instruction::Scope.new('dinum:api_entreprise').label)
+  end
+
+  it 'groups several readonly rights of the same role into a single alert' do
+    render_component(
+      [
+        { scope: 'dinum:api_entreprise', role_type: 'developer' },
+        { scope: 'dinum:api_particulier', role_type: 'developer' }
+      ]
+    )
+
+    expect(page).to have_css('.fr-alert--info', count: 1)
+  end
+end

--- a/spec/components/molecules/instruction/user_rights/table_row_component_spec.rb
+++ b/spec/components/molecules/instruction/user_rights/table_row_component_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Molecules::Instruction::UserRights::TableRowComponent, type: :component do
+  let(:manager) { create(:user, :manager, authorization_request_types: %i[api_entreprise]) }
+  let(:other_user) { create(:user, email: 'other@gouv.fr', roles: ['dinum:api_entreprise:reporter']) }
+
+  def render_row(user:, authority:, current_user:)
+    render_inline(described_class.new(user:, authority:, current_user:))
+  end
+
+  context 'when the row belongs to another user' do
+    it 'renders the edit and delete actions' do
+      render_row(user: other_user, authority: Rights::ManagerAuthority.new(manager), current_user: manager)
+
+      expect(page).to have_css('.fr-icon-edit-line')
+      expect(page).to have_css('.fr-icon-delete-line')
+    end
+  end
+
+  context 'when the row belongs to the connected manager' do
+    it 'hides the edit and delete actions (a manager cannot self-edit)' do
+      render_row(user: manager, authority: Rights::ManagerAuthority.new(manager), current_user: manager)
+
+      expect(page).to have_no_css('.fr-icon-edit-line')
+      expect(page).to have_no_css('.fr-icon-delete-line')
+    end
+  end
+
+  context 'when the row belongs to the connected admin' do
+    let(:admin) { create(:user, roles: ['admin']) }
+
+    it 'keeps the edit action (self-edit allowed)' do
+      render_row(user: admin, authority: Rights::AdminAuthority.new(admin), current_user: admin)
+
+      expect(page).to have_css('.fr-icon-edit-line')
+    end
+  end
+end

--- a/spec/components/previews/organisms/instruction/user_rights/table_component_preview.rb
+++ b/spec/components/previews/organisms/instruction/user_rights/table_component_preview.rb
@@ -3,6 +3,24 @@ class Organisms::Instruction::UserRights::TableComponentPreview < ViewComponent:
     actor = User.find_by!(email: 'datapass@yopmail.com')
     users = User.with_roles.where.not(id: actor.id).limit(5)
 
-    render Organisms::Instruction::UserRights::TableComponent.new(users: users, authority: Rights::ManagerAuthority.new(actor))
+    render Organisms::Instruction::UserRights::TableComponent.new(
+      users: users,
+      authority: Rights::ManagerAuthority.new(actor),
+      current_user: actor,
+      total_count: users.size
+    )
+  end
+
+  def with_own_row_non_editable_as_manager
+    actor = User.find_by!(email: 'datapass@yopmail.com')
+    others = User.with_roles.where.not(id: actor.id).limit(4).to_a
+    users = [actor, *others]
+
+    render Organisms::Instruction::UserRights::TableComponent.new(
+      users: users,
+      authority: Rights::ManagerAuthority.new(actor),
+      current_user: actor,
+      total_count: users.size
+    )
   end
 end

--- a/spec/models/instruction/user_rights_search_spec.rb
+++ b/spec/models/instruction/user_rights_search_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Instruction::UserRightsSearch do
+  let(:alice) { create(:user, email: 'alice@gouv.fr', given_name: 'Alice', family_name: 'Martin') }
+  let(:bob) { create(:user, email: 'bob@gouv.fr', given_name: 'Bob', family_name: 'Durand') }
+  let(:outsider) { create(:user, email: 'outsider@gouv.fr') }
+  let(:scope) { User.where(id: [alice.id, bob.id]) }
+
+  def search(params)
+    described_class.new(scope: scope, params: ActionController::Parameters.new(params))
+  end
+
+  describe '#term' do
+    it 'strips surrounding whitespace' do
+      expect(search(search_query: { email_or_given_name_or_family_name_cont: '  alice  ' }).term).to eq('alice')
+    end
+
+    it 'is nil when the search query is absent' do
+      expect(search({}).term).to be_nil
+    end
+
+    it 'is nil when the search term is blank or whitespace-only' do
+      expect(search(search_query: { email_or_given_name_or_family_name_cont: '   ' }).term).to be_nil
+    end
+
+    it 'is nil when a crafted param sends an array instead of a string' do
+      expect(search(search_query: { email_or_given_name_or_family_name_cont: ['x'] }).term).to be_nil
+    end
+
+    it 'is nil when a crafted param sends a nested hash instead of a string' do
+      expect(search(search_query: { email_or_given_name_or_family_name_cont: { nested: 'x' } }).term).to be_nil
+    end
+  end
+
+  describe '#results' do
+    before { outsider }
+
+    it 'returns the whole scope when no search query is given' do
+      expect(search({}).results).to contain_exactly(alice, bob)
+    end
+
+    it 'returns the whole scope when the search term is blank' do
+      expect(search(search_query: { email_or_given_name_or_family_name_cont: '   ' }).results).to contain_exactly(alice, bob)
+    end
+
+    it 'never returns records outside the given scope on a blank search' do
+      expect(search({}).results).not_to include(outsider)
+    end
+
+    it 'returns the whole scope without raising when a crafted param sends an array' do
+      expect(search(search_query: { email_or_given_name_or_family_name_cont: ['x'] }).results).to contain_exactly(alice, bob)
+    end
+
+    it 'filters by email, given name or family name when a term is present' do
+      expect(search(search_query: { email_or_given_name_or_family_name_cont: 'alice' }).results).to contain_exactly(alice)
+    end
+
+    it 'orders results by email' do
+      expect(search({}).results.to_a).to eq([alice, bob])
+    end
+  end
+end

--- a/spec/models/rights/admin_authority_spec.rb
+++ b/spec/models/rights/admin_authority_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe Rights::AdminAuthority do
     end
   end
 
+  describe '#can_self_edit?' do
+    it 'returns true (an admin can edit their own rights)' do
+      expect(authority.can_self_edit?).to be true
+    end
+  end
+
   describe '#authorized_scopes' do
     it 'includes a fd-wildcard scope for every provider' do
       provider_slugs = AuthorizationDefinition.all.filter_map(&:provider_slug).uniq

--- a/spec/models/rights/manager_authority_spec.rb
+++ b/spec/models/rights/manager_authority_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe Rights::ManagerAuthority do
     end
   end
 
+  describe '#can_self_edit?' do
+    let(:user) { create(:user, roles: ['dinum:api_entreprise:manager']) }
+
+    it 'returns false (a manager cannot edit their own rights)' do
+      expect(authority.can_self_edit?).to be false
+    end
+  end
+
   describe '#authorized_scopes' do
     context 'when the user is FD-manager and definition-manager' do
       let(:user) { create(:user, roles: ['dinum:*:manager', 'dgfip:api_ficoba:manager']) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe User do
 
       it { is_expected.to be_empty }
     end
+
+    context 'when a user holds an FD-wildcard role for the provider' do
+      let(:definition_ids) { ['api_entreprise'] }
+      let!(:fd_wildcard_manager) { create(:user, roles: ['dinum:*:manager']) }
+
+      it 'includes the FD-wildcard role holder, so an FD-manager sees their own row' do
+        expect(subject).to include(fd_wildcard_manager)
+      end
+    end
   end
 
   describe '#managed_fd_slugs' do


### PR DESCRIPTION
## Summary

Quatre correctifs post-livraison sur l'écran partagé `/(admin|instruction)/gestion-des-droits` (suite de DP-1684 / DP-1691 / DP-1692, et complémentaire de DP-1720 déjà mergé).

- **Recherche vide = liste scopée normale.** Query object `Instruction::UserRightsSearch` : un terme vide / whitespace / forgé non-scalaire est traité comme « pas de recherche » → liste complète **dans le périmètre de l'autorité** (jamais de fuite hors périmètre, plus de 500 sur paramètre forgé). Déduplique le `#index` admin/instruction. Corrige aussi le formulaire de recherche qui pointait en dur vers `instruction_user_rights_path` (cassait la recherche côté admin) → `user_rights_index_path` polymorphe.
- **UX auto-submit.** Debounce `500 → 800 ms` + `autofocus` sur le champ de recherche.
- **Le manager se voit, en non-éditable.** `Authority#can_self_edit?` (admin `true`, manager `false`) ; le manager apparaît dans sa propre liste sans bouton d'édition/suppression, l'admin garde l'auto-édition (DP-1720). La policy bloque toujours le self-edit manager par URL (défense en profondeur).
- **Droits non modifiables = alertes info ciblées.** Une alerte info DSFR par type de droit : admin → « Contactez un tech de l'équipe pour modifier un droit admin », développeur → « Contactez l'équipe DataPass pour modifier le droit développeur ».

## Test plan

- [x] `rspec` périmètre touché (query object incl. params forgés, autorités `can_self_edit?`, `User.with_any_role_on` manager FD-wildcard, composants `TableRow` / `ReadonlyRightsList`, forms/organizers/policies) — 180 ex, 0 échec
- [x] `cucumber features/instructeurs/gestion_des_droits features/admin/gestion_des_droits` — 46 scénarios, 0 échec
- [x] `rubocop` (0 offense), `brakeman` (0 warning), `i18n-tasks` (aucune clé orpheline)

Closes DP-1765 — https://linear.app/pole-api/issue/DP-1765
