### PR TITLE
Autonomiser les FD à gérer leurs clefs API (API Datapass en lecture)

### DIFF
--- a/app/assets/stylesheets/components/copiable_field.css
+++ b/app/assets/stylesheets/components/copiable_field.css
@@ -1,0 +1,5 @@
+.copiable-field__input {
+  font-family: monospace;
+  font-size: 0.875rem;
+  width: auto;
+}

--- a/app/controllers/developers/oauth_applications_controller.rb
+++ b/app/controllers/developers/oauth_applications_controller.rb
@@ -1,5 +1,48 @@
 class Developers::OauthApplicationsController < DevelopersController
+  before_action :set_application, only: :destroy
+
   def index
-    @applications = Doorkeeper::Application.where(owner: current_user)
+    authorize Doorkeeper::Application, policy_class: Developer::OauthApplicationPolicy
+    @applications = policy_scope(Doorkeeper::Application, policy_scope_class: Developer::OauthApplicationPolicy::Scope)
+  end
+
+  def new
+    authorize Doorkeeper::Application, :create?, policy_class: Developer::OauthApplicationPolicy
+    @application = Doorkeeper::Application.new
+  end
+
+  def create
+    authorize Doorkeeper::Application, :create?, policy_class: Developer::OauthApplicationPolicy
+    @application = Doorkeeper::Application.new(
+      application_params.merge(owner: current_user, scopes: read_only_scopes)
+    )
+
+    if @application.save
+      success_message(title: t('.success'))
+      redirect_to developers_oauth_applications_path
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    authorize @application, policy_class: Developer::OauthApplicationPolicy
+    @application.destroy!
+    success_message(title: t('.success'))
+    redirect_to developers_oauth_applications_path
+  end
+
+  private
+
+  def set_application
+    @application = policy_scope(Doorkeeper::Application, policy_scope_class: Developer::OauthApplicationPolicy::Scope).find(params.expect(:id))
+  end
+
+  def application_params
+    params.expect(doorkeeper_application: [:name])
+  end
+
+  def read_only_scopes
+    Doorkeeper.configuration.default_scopes.to_s
   end
 end

--- a/app/controllers/developers/oauth_applications_controller.rb
+++ b/app/controllers/developers/oauth_applications_controller.rb
@@ -1,5 +1,5 @@
 class Developers::OauthApplicationsController < DevelopersController
-  before_action :set_application, only: :destroy
+  before_action :set_application, only: %i[destroy show_credentials]
 
   def index
     authorize Doorkeeper::Application, policy_class: Developer::OauthApplicationPolicy
@@ -18,11 +18,17 @@ class Developers::OauthApplicationsController < DevelopersController
     )
 
     if @application.save
-      success_message(title: t('.success'))
-      redirect_to developers_oauth_applications_path
+      flash[:show_credentials] = true
+      redirect_to show_credentials_developers_oauth_application_path(@application)
     else
       render :new, status: :unprocessable_content
     end
+  end
+
+  def show_credentials
+    authorize @application, policy_class: Developer::OauthApplicationPolicy
+
+    redirect_to developers_oauth_applications_path unless flash[:show_credentials]
   end
 
   def destroy
@@ -44,5 +50,9 @@ class Developers::OauthApplicationsController < DevelopersController
 
   def read_only_scopes
     Doorkeeper.configuration.default_scopes.to_s
+  end
+
+  def model_to_track_for_impersonation
+    @application
   end
 end

--- a/app/interactors/instruction/revoke_oauth_applications_if_no_developer_role.rb
+++ b/app/interactors/instruction/revoke_oauth_applications_if_no_developer_role.rb
@@ -1,0 +1,9 @@
+class Instruction::RevokeOauthApplicationsIfNoDeveloperRole
+  include Interactor
+
+  def call
+    return if context.user.developer?
+
+    Doorkeeper::Application.where(owner: context.user).destroy_all
+  end
+end

--- a/app/javascript/controllers/oauth_revocation_warning_controller.js
+++ b/app/javascript/controllers/oauth_revocation_warning_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['submit']
+  static values = { message: String }
+
+  connect () {
+    this.update()
+  }
+
+  update () {
+    if (this.hasDeveloperRole()) {
+      this.submitTarget.removeAttribute('data-turbo-confirm')
+    } else {
+      this.submitTarget.setAttribute('data-turbo-confirm', this.messageValue)
+    }
+  }
+
+  hasDeveloperRole () {
+    const selects = this.element.querySelectorAll('select[name="instruction_user_right_form[rights][][role_type]"]')
+    return Array.from(selects).some(select => select.value === 'developer')
+  }
+}

--- a/app/models/rights/manager_authority.rb
+++ b/app/models/rights/manager_authority.rb
@@ -1,5 +1,5 @@
 class Rights::ManagerAuthority < Rights::Authority
-  ALLOWED_ROLE_TYPES = %w[reporter instructor manager].freeze
+  ALLOWED_ROLE_TYPES = %w[reporter instructor manager developer].freeze
 
   def allowed_role_types
     ALLOWED_ROLE_TYPES

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,7 +105,7 @@ class User < ApplicationRecord
   has_many :oauth_applications,
     class_name: 'Doorkeeper::Application',
     as: :owner,
-    dependent: :restrict_with_exception
+    dependent: :destroy
 
   has_many :access_grants,
     class_name: 'Doorkeeper::AccessGrant',
@@ -128,6 +128,11 @@ class User < ApplicationRecord
 
     formatted_given_name = given_name.gsub(/\b\w+/) { |word| word.downcase.capitalize }
     "#{family_name.upcase} #{formatted_given_name}"
+  end
+
+  def roles=(value)
+    super
+    @role_sets = nil
   end
 
   def roles_for(kind)

--- a/app/organizers/instruction/update_user_rights.rb
+++ b/app/organizers/instruction/update_user_rights.rb
@@ -6,9 +6,14 @@ class Instruction::UpdateUserRights < ApplicationOrganizer
     context.admin_before_attributes = { roles: context.user.roles.dup }
   end
 
+  around do |interactor|
+    ActiveRecord::Base.transaction { interactor.call }
+  end
+
   organize Instruction::MergeManagedRoles,
+    Instruction::RevokeOauthApplicationsIfNoDeveloperRole,
     Admin::TrackEvent,
     Admin::NotifyAdminsForRolesUpdate
 
-  after { context.user.save }
+  after { context.user.save! }
 end

--- a/app/policies/developer/oauth_application_policy.rb
+++ b/app/policies/developer/oauth_application_policy.rb
@@ -1,21 +1,23 @@
-module Developer
-  class OauthApplicationPolicy < ApplicationPolicy
-    def index?
-      user.developer?
-    end
+class Developer::OauthApplicationPolicy < ApplicationPolicy
+  def index?
+    user.developer?
+  end
 
