### PR TITLE
Inclut les demandes validées dans les résultats de recherche par ID

### DIFF
--- a/app/facades/instruction/search/dashboard_demandes_search.rb
+++ b/app/facades/instruction/search/dashboard_demandes_search.rb
@@ -3,6 +3,8 @@ class Instruction::Search::DashboardDemandesSearch < Instruction::Search::Dashbo
 
   def base_relation
     base_scope = super
+    return base_scope if search_terms_is_a_possible_id?
+
     base_scope = base_scope.not_validated
     base_scope = base_scope.not_archived if state_filter_blank?
     base_scope

--- a/spec/facades/instruction/search/dashboard_demandes_search_spec.rb
+++ b/spec/facades/instruction/search/dashboard_demandes_search_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Instruction::Search::DashboardDemandesSearch do
   let(:params) { { search_query: {} } }
   let!(:authorization_request) { create(:authorization_request) }
   let(:scope) { AuthorizationRequest.all }
+  let(:search_key) { described_class.key }
 
   describe '#initialize' do
     it 'creates a search object successfully' do
@@ -23,8 +24,6 @@ RSpec.describe Instruction::Search::DashboardDemandesSearch do
   end
 
   describe 'ID search' do
-    let(:search_key) { described_class.key }
-
     context 'with an exact numeric ID' do
       let(:params) { { search_query: { search_key => authorization_request.id.to_s } } }
 
@@ -69,6 +68,38 @@ RSpec.describe Instruction::Search::DashboardDemandesSearch do
       it 'returns no results' do
         search = described_class.new(params: params, scope: scope)
         expect(search.results).to be_empty
+      end
+    end
+
+    context 'with a validated demande' do
+      let!(:validated_request) { create(:authorization_request, :validated) }
+      let(:params) { { search_query: { search_key => validated_request.id.to_s } } }
+
+      it 'returns the validated request' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(validated_request)
+      end
+    end
+
+    context 'with an archived demande' do
+      let!(:archived_request) { create(:authorization_request, :archived) }
+      let(:params) { { search_query: { search_key => archived_request.id.to_s } } }
+
+      it 'returns the archived request' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).to include(archived_request)
+      end
+    end
+  end
+
+  describe 'non-ID search' do
+    context 'with a validated demande' do
+      let!(:validated_request) { create(:authorization_request, :validated) }
+      let(:params) { { search_query: { search_key => validated_request.organization.siret } } }
+
+      it 'does not return the validated request' do
+        search = described_class.new(params: params, scope: scope)
+        expect(search.results).not_to include(validated_request)
       end
     end
   end


### PR DESCRIPTION
Lors d'une recherche par ID dans la liste des demandes (onglet instructeur), le filtre `not_validated` était appliqué systématiquement, empêchant de retrouver une demande validée même en tapant son identifiant exact.

Le filtre `not_validated` (et `not_archived`) n'est désormais appliqué que pour les recherches textuelles classiques ; les recherches par ID retournent toutes les demandes correspondantes, quel que soit leur état.