-    def create?
-      user.developer?
-    end
+  def create?
+    user.developer?
+  end
 
-    def destroy?
-      record.owner == user
-    end
+  def show_credentials?
+    user.developer? && record.owner == user
+  end
 
-    class Scope < ApplicationPolicy::Scope
-      def resolve
-        scope.where(owner: user)
-      end
+  def destroy?
+    user.developer? && record.owner == user
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.where(owner: user)
     end
   end
 end

--- a/app/policies/developer/oauth_application_policy.rb
+++ b/app/policies/developer/oauth_application_policy.rb
@@ -1,0 +1,21 @@
+module Developer
+  class OauthApplicationPolicy < ApplicationPolicy
+    def index?
+      user.developer?
+    end
+
+    def create?
+      user.developer?
+    end
+
+    def destroy?
+      record.owner == user
+    end
+
+    class Scope < ApplicationPolicy::Scope
+      def resolve
+        scope.where(owner: user)
+      end
+    end
+  end
+end

--- a/app/policies/developer/webhook_attempt_policy.rb
+++ b/app/policies/developer/webhook_attempt_policy.rb
@@ -1,27 +1,25 @@
-module Developer
-  class WebhookAttemptPolicy < ApplicationPolicy
+class Developer::WebhookAttemptPolicy < ApplicationPolicy
+  include DeveloperScoping
+
+  def index?
+    user_is_developer_for_definition?(record.webhook.authorization_definition_id)
+  end
+
+  def show?
+    user_is_developer_for_definition?(record.webhook.authorization_definition_id)
+  end
+
+  def replay?
+    user_is_developer_for_definition?(record.webhook.authorization_definition_id)
+  end
+
+  class Scope < ApplicationPolicy::Scope
     include DeveloperScoping
 
-    def index?
-      user_is_developer_for_definition?(record.webhook.authorization_definition_id)
-    end
+    def resolve
+      return scope.none unless user.developer?
 
-    def show?
-      user_is_developer_for_definition?(record.webhook.authorization_definition_id)
-    end
-
-    def replay?
-      user_is_developer_for_definition?(record.webhook.authorization_definition_id)
-    end
-
-    class Scope < ApplicationPolicy::Scope
-      include DeveloperScoping
-
-      def resolve
-        return scope.none unless user.developer?
-
-        scope.joins(:webhook).where(webhooks: { authorization_definition_id: developer_definition_ids })
-      end
+      scope.joins(:webhook).where(webhooks: { authorization_definition_id: developer_definition_ids })
     end
   end
 end

--- a/app/policies/developer/webhook_policy.rb
+++ b/app/policies/developer/webhook_policy.rb
@@ -1,51 +1,49 @@
-module Developer
-  class WebhookPolicy < ApplicationPolicy
+class Developer::WebhookPolicy < ApplicationPolicy
+  include DeveloperScoping
+
+  def index?
+    user.developer?
+  end
+
+  def show?
+    user_is_developer_for_definition?(record.authorization_definition_id)
+  end
+
+  def create?
+    user.developer?
+  end
+
+  def update?
+    user_is_developer_for_definition?(record.authorization_definition_id)
+  end
+
+  def destroy?
+    user_is_developer_for_definition?(record.authorization_definition_id) && !record.enabled?
+  end
+
+  def enable?
+    user_is_developer_for_definition?(record.authorization_definition_id) && record.validated? && !record.enabled?
+  end
+
+  def disable?
+    user_is_developer_for_definition?(record.authorization_definition_id) && record.enabled?
+  end
+
+  def regenerate_secret?
+    user_is_developer_for_definition?(record.authorization_definition_id)
+  end
+
+  def show_secret?
+    user_is_developer_for_definition?(record.authorization_definition_id)
+  end
+
+  class Scope < ApplicationPolicy::Scope
     include DeveloperScoping
 
-    def index?
-      user.developer?
-    end
+    def resolve
+      return scope.none unless user.developer?
 
-    def show?
-      user_is_developer_for_definition?(record.authorization_definition_id)
-    end
-
-    def create?
-      user.developer?
-    end
-
-    def update?
-      user_is_developer_for_definition?(record.authorization_definition_id)
-    end
-
-    def destroy?
-      user_is_developer_for_definition?(record.authorization_definition_id) && !record.enabled?
-    end
-
-    def enable?
-      user_is_developer_for_definition?(record.authorization_definition_id) && record.validated? && !record.enabled?
-    end
-
-    def disable?
-      user_is_developer_for_definition?(record.authorization_definition_id) && record.enabled?
-    end
-
-    def regenerate_secret?
-      user_is_developer_for_definition?(record.authorization_definition_id)
-    end
-
-    def show_secret?
-      user_is_developer_for_definition?(record.authorization_definition_id)
-    end
-
-    class Scope < ApplicationPolicy::Scope
-      include DeveloperScoping
-
-      def resolve
-        return scope.none unless user.developer?
-
-        scope.where(authorization_definition_id: developer_definition_ids)
-      end
+      scope.where(authorization_definition_id: developer_definition_ids)
     end
   end
 end

--- a/app/views/developers/oauth_applications/_copiable_field.html.erb
+++ b/app/views/developers/oauth_applications/_copiable_field.html.erb
@@ -1,0 +1,27 @@
+<div class="fr-input-group fr-mb-4w" data-controller="clipboard" data-clipboard-content-value="<%= value %>">
+  <label class="fr-label fr-mb-1w" for="<%= label.parameterize %>">
+    <strong><%= label %></strong>
+  </label>
+  <div class="fr-grid-row fr-grid-row--middle">
+    <div class="fr-col-auto">
+      <input
+        id="<%= label.parameterize %>"
+        type="text"
+        class="fr-input copiable-field__input"
+        value="<%= value %>"
+        size="<%= value.length %>"
+        readonly
+      >
+    </div>
+    <div class="fr-col-auto fr-ml-1w">
+      <button
+        class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-clipboard-line"
+        type="button"
+        data-action="click->clipboard#copy"
+        aria-label="<%= copy_aria_label %>"
+      >
+        <%= t('developers.oauth_applications.show_credentials.copy_button') %>
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/developers/oauth_applications/index.html.erb
+++ b/app/views/developers/oauth_applications/index.html.erb
@@ -1,3 +1,5 @@
+<% set_title! t('.title') %>
+
 <% content_for :content_skip_link_text do %>
   Mes applications OAuth
 <% end %>
@@ -17,9 +19,7 @@
 
 <div class="fr-mb-2w">
   <%= link_to t('.documentation_url'), developers_documentation_path, class: 'fr-btn fr-btn--secondary' %>
-  <% if current_user.developer? %>
-    <%= link_to t('.new_key'), new_developers_oauth_application_path, class: 'fr-btn fr-ml-2w' %>
-  <% end %>
+  <%= link_to t('.new_key'), new_developers_oauth_application_path, class: 'fr-btn fr-ml-2w' %>
 </div>
 
 <% if @applications.any? %>
@@ -32,12 +32,13 @@
       <div class="fr-table__container">
         <div class="fr-table__content">
           <table>
+            <caption class="fr-sr-only"><%= t('.title') %></caption>
             <thead>
               <tr>
-                <th><%= t('.table.headers.name') %></th>
-                <th><%= t('.table.headers.credentials') %></th>
-                <th><%= t('.table.headers.scopes') %></th>
-                <th><%= t('.table.headers.actions') %></th>
+                <th scope="col"><%= t('.table.headers.name') %></th>
+                <th scope="col"><%= t('.table.headers.credentials') %></th>
+                <th scope="col"><%= t('.table.headers.scopes') %></th>
+                <th scope="col"><%= t('.table.headers.actions') %></th>
               </tr>
             </thead>
             <tbody>
@@ -45,14 +46,12 @@
                 <tr>
                   <td><%= app.name %></td>
                   <td>
-                    <span data-controller="clipboard" data-clipboard-content-value="<%= app.uid %>">
+                    <span>
                       <%= t('.table.row.client_id') %>: <%= obfuscate(app.uid) %>
-                      <button class="fr-btn fr-btn--tertiary-no-outline fr-btn--sm" data-action="click->clipboard#copy">Copier</button>
                     </span>
                     <br>
-                    <span data-controller="clipboard" data-clipboard-content-value="<%= app.secret %>">
-                    <%= t('.table.row.client_secret') %>: <%= obfuscate(app.secret) %>
-                      <button class="fr-btn fr-btn--tertiary-no-outline fr-btn--sm" data-action="click->clipboard#copy">Copier</button>
+                    <span>
+                      <%= t('.table.row.client_secret') %>: <%= obfuscate(app.secret) %>
                     </span>
                   </td>
                   <td><%= (Doorkeeper.configuration.default_scopes + app.scopes).to_a.uniq.join(', ') %></td>
@@ -73,10 +72,9 @@
   </div>
 <% end %>
 
-<% if current_user.developer? %>
-  <div class="fr-mt-2w">
-    <p class="fr-mt-2w fr-mb-1w">
-      <strong><%= t('.list_of_habilitations_description') %></strong>
+<div class="fr-mt-2w">
+  <p class="fr-mt-2w fr-mb-1w">
+    <strong><%= t('.list_of_habilitations_description') %></strong>
   </p>
   <ul>
     <% current_user.definition_ids_for(:developer).each do |authorization_definition_name| %>
@@ -84,12 +82,5 @@
         <%= authorization_definition_name %>
       </li>
     <% end %>
-    </ul>
-  </div>
-<% else %>
-  <div class="fr-mt-2w">
-    <p class="fr-mt-2w fr-mb-1w">
-      <strong><%= t('.no_developer_roles') %></strong>
-    </p>
-  </div>
-<% end %>
+  </ul>
+</div>

--- a/app/views/developers/oauth_applications/index.html.erb
+++ b/app/views/developers/oauth_applications/index.html.erb
@@ -15,7 +15,12 @@
   </div>
 </div>
 
-<%= link_to t('.documentation_url'), developers_documentation_path, class: 'fr-btn fr-btn--secondary' %>
+<div class="fr-mb-2w">
+  <%= link_to t('.documentation_url'), developers_documentation_path, class: 'fr-btn fr-btn--secondary' %>
+  <% if current_user.developer? %>
+    <%= link_to t('.new_key'), new_developers_oauth_application_path, class: 'fr-btn fr-ml-2w' %>
+  <% end %>
+</div>
 
 <% if @applications.any? %>
   <div class="fr-mt-2w">
@@ -32,6 +37,7 @@
                 <th><%= t('.table.headers.name') %></th>
                 <th><%= t('.table.headers.credentials') %></th>
                 <th><%= t('.table.headers.scopes') %></th>
+                <th><%= t('.table.headers.actions') %></th>
               </tr>
             </thead>
             <tbody>
@@ -50,6 +56,13 @@
                     </span>
                   </td>
                   <td><%= (Doorkeeper.configuration.default_scopes + app.scopes).to_a.uniq.join(', ') %></td>
+                  <td>
+                    <%= button_to t('.table.row.delete'),
+                      developers_oauth_application_path(app),
+                      method: :delete,
+                      class: 'fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-delete-line',
+                      data: { turbo_confirm: t('.table.row.delete_confirm') } %>
+                  </td>
                 </tr>
               <% end %>
             </tbody>

--- a/app/views/developers/oauth_applications/new.html.erb
+++ b/app/views/developers/oauth_applications/new.html.erb
@@ -1,0 +1,43 @@
+<% set_title! t('page_titles.new_oauth_application') %>
+
+<% content_for :content_skip_link_text do %>
+  Nouvelle clef API
+<% end %>
+
+<% content_for :skip_links do %>
+  <%= skip_link("Formulaire", "oauth-application-form") %>
+  <%= skip_link("Menu", "header") %>
+  <%= skip_link("Pied de page", "footer") %>
+<% end %>
+
+<div class="sub-header fr-mt-4w fr-mb-2w">
+  <div class="sub-header-content">
+    <h1>
+      <%= t('.title') %>
+    </h1>
+  </div>
+</div>
+
+<div class="fr-grid-row" id="oauth-application-form">
+  <div class="fr-col-12 fr-col-md-6">
+    <%= form_with(model: @application, url: developers_oauth_applications_path, builder: DsfrFormBuilder) do |f| %>
+      <% if @application.errors.any? %>
+        <div class="fr-alert fr-alert--error fr-mb-4w">
+          <h3 class="fr-alert__title"><%= t('errors.messages.form_errors', count: @application.errors.count) %></h3>
+          <ul>
+            <% @application.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= f.dsfr_text_field :name, required: true, label: t('.name_label') %>
+
+      <div class="fr-mt-4w">
+        <%= f.submit t('.submit'), class: %w[fr-btn] %>
+        <%= link_to t('.cancel'), developers_oauth_applications_path, class: %w[fr-btn fr-btn--secondary] %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/developers/oauth_applications/new.html.erb
+++ b/app/views/developers/oauth_applications/new.html.erb
@@ -23,7 +23,7 @@
     <%= form_with(model: @application, url: developers_oauth_applications_path, builder: DsfrFormBuilder) do |f| %>
       <% if @application.errors.any? %>
         <div class="fr-alert fr-alert--error fr-mb-4w">
-          <h3 class="fr-alert__title"><%= t('errors.messages.form_errors', count: @application.errors.count) %></h3>
+          <h2 class="fr-alert__title"><%= t('errors.messages.form_errors', count: @application.errors.count) %></h2>
           <ul>
             <% @application.errors.full_messages.each do |message| %>
               <li><%= message %></li>

--- a/app/views/developers/oauth_applications/show_credentials.html.erb
+++ b/app/views/developers/oauth_applications/show_credentials.html.erb
@@ -1,0 +1,41 @@
+<% set_title! t('.title') %>
+
+<% content_for :content_skip_link_text do %>
+  Identifiants de l'application
+<% end %>
+
+<% content_for :skip_links do %>
+  <%= skip_link("Contenu principal", "oauth-credentials") %>
+  <%= skip_link("Menu", "header") %>
+  <%= skip_link("Pied de page", "footer") %>
+<% end %>
+
+<div class="sub-header fr-mt-4w fr-mb-2w">
+  <div>
+    <h1>
+      <%= t('.title') %>
+    </h1>
+  </div>
+</div>
+
+<div id="oauth-credentials">
+  <div class="fr-alert fr-alert--warning fr-mb-4w">
+    <h3 class="fr-alert__title"><%= t('.warning_title') %></h3>
+    <p><%= t('.warning_message') %></p>
+  </div>
+
+  <%= render 'copiable_field', label: t('.client_id_label'), value: @application.uid, copy_aria_label: t('.copy_client_id') %>
+  <%= render 'copiable_field', label: t('.client_secret_label'), value: @application.secret, copy_aria_label: t('.copy_client_secret') %>
+
+  <div class="fr-mt-6w">
+    <h2 class="fr-h6"><%= t('.best_practices_title') %></h2>
+    <ul>
+      <li><%= t('.best_practice_1') %></li>
+      <li><%= t('.best_practice_2') %></li>
+    </ul>
+  </div>
+
+  <div class="fr-mt-6w">
+    <%= link_to t('.back_to_applications'), developers_oauth_applications_path, class: %w[fr-btn] %>
+  </div>
+</div>

--- a/app/views/instruction/user_rights/_confirm_destroy.html.erb
+++ b/app/views/instruction/user_rights/_confirm_destroy.html.erb
@@ -17,6 +17,12 @@
     <% else %>
       <p id="no-modifiable-rights-msg"><%= t('instruction.user_rights.confirm_destroy.no_modifiable_rights') %></p>
     <% end %>
+
+    <% if @target_user.oauth_applications.any? %>
+      <%= dsfr_alert type: :warning,
+                     title: t('instruction.user_rights.confirm_destroy.oauth_revocation_warning', count: @target_user.oauth_applications.count),
+                     html_attributes: { class: 'fr-mt-2w' } %>
+    <% end %>
   </div>
 
   <div class="fr-modal__footer">

--- a/app/views/instruction/user_rights/_form.html.erb
+++ b/app/views/instruction/user_rights/_form.html.erb
@@ -2,7 +2,8 @@
               url: url,
               method: method,
               scope: :instruction_user_right_form,
-              builder: DsfrFormBuilder do |f| %>
+              builder: DsfrFormBuilder,
+              data: oauth_applications_count.positive? ? { controller: 'oauth-revocation-warning', action: 'change->oauth-revocation-warning#update click->oauth-revocation-warning#update', oauth_revocation_warning_message_value: t('instruction.user_rights.edit.oauth_revocation_warning', count: oauth_applications_count) } : {} do |f| %>
 
   <% if form.errors.any? %>
     <%= dsfr_alert type: :error,
@@ -72,7 +73,10 @@
             class: %w[fr-btn fr-btn--secondary] %>
     </li>
     <li>
-      <%= f.button submit_label, type: :submit, class: %w[fr-btn fr-btn--primary fr-icon-check-line fr-btn--icon-left] %>
+      <%= f.button submit_label,
+            type: :submit,
+            class: %w[fr-btn fr-btn--primary fr-icon-check-line fr-btn--icon-left],
+            data: oauth_applications_count.positive? ? { oauth_revocation_warning_target: 'submit' } : {} %>
     </li>
   </ul>
 <% end %>

--- a/app/views/instruction/user_rights/edit.html.erb
+++ b/app/views/instruction/user_rights/edit.html.erb
@@ -18,5 +18,6 @@
     method: :patch,
     show_email_field: false,
     readonly_rights: @form.readonly_rights,
-    submit_label: t('instruction.user_rights.edit.submit') %>
+    submit_label: t('instruction.user_rights.edit.submit'),
+    oauth_applications_count: @target_user.oauth_applications.count %>
 </div>

--- a/app/views/instruction/user_rights/new.html.erb
+++ b/app/views/instruction/user_rights/new.html.erb
@@ -13,5 +13,6 @@
     method: :post,
     show_email_field: true,
     readonly_rights: [],
-    submit_label: t('instruction.user_rights.new.submit') %>
+    submit_label: t('instruction.user_rights.new.submit'),
+    oauth_applications_count: 0 %>
 </div>

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -28,7 +28,7 @@ fr:
             rights:
               scope_not_authorized: contiennent une portée qui n’est pas dans votre périmètre
               incomplete_right: chaque droit doit renseigner une portée et un rôle
-              role_type_not_allowed: contiennent un rôle non autorisé (seuls reporter, instructeur et manager sont autorisés)
+              role_type_not_allowed: contiennent un rôle non autorisé (seuls reporter, instructeur, manager et développeur sont autorisés)
   activerecord:
     attributes:
       user:
@@ -47,9 +47,9 @@ fr:
       webhook:
         url: URL de destination
         authorization_definition_id: Service
+        events: Événements à écouter
       doorkeeper/application:
         name: "Nom de l'application"
-        events: Événements à écouter
       authorization_request:
         terms_of_service_accepted: J’ai pris connaissance des conditions générales d’utilisation et je les valide.
         data_protection_officer_informed: Je confirme que le délégué à la protection des données de mon organisation est informé de ma demande.

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -47,6 +47,8 @@ fr:
       webhook:
         url: URL de destination
         authorization_definition_id: Service
+      doorkeeper/application:
+        name: "Nom de l'application"
         events: Événements à écouter
       authorization_request:
         terms_of_service_accepted: J’ai pris connaissance des conditions générales d’utilisation et je les valide.

--- a/config/locales/developers.fr.yml
+++ b/config/locales/developers.fr.yml
@@ -143,11 +143,24 @@ fr:
         description_html: Liste de vos applications OAuth et de leurs credentials API
         list_of_habilitations_description: Vos clefs d'accès API vous permettent d'accéder aux demandes et habilitations suivantes
         no_developer_roles: Vous n'avez pas de clefs d'accès API, contactez un administrateur pour en obtenir.
+        new_key: Nouvelle clef API
         table:
           headers:
             name: Nom de l'application
             credentials: Identifiants
             scopes: Scopes
+            actions: Actions
           row:
             client_id: Id
             client_secret: Secret
+            delete: Supprimer
+            delete_confirm: "Êtes-vous sûr de vouloir supprimer cette clef API ? Les tokens associés seront révoqués."
+      new:
+        title: Nouvelle clef API
+        submit: Créer la clef API
+        cancel: Annuler
+        name_label: Nom de l'application
+      create:
+        success: Clef API créée avec succès
+      destroy:
+        success: Clef API supprimée avec succès

--- a/config/locales/developers.fr.yml
+++ b/config/locales/developers.fr.yml
@@ -142,7 +142,6 @@ fr:
         documentation_url: Voir la documentation API
         description_html: Liste de vos applications OAuth et de leurs credentials API
         list_of_habilitations_description: Vos clefs d'accès API vous permettent d'accéder aux demandes et habilitations suivantes
-        no_developer_roles: Vous n'avez pas de clefs d'accès API, contactez un administrateur pour en obtenir.
         new_key: Nouvelle clef API
         table:
           headers:
@@ -160,7 +159,18 @@ fr:
         submit: Créer la clef API
         cancel: Annuler
         name_label: Nom de l'application
-      create:
-        success: Clef API créée avec succès
+      show_credentials:
+        title: Identifiants de votre nouvelle clef API
+        warning_title: Attention – Sauvegardez ces identifiants maintenant
+        warning_message: Ces identifiants ne seront affichés qu'une seule fois. Assurez-vous de les sauvegarder dans un endroit sûr avant de quitter cette page.
+        client_id_label: Identifiant client (Client ID)
+        client_secret_label: Secret client (Client Secret)
+        copy_client_id: Copier l'identifiant client
+        copy_client_secret: Copier le secret client
+        copy_button: Copier
+        best_practices_title: Bonnes pratiques de sécurité
+        best_practice_1: Stockez ces identifiants dans vos variables d'environnement
+        best_practice_2: Ne commitez jamais ces identifiants dans votre système de contrôle de version
+        back_to_applications: Retour aux clefs API
       destroy:
         success: Clef API supprimée avec succès

--- a/config/locales/instruction.fr.yml
+++ b/config/locales/instruction.fr.yml
@@ -594,9 +594,11 @@ fr:
         readonly_alerts:
           default: Ce droit n’est pas modifiable depuis cette interface.
           admin: Contactez un tech de l’équipe pour modifier un droit admin.
-          developer: Contactez l’équipe DataPass pour modifier le droit développeur.
         readonly_scopes: "Concerné : %{scopes}"
         destroy_cta: Supprimer tous les droits
+        oauth_revocation_warning:
+          one: "Cet utilisateur possède une clef API. Si le rôle développeur est retiré, elle sera définitivement révoquée. Continuer ?"
+          other: "Cet utilisateur possède %{count} clefs API. Si le rôle développeur est retiré, elles seront définitivement révoquées. Continuer ?"
       update:
         success: Les droits de %{email} ont été mis à jour
         error: Impossible de mettre à jour les droits
@@ -606,6 +608,9 @@ fr:
         no_modifiable_rights: Cet utilisateur n’a aucun droit modifiable dans votre périmètre.
         cancel: Annuler
         submit: Supprimer tous les droits de l’utilisateur
+        oauth_revocation_warning:
+          one: "Cet utilisateur possède une clef API qui sera définitivement révoquée."
+          other: "Cet utilisateur possède %{count} clefs API qui seront définitivement révoquées."
       destroy:
         success: Tous les droits de %{email} ont été supprimés
         error: Impossible de supprimer les droits

--- a/config/locales/page_titles.fr.yml
+++ b/config/locales/page_titles.fr.yml
@@ -13,6 +13,7 @@ fr:
     developers_home: Espace développeur
     developers_tutorials: Tutoriels développeurs
     developers_tutorial: "Tutoriel : %{title}"
+    new_oauth_application: Nouvelle clef API
 
     dashboard: Tableau de bord
     profile: Votre compte utilisateur

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,7 +191,11 @@ Rails.application.routes.draw do
   get '/developpeurs', to: 'developers#index', as: :developers_root
 
   namespace :developers, path: 'developpeurs' do
-    resources :oauth_applications, only: %i[index new create destroy], path: 'applications'
+    resources :oauth_applications, only: %i[index new create destroy], path: 'applications' do
+      member do
+        get :show_credentials
+      end
+    end
     get 'documentation', to: 'open_api#show'
 
     get 'tutoriels', to: 'tutorials#index', as: :tutorials

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,7 +191,7 @@ Rails.application.routes.draw do
   get '/developpeurs', to: 'developers#index', as: :developers_root
 
   namespace :developers, path: 'developpeurs' do
-    resources :oauth_applications, only: :index, path: 'applications'
+    resources :oauth_applications, only: %i[index new create destroy], path: 'applications'
     get 'documentation', to: 'open_api#show'
 
     get 'tutoriels', to: 'tutorials#index', as: :tutorials

--- a/features/developpeurs/applications.feature
+++ b/features/developpeurs/applications.feature
@@ -20,6 +20,5 @@ Fonctionnalité: Développeurs: consultation de ses applications
     Alors la page contient "Mes clefs d'accès API"
     Et la page contient "Accès API Entreprise"
     Et la page contient "Secret: ****ecret"
-    Et il y a un bouton "Copier"
     Et la page contient "Vos clefs d'accès API vous permettent d'accéder aux demandes et habilitations suivantes"
     Et la page contient "api_entreprise"

--- a/features/developpeurs/gestion_des_cles_api.feature
+++ b/features/developpeurs/gestion_des_cles_api.feature
@@ -1,0 +1,37 @@
+# language: fr
+
+Fonctionnalité: Développeurs: gestion des clefs API
+  En tant que développeur
+  Je veux créer et supprimer mes clefs API
+  Afin de gérer mon accès à l'API DataPass
+
+  Contexte:
+    Sachant que je suis un développeur "API Entreprise"
+    Et que je me connecte
+
+  Scénario: Je peux créer une clef API
+    Quand je me rends sur le chemin "/developpeurs/applications"
+    Et que je clique sur "Nouvelle clef API"
+    Et que je remplis "Nom de l'application" avec "Mon application"
+    Et que je clique sur "Créer la clef API"
+    Alors la page contient "Mes clefs d'accès API"
+    Et il y a un message de succès contenant "Clef API créée avec succès"
+    Et la page contient "Mon application"
+
+  Scénario: Je ne peux pas créer une clef API sans nom
+    Quand je me rends sur le chemin "/developpeurs/applications"
+    Et que je clique sur "Nouvelle clef API"
+    Et que je clique sur "Créer la clef API"
+    Alors la page contient "erreur"
+
+  Scénario: Je peux supprimer une de mes clefs API
+    Sachant qu'il existe une application OAuth "App à supprimer" appartenant au développeur courant
+    Quand je me rends sur le chemin "/developpeurs/applications"
+    Et que je clique sur "Supprimer" dans la rangée "App à supprimer"
+    Alors il y a un message de succès contenant "Clef API supprimée avec succès"
+    Et la page ne contient pas "App à supprimer"
+
+  Scénario: Je ne peux pas supprimer une clef API qui ne m'appartient pas
+    Sachant qu'il existe une application OAuth appartenant à un autre développeur
+    Quand j'essaie de supprimer cette application directement
+    Alors l'application n'a pas été supprimée

--- a/features/developpeurs/gestion_des_cles_api.feature
+++ b/features/developpeurs/gestion_des_cles_api.feature
@@ -9,13 +9,17 @@ Fonctionnalité: Développeurs: gestion des clefs API
     Sachant que je suis un développeur "API Entreprise"
     Et que je me connecte
 
-  Scénario: Je peux créer une clef API
+  Scénario: Je peux créer une clef API et voir les identifiants une seule fois
     Quand je me rends sur le chemin "/developpeurs/applications"
     Et que je clique sur "Nouvelle clef API"
     Et que je remplis "Nom de l'application" avec "Mon application"
     Et que je clique sur "Créer la clef API"
+    Alors la page contient "Identifiants de votre nouvelle clef API"
+    Et la page contient "Attention"
+    Et la page contient "Identifiant client"
+    Et la page contient "Secret client"
+    Quand je clique sur "Retour aux clefs API"
     Alors la page contient "Mes clefs d'accès API"
-    Et il y a un message de succès contenant "Clef API créée avec succès"
     Et la page contient "Mon application"
 
   Scénario: Je ne peux pas créer une clef API sans nom

--- a/features/instructeurs/gestion_des_droits/j_ajoute_des_droits.feature
+++ b/features/instructeurs/gestion_des_droits/j_ajoute_des_droits.feature
@@ -46,13 +46,23 @@ Fonctionnalité: Instruction — Gestion des droits — ajouter des droits à un
     Et la page contient "Peut instruire les demandes"
     Et la page contient "peut attribuer ou retirer des droits"
 
-  Scénario: La liste des rôles ne contient ni admin ni développeur
+  Scénario: La liste des rôles contient les quatre rôles gérables mais pas admin
     Quand je me rends sur la page d'ajout de droits
     Alors le select "Rôle" contient "Observateur"
     Et le select "Rôle" contient "Instructeur"
     Et le select "Rôle" contient "Manager"
-    Et le select "Rôle" ne contient pas "Développeur"
+    Et le select "Rôle" contient "Développeur"
     Et le select "Rôle" ne contient pas "Admin"
+
+  Scénario: J'ajoute le rôle développeur à un utilisateur
+    Quand il y a l'utilisateur "dev@gouv.fr" sans rôle
+    Et que je me rends sur la page d'ajout de droits
+    Et que je remplis "Email de l’utilisateur" avec "dev@gouv.fr"
+    Et que je sélectionne "API Entreprise" pour "Portée des droits"
+    Et que je sélectionne "Développeur" pour "Rôle"
+    Et que je clique sur "Valider les modifications"
+    Alors il y a un message de succès contenant "mis à jour"
+    Et l'utilisateur "dev@gouv.fr" a les rôles "dinum:api_entreprise:developer"
 
   Scénario: Je préserve les rôles existants hors de mon périmètre
     Quand il y a l'utilisateur "existant@gouv.fr" avec le rôle "Rapporteur" pour "API Particulier"

--- a/features/instructeurs/gestion_des_droits/je_modifie_des_droits.feature
+++ b/features/instructeurs/gestion_des_droits/je_modifie_des_droits.feature
@@ -45,14 +45,21 @@ Fonctionnalité: Instruction — Gestion des droits — modifier les droits d’
     Et que je tente de modifier les droits de "externe@gouv.fr" via URL
     Alors il y a un message d'erreur contenant "Vous n'avez pas le droit d'accéder à cette page"
 
-  Scénario: Un rôle développeur est affiché en lecture seule et préservé lors d’une modification
+  Scénario: Je peux attribuer le rôle développeur lors d'une modification
     Quand il y a l'utilisateur "dev@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
-    Et qu'il y a l'utilisateur "dev@gouv.fr" avec le rôle "Développeur" pour "API Entreprise"
     Et que je me rends sur la page de gestion des droits
     Et que je clique sur "Modifier les droits de dev@gouv.fr"
-    Alors la page contient "Droits non modifiables depuis cette interface"
-    Et la section des droits non modifiables indique "Contactez l’équipe DataPass pour modifier le droit développeur."
-    Quand je sélectionne "Instructeur" pour "Rôle"
+    Quand je sélectionne "Développeur" pour "Rôle"
     Et que je clique sur "Valider les modifications"
     Alors il y a un message de succès contenant "mis à jour"
-    Et l'utilisateur "dev@gouv.fr" a les rôles "dinum:api_entreprise:developer,dinum:api_entreprise:instructor"
+    Et l'utilisateur "dev@gouv.fr" a les rôles "dinum:api_entreprise:developer"
+
+  Scénario: Révoquer le rôle développeur supprime les clefs API de l'utilisateur
+    Quand il y a l'utilisateur "dev@gouv.fr" avec le rôle "Développeur" pour "API Entreprise"
+    Et qu'il existe une application OAuth appartenant à "dev@gouv.fr"
+    Et que je me rends sur la page de gestion des droits
+    Et que je clique sur "Modifier les droits de dev@gouv.fr"
+    Et que je sélectionne "Observateur" pour "Rôle"
+    Et que je clique sur "Valider les modifications"
+    Alors il y a un message de succès contenant "mis à jour"
+    Et l'utilisateur "dev@gouv.fr" n'a plus de clefs API

--- a/features/instructeurs/gestion_des_droits/je_supprime_tous_les_droits.feature
+++ b/features/instructeurs/gestion_des_droits/je_supprime_tous_les_droits.feature
@@ -28,15 +28,6 @@ Fonctionnalité: Instruction — Gestion des droits — supprimer tous les droit
     Alors il y a un message de succès contenant "ont été supprimés"
     Et l'utilisateur "mixte@gouv.fr" a les rôles "dinum:api_particulier:reporter"
 
-  Scénario: Les rôles développeur sont préservés lors d’une suppression
-    Quand il y a l'utilisateur "dev@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
-    Et qu'il y a l'utilisateur "dev@gouv.fr" avec le rôle "Développeur" pour "API Entreprise"
-    Et que je me rends sur la page de gestion des droits
-    Et que je clique sur "Supprimer tous les droits de dev@gouv.fr"
-    Et que je clique sur "Supprimer tous les droits de l’utilisateur"
-    Alors il y a un message de succès contenant "ont été supprimés"
-    Et l'utilisateur "dev@gouv.fr" a les rôles "dinum:api_entreprise:developer"
-
   Scénario: Je peux déclencher la suppression depuis la page d’édition
     Quand il y a l'utilisateur "eva@gouv.fr" avec le rôle "Rapporteur" pour "API Entreprise"
     Et que je me rends sur la page de gestion des droits

--- a/features/step_definitions/oauth_application_steps.rb
+++ b/features/step_definitions/oauth_application_steps.rb
@@ -1,0 +1,18 @@
+Sachantque('il existe une application OAuth {string} appartenant au développeur courant') do |name|
+  @own_application = FactoryBot.create(:oauth_application, name:, owner: current_user)
+end
+
+Sachantque('il existe une application OAuth appartenant à un autre développeur') do
+  other_user = FactoryBot.create(:user, :developer)
+  @other_application = FactoryBot.create(:oauth_application, owner: other_user)
+end
+
+Quand("j'essaie de supprimer cette application directement") do
+  page.driver.delete(developers_oauth_application_path(@other_application))
+rescue ActiveRecord::RecordNotFound
+  nil
+end
+
+Alors("l'application n'a pas été supprimée") do
+  expect(Doorkeeper::Application.exists?(@other_application.id)).to be true
+end

--- a/features/step_definitions/oauth_application_steps.rb
+++ b/features/step_definitions/oauth_application_steps.rb
@@ -16,3 +16,13 @@ end
 Alors("l'application n'a pas été supprimée") do
   expect(Doorkeeper::Application.exists?(@other_application.id)).to be true
 end
+
+Sachantque('il existe une application OAuth appartenant à {string}') do |email|
+  user = User.find_by!(email:)
+  FactoryBot.create(:oauth_application, owner: user)
+end
+
+Alors("l'utilisateur {string} n'a plus de clefs API") do |email|
+  user = User.find_by!(email:)
+  expect(Doorkeeper::Application.where(owner: user)).to be_empty
+end

--- a/spec/components/molecules/instruction/user_rights/readonly_rights_list_component_spec.rb
+++ b/spec/components/molecules/instruction/user_rights/readonly_rights_list_component_spec.rb
@@ -24,19 +24,24 @@ RSpec.describe Molecules::Instruction::UserRights::ReadonlyRightsListComponent, 
     expect(page).to have_css('h4.fr-alert__title')
   end
 
-  it 'renders an info alert with the developer wording and lists the concerned scopes' do
-    render_component([{ scope: 'dinum:api_entreprise', role_type: 'developer' }])
+  context 'with a role type that has no specific wording' do
+    before { render_component([{ scope: 'dinum:api_entreprise', role_type: 'some_role' }]) }
 
-    expect(page).to have_css('.fr-alert--info')
-    expect(page).to have_text('Contactez l’équipe DataPass pour modifier le droit développeur.')
-    expect(page).to have_text(Instruction::Scope.new('dinum:api_entreprise').label)
+    it 'renders an info alert with the default wording' do
+      expect(page).to have_css('.fr-alert--info')
+      expect(page).to have_text('Ce droit n’est pas modifiable depuis cette interface.')
+    end
+
+    it 'lists the concerned scopes' do
+      expect(page).to have_text(Instruction::Scope.new('dinum:api_entreprise').label)
+    end
   end
 
   it 'groups several readonly rights of the same role into a single alert' do
     render_component(
       [
-        { scope: 'dinum:api_entreprise', role_type: 'developer' },
-        { scope: 'dinum:api_particulier', role_type: 'developer' }
+        { scope: 'dinum:api_entreprise', role_type: 'some_role' },
+        { scope: 'dinum:api_particulier', role_type: 'some_role' }
       ]
     )
 

--- a/spec/components/molecules/instruction/user_rights/right_field_component_spec.rb
+++ b/spec/components/molecules/instruction/user_rights/right_field_component_spec.rb
@@ -46,16 +46,12 @@ RSpec.describe Molecules::Instruction::UserRights::RightFieldComponent, type: :c
     )
   end
 
-  it 'lists only reporter, instructor and manager as role options' do
+  it 'lists reporter, instructor, manager and developer as role options' do
     render_component(index: 0)
 
     expect(page).to have_select(
       'instruction_user_right_form[rights][][role_type]',
-      with_options: %w[Observateur Instructeur Manager]
-    )
-    expect(page).to have_no_select(
-      'instruction_user_right_form[rights][][role_type]',
-      with_options: %w[Développeur]
+      with_options: %w[Observateur Instructeur Manager Développeur]
     )
   end
 

--- a/spec/forms/instruction/user_right_form_spec.rb
+++ b/spec/forms/instruction/user_right_form_spec.rb
@@ -95,17 +95,6 @@ RSpec.describe Instruction::UserRightForm do
         expect(form.errors.details[:rights]).to include(hash_including(error: :role_type_not_allowed))
       end
     end
-
-    context 'when a role_type is not in the allowed list' do
-      let(:attrs) do
-        { email: 'user@gouv.fr', rights: [valid_right(role_type: 'developer')] }
-      end
-
-      it 'is invalid with role_type_not_allowed on :rights' do
-        expect(form).not_to be_valid
-        expect(form.errors.details[:rights]).to include(hash_including(error: :role_type_not_allowed))
-      end
-    end
   end
 
   describe '#to_roles' do

--- a/spec/interactors/instruction/merge_managed_roles_spec.rb
+++ b/spec/interactors/instruction/merge_managed_roles_spec.rb
@@ -65,25 +65,14 @@ RSpec.describe Instruction::MergeManagedRoles, type: :interactor do
       end
     end
 
-    context 'when user has a developer role on a managed definition' do
-      let(:initial_roles) { %w[dinum:api_entreprise:developer dinum:api_entreprise:reporter] }
-      let(:new_roles) { %w[dinum:api_entreprise:instructor] }
-
-      it 'preserves the developer role and replaces the other managed roles' do
-        result
-
-        expect(user.roles).to match_array(%w[dinum:api_entreprise:developer dinum:api_entreprise:instructor])
-      end
-    end
-
     context 'when destroy-like call (empty new_roles) and user has a developer role' do
       let(:initial_roles) { %w[dinum:api_entreprise:developer dinum:api_entreprise:reporter dinum:api_particulier:reporter] }
       let(:new_roles) { [] }
 
-      it 'preserves developer and out-of-scope roles and drops the other managed roles' do
+      it 'drops all managed roles including developer and preserves out-of-scope roles' do
         result
 
-        expect(user.roles).to match_array(%w[dinum:api_entreprise:developer dinum:api_particulier:reporter])
+        expect(user.roles).to eq(%w[dinum:api_particulier:reporter])
       end
     end
 

--- a/spec/interactors/instruction/revoke_oauth_applications_if_no_developer_role_spec.rb
+++ b/spec/interactors/instruction/revoke_oauth_applications_if_no_developer_role_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Instruction::RevokeOauthApplicationsIfNoDeveloperRole, type: :interactor do
+  describe '.call' do
+    subject(:result) { described_class.call(user:) }
+
+    context 'when the user no longer has any developer role' do
+      let(:user) { create(:user, roles: ['dinum:api_entreprise:reporter']) }
+
+      before { create(:oauth_application, owner: user) }
+
+      it 'destroys all their OAuth applications' do
+        expect { result }.to change { Doorkeeper::Application.where(owner: user).count }.from(1).to(0)
+      end
+    end
+
+    context 'when the user still has a developer role' do
+      let(:user) { create(:user, roles: ['dinum:api_entreprise:developer']) }
+
+      before { create(:oauth_application, owner: user) }
+
+      it 'preserves their OAuth applications' do
+        expect { result }.not_to change { Doorkeeper::Application.where(owner: user).count }
+      end
+    end
+
+    context 'when the user has no OAuth applications' do
+      let(:user) { create(:user, roles: []) }
+
+      it 'succeeds without error' do
+        expect(result).to be_success
+      end
+    end
+  end
+end

--- a/spec/models/rights/manager_authority_spec.rb
+++ b/spec/models/rights/manager_authority_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Rights::ManagerAuthority do
   describe '#allowed_role_types' do
     let(:user) { create(:user) }
 
-    it 'returns reporter, instructor and manager' do
-      expect(authority.allowed_role_types).to eq(%w[reporter instructor manager])
+    it 'returns reporter, instructor, manager and developer' do
+      expect(authority.allowed_role_types).to eq(%w[reporter instructor manager developer])
     end
   end
 
@@ -62,10 +62,6 @@ RSpec.describe Rights::ManagerAuthority do
       expect(authority.can_manage_role?('not-a-role')).to be false
     end
 
-    it 'returns false for the developer role (outside allowed_role_types)' do
-      expect(authority.can_manage_role?('dinum:api_entreprise:developer')).to be false
-    end
-
     it 'returns true for an allowed role on a managed scope' do
       expect(authority.can_manage_role?('dinum:api_entreprise:reporter')).to be true
     end
@@ -92,10 +88,6 @@ RSpec.describe Rights::ManagerAuthority do
 
     it 'returns false for the admin role' do
       expect(authority.covers_role?('admin')).to be false
-    end
-
-    it 'returns true for the developer role on a managed scope (covered but not modifiable)' do
-      expect(authority.covers_role?('dinum:api_entreprise:developer')).to be true
     end
 
     it 'returns false for any role on a scope the user does not manage' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -598,6 +598,18 @@ RSpec.describe User do
     end
   end
 
+  describe '#roles=' do
+    it 'clears memoized role sets so role checks reflect the new roles' do
+      user = build(:user, roles: ['dinum:api_entreprise:developer'])
+
+      expect(user.developer?).to be true
+
+      user.roles = ['dinum:api_entreprise:reporter']
+
+      expect(user.developer?).to be false
+    end
+  end
+
   describe '.banned' do
     subject { described_class.banned }
 

--- a/spec/policies/developer/oauth_application_policy_spec.rb
+++ b/spec/policies/developer/oauth_application_policy_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe Developer::OauthApplicationPolicy do
+  subject(:policy) { described_class.new(UserContext.new(user), application) }
+
+  let(:owner) { create(:user, :developer) }
+  let(:application) { create(:oauth_application, owner:) }
+
+  describe '#index?' do
+    subject { policy.index? }
+
+    context 'when user has developer role' do
+      let(:user) { owner }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user has no developer role' do
+      let(:user) { create(:user) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#create?' do
+    subject { policy.create? }
+
+    context 'when user has developer role' do
+      let(:user) { owner }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user has no developer role' do
+      let(:user) { create(:user) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#destroy?' do
+    subject { policy.destroy? }
+
+    context 'when user owns the application' do
+      let(:user) { owner }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user does not own the application' do
+      let(:user) { create(:user, :developer) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe 'Scope' do
+    subject(:scope) { described_class::Scope.new(UserContext.new(user), Doorkeeper::Application).resolve }
+
+    let(:other_user) { create(:user, :developer) }
+    let!(:own_application) { create(:oauth_application, owner:) }
+    let!(:other_application) { create(:oauth_application, owner: other_user) }
+
+    context 'when user has developer role' do
+      let(:user) { owner }
+
+      it 'returns only own applications' do
+        expect(scope).to include(own_application)
+        expect(scope).not_to include(other_application)
+      end
+    end
+  end
+end

--- a/spec/policies/developer/oauth_application_policy_spec.rb
+++ b/spec/policies/developer/oauth_application_policy_spec.rb
@@ -36,6 +36,30 @@ RSpec.describe Developer::OauthApplicationPolicy do
     end
   end
 
+  describe '#show_credentials?' do
+    subject { policy.show_credentials? }
+
+    context 'when user owns the application' do
+      let(:user) { owner }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user does not own the application' do
+      let(:user) { create(:user, :developer) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when user owns the application but is not a developer' do
+      let(:non_developer_owner) { create(:user) }
+      let(:application) { create(:oauth_application, owner: non_developer_owner) }
+      let(:user) { non_developer_owner }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#destroy?' do
     subject { policy.destroy? }
 
@@ -47,6 +71,14 @@ RSpec.describe Developer::OauthApplicationPolicy do
 
     context 'when user does not own the application' do
       let(:user) { create(:user, :developer) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when user owns the application but is not a developer' do
+      let(:non_developer_owner) { create(:user) }
+      let(:application) { create(:oauth_application, owner: non_developer_owner) }
+      let(:user) { non_developer_owner }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
Les utilisateurs avec un rôle développeur peuvent désormais gérer leurs applications OAuth (clefs d'accès API) en autonomie depuis l'espace développeur, sans intervention d'un administrateur.


On permet aussi aux managers d'attribuer le rôle développeur à leurs utilisateurs pour compléter l'autonomie des FD.