### PR TITLE
DP-1789 — Réduit la session à 12 h idle glissant, plafonnée à 24 h

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -58,13 +58,18 @@ module Authentication
       return
     end
 
-    session[:return_to_after_sign_in] = request.url
-    redirect_to sign_in_path
+    redirect_to_sign_in
   end
 
   def user_signed_in?
     valid_user_session? &&
       current_user.present?
+  end
+
+  def redirect_to_sign_in
+    info_message(title: t('sessions.authenticate_user.session_expired')) if session_expired?
+    save_redirect_path
+    redirect_to sign_in_path
   end
 
   def save_redirect_path

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,6 +1,7 @@
 module Authentication
   extend ActiveSupport::Concern
   include ImpersonationTrackingManagement
+  include SessionLifecycle
 
   included do
     before_action :authenticate_user!
@@ -23,9 +24,12 @@ module Authentication
   def after_sign_in_path = dashboard_path
 
   def sign_in(user, identity_federator:, identity_provider_uid:)
+    rotate_session
+
     session[:user_id] = {
       value: user.id,
-      expires_at: 1.month.from_now,
+      expires_at: SESSION_IDLE_TIMEOUT.from_now,
+      absolute_expires_at: SESSION_ABSOLUTE_TIMEOUT.from_now,
       identity_federator:,
       identity_provider_uid:,
     }
@@ -50,6 +54,7 @@ module Authentication
     if user_signed_in?
       raise ApplicationController::BannedUserError if current_user.banned?
 
+      slide_session_expiry
       return
     end
 
@@ -60,17 +65,6 @@ module Authentication
   def user_signed_in?
     valid_user_session? &&
       current_user.present?
-  end
-
-  def valid_user_session?
-    user_id_session.present? &&
-      user_id_session['value'].present? &&
-      user_id_session['expires_at'].present? &&
-      user_id_session['expires_at'] > Time.current
-  end
-
-  def user_id_session
-    session[:user_id]
   end
 
   def save_redirect_path

--- a/app/controllers/concerns/authentication/session_lifecycle.rb
+++ b/app/controllers/concerns/authentication/session_lifecycle.rb
@@ -31,6 +31,10 @@ module Authentication::SessionLifecycle
 
   def valid_user_session? = Authentication::SessionLifecycle.valid_session?(user_id_session)
 
+  def session_expired?
+    user_id_session.present? && !valid_user_session?
+  end
+
   def user_id_session
     session[:user_id]
   end

--- a/app/controllers/concerns/authentication/session_lifecycle.rb
+++ b/app/controllers/concerns/authentication/session_lifecycle.rb
@@ -1,0 +1,55 @@
+module Authentication::SessionLifecycle
+  SESSION_IDLE_TIMEOUT = 12.hours
+  SESSION_ABSOLUTE_TIMEOUT = 24.hours
+
+  ROTATION_PRESERVED_KEYS = %w[
+    omniauth.pc.access_token
+    omniauth.pc.id_token
+    omniauth.pc.refresh_token
+    return_to_after_sign_in
+  ].freeze
+
+  def self.valid_session?(user_id_session)
+    user_id_session.present? &&
+      user_id_session['value'].present? &&
+      future_timestamp?(user_id_session['expires_at']) &&
+      future_timestamp?(user_id_session['absolute_expires_at'])
+  end
+
+  def self.future_timestamp?(timestamp)
+    time = normalize_timestamp(timestamp)
+    time.present? && time > Time.current
+  end
+
+  def self.normalize_timestamp(timestamp)
+    return Time.zone.parse(timestamp) if timestamp.is_a?(String)
+
+    timestamp
+  rescue ArgumentError
+    nil
+  end
+
+  def valid_user_session? = Authentication::SessionLifecycle.valid_session?(user_id_session)
+
+  def user_id_session
+    session[:user_id]
+  end
+
+  private
+
+  def rotate_session
+    preserved = session.to_hash.slice(*ROTATION_PRESERVED_KEYS)
+    reset_session
+    preserved.each { |key, value| session[key] = value }
+  end
+
+  def slide_session_expiry
+    session[:user_id] = user_id_session.merge(
+      'expires_at' => [SESSION_IDLE_TIMEOUT.from_now, absolute_expires_at_time].min
+    )
+  end
+
+  def absolute_expires_at_time
+    Authentication::SessionLifecycle.normalize_timestamp(user_id_session['absolute_expires_at'])
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,8 @@ module DataPass
 
     config.active_support.to_time_preserves_timezone = :zone
 
+    config.action_dispatch.cookies_same_site_protection = :lax
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module DataPass
     config.active_support.to_time_preserves_timezone = :zone
 
     config.action_dispatch.cookies_same_site_protection = :lax
+    config.action_controller.default_protect_from_forgery = true
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/rails_pulse.rb
+++ b/config/initializers/rails_pulse.rb
@@ -50,10 +50,7 @@ RailsPulse.configure do |config|
   config.authentication_redirect_path = '/'
   config.authentication_method = proc {
     user_id_session = session[:user_id]
-    valid_session = user_id_session.present? &&
-                    user_id_session['value'].present? &&
-                    user_id_session['expires_at'].present? &&
-                    user_id_session['expires_at'] > Time.current
+    valid_session = Authentication::SessionLifecycle.valid_session?(user_id_session)
 
     current_user = valid_session ? User.find_by(id: user_id_session['value']) : nil
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -195,6 +195,7 @@ fr:
     authenticate_user:
       success:
         title: Vous êtes connecté
+      session_expired: "Votre session a expiré. Veuillez vous reconnecter."
       errors:
         banned: "Votre accès à DataPass a été suspendu. Si vous pensez qu’il s’agit d’une erreur, contactez notre support à l’adresse suivante : datapass@api.gouv.fr"
     change_current_organization:

--- a/docs/technique/authentification_proconnect.md
+++ b/docs/technique/authentification_proconnect.md
@@ -27,9 +27,13 @@ Le déroulé est le suivant :
   DataPass échange en arrière-plan contre les informations de l’agent : nom, email, et surtout
   le SIRET de l’organisation où il travaille.
 - DataPass en déduit trois choses : qui est l’agent, dans quelle organisation il travaille, et
-  si ce lien peut être considéré comme vérifié. Il ouvre alors une session valable un mois.
-- Tant que cette session est valide, l’agent navigue dans DataPass sans repasser par
-  ProConnect. À son expiration, ou après une déconnexion, le parcours complet recommence.
+  si ce lien peut être considéré comme vérifié. Il ouvre alors une session applicative courte,
+  alignée sur ProConnect.
+- La session suit un modèle **idle glissant** : chaque requête repousse l’échéance à 12 h
+  d’inactivité, sans jamais dépasser un **plafond absolu de 24 h** depuis la connexion. Au-delà —
+  12 h sans activité ou 24 h au total — ou après une déconnexion, le parcours complet recommence.
+  Cet alignement sur les 12 h de ProConnect réduit la fenêtre d’exposition (poste partagé, cookie
+  volé).
 
 Les sections suivantes détaillent l’implémentation de ce parcours.
 
@@ -121,12 +125,20 @@ Trois objets distincts en sortent : **qui** est l’agent (User, via email), **o
 (Organization, via SIRET enrichi INSEE), et le **lien de confiance** entre les deux (`verified`
 ou non, selon le FI).
 
-Le controller appelle ensuite `sign_in`, qui crée la **session applicative DataPass** :
+Le controller appelle ensuite `sign_in`, qui crée la **session applicative DataPass**. La logique
+de cycle de vie est isolée dans le concern `Authentication::SessionLifecycle` (durées, validation,
+glissement, rotation). Au login, `rotate_session` régénère l’identifiant de session (protection
+contre la *fixation de session*) tout en préservant les tokens ProConnect (`omniauth.pc.*`) et le
+chemin de retour. La session porte deux échéances : `expires_at` (12 h glissantes,
+`SESSION_IDLE_TIMEOUT`) et `absolute_expires_at` (plafond fixe 24 h, `SESSION_ABSOLUTE_TIMEOUT`) :
 
 ```ruby
+rotate_session
+
 session[:user_id] = {
   value: user.id,
-  expires_at: 1.month.from_now,
+  expires_at: SESSION_IDLE_TIMEOUT.from_now,
+  absolute_expires_at: SESSION_ABSOLUTE_TIMEOUT.from_now,
   identity_federator:,
   identity_provider_uid:,
 }
@@ -141,20 +153,24 @@ dashboard.
 ```mermaid
 flowchart TD
     A["Requête de l’agent"] --> B["before_action :authenticate_user!<br/>(concern Authentication)"]
-    B --> C{"session[:user_id] présente<br/>et non expirée (< 1 mois) ?"}
-    C -- Oui --> D["Accès autorisé<br/>ProConnect n’est pas sollicité"]
+    B --> C{"session valide ?<br/>value + expires_at (idle) + absolute_expires_at<br/>tous deux dans le futur"}
+    C -- Oui --> D["Glisse expires_at à +12 h<br/>(plafonné à absolute_expires_at)<br/>puis accès autorisé"]
     C -- Non --> E["Redirige vers la connexion<br/>relance tout le flux ProConnect"]
 ```
 
-Une fois connecté, DataPass vit sur **sa propre session** (cookie, un mois). Il ne rappelle pas
-ProConnect à chaque page. ProConnect ne sert qu’à prouver l’identité au moment du login.
+Une fois connecté, DataPass vit sur **sa propre session** (cookie chiffré, 12 h glissantes
+plafonnées à 24 h). À chaque requête authentifiée, `slide_session_expiry` repousse `expires_at` à
+12 h, borné par `absolute_expires_at`. Un ancien cookie « 1 mois » dépourvu d’`absolute_expires_at`
+est désormais considéré invalide → reconnexion douce (re-clic silencieux si la session ProConnect
+est encore active). DataPass ne rappelle pas ProConnect à chaque page ; ProConnect ne sert qu’à
+prouver l’identité au moment du login.
 
 Il y a donc **deux sessions distinctes** :
 
 - les **tokens ProConnect** (`omniauth.pc.*`) — utilisés au login et conservés surtout pour la
   déconnexion globale ;
 - la **session applicative DataPass** (`session[:user_id]`) — c’est elle qui maintient l’agent
-  connecté pendant un mois.
+  connecté tant qu’il reste actif (≤ 12 h entre deux requêtes, 24 h au total).
 
 ## Mécanismes de sécurité
 
@@ -185,6 +201,21 @@ DataPass. C’est la partie la plus subtile de `config/initializers/omniauth.rb`
 > Repères : `amr` (*Authentication Methods References*) = les méthodes d’authentification
 > employées ; `acr` (*Authentication Context Class Reference*) = le niveau de garantie atteint.
 
+**La rotation de session — empêcher la fixation de session.**
+Au moment du login (`sign_in`), DataPass régénère l’identifiant de session (`rotate_session` →
+`reset_session`) pour qu’un identifiant éventuellement connu d’un attaquant avant authentification
+ne donne aucun accès après. Les clés strictement nécessaires sont préservées : les tokens
+ProConnect (`omniauth.pc.access_token`, `id_token`, `refresh_token`, indispensables au logout
+global) et `return_to_after_sign_in`. La durée de session courte (12 h / 24 h) complète ce
+durcissement en réduisant la fenêtre d’exploitation d’un cookie volé.
+
+**La durée de session courte — réduire la fenêtre d’exposition.**
+L’ordre des contrôles dans `authenticate_user!` est volontaire : validité de session, puis
+bannissement (`BannedUserError`), puis seulement `slide_session_expiry` — pour ne jamais prolonger
+la session d’un agent banni. Limites de ce palier *stateless* (cookie store, sans store serveur) :
+pas de révocation à distance ni de « déconnecter partout », un cookie volé reste valide jusqu’à son
+expiration (12-24 h). Ces points seront traités par **DP-1790** (store serveur révocable).
+
 ## Déconnexion
 
 ```mermaid
@@ -211,7 +242,8 @@ d’organisation courante) et `update_userinfo` (rafraîchir les infos de l’ag
 ## En une phrase
 
 ProConnect prouve l’identité une fois (OIDC code flow) ; DataPass en tire trois objets — agent,
-organisation, lien de confiance — puis vit sur sa propre session d’un mois.
+organisation, lien de confiance — puis vit sur sa propre session courte (idle glissant 12 h,
+plafonné à 24 h).
 
 ## Fichiers de référence
 
@@ -223,6 +255,7 @@ organisation, lien de confiance — puis vit sur sa propre session d’un mois.
 | Bouton de connexion | `app/views/pages/shared/unauthenticated_pages/_pro_connect.html.erb` |
 | Aiguillage du callback, MFA, logout | `app/controllers/sessions_controller.rb` |
 | Session applicative (sign_in/out) | `app/controllers/concerns/authentication.rb` |
+| Cycle de vie de session (durées, glissement, rotation) | `app/controllers/concerns/authentication/session_lifecycle.rb` |
 | Organizer ProConnect | `app/organizers/authenticate_user_through_pro_connect.rb` |
 | Organisation depuis le SIRET | `app/interactors/find_or_create_organization_through_pro_connect.rb` |
 | Enrichissement INSEE | `app/interactors/update_organization_insee_payload.rb` |
@@ -244,7 +277,7 @@ organisation, lien de confiance — puis vit sur sa propre session d’un mois.
 | **Scope** | La liste des informations que DataPass a le droit de demander sur l’agent (nom, email, SIRET…). |
 | **SIRET** | Le numéro qui identifie officiellement l’organisation (l’employeur) de l’agent. DataPass s’en sert pour reconnaître l’organisation. |
 | **INSEE Sirene** | Le registre officiel des entreprises et administrations. DataPass y récupère les informations détaillées d’une organisation à partir de son SIRET. |
-| **Session** | L’état de connexion maintenu par DataPass après authentification, valable un mois, qui évite de repasser par ProConnect à chaque page. |
+| **Session** | L’état de connexion maintenu par DataPass après authentification (idle glissant 12 h, plafonné à 24 h), qui évite de repasser par ProConnect à chaque page. |
 | **MFA (double authentification)** | Une vérification supplémentaire (code sur téléphone, application…) exigée par certains fournisseurs d’identité en plus du mot de passe. |
 | **Back-channel** | Un échange direct de serveur à serveur entre DataPass et ProConnect, sans passer par le navigateur de l’agent — donc non exposé côté client. |
 | **state / nonce** | Deux identifiants aléatoires générés par DataPass pour s’assurer que la réponse reçue de ProConnect est authentique et n’est pas rejouée. |

--- a/features/session_expiree.feature
+++ b/features/session_expiree.feature
@@ -1,0 +1,15 @@
+# language: fr
+
+Fonctionnalité: Message flash lors de l'expiration de session
+  En tant qu'utilisateur dont la session a expiré
+  Je suis informé que ma session a expiré lorsque je suis redirigé vers la connexion
+
+  Scénario: Un utilisateur dont la session a expiré est redirigé avec un message d'info
+    Étant donné que je suis un demandeur
+    Et que ma session a expiré
+    Quand je me rends sur mon tableau de bord
+    Alors il y a un message d'info contenant "Votre session a expiré"
+
+  Scénario: Un visiteur anonyme est redirigé sans message d'alerte
+    Quand je me rends sur mon tableau de bord
+    Alors il n'y a pas de message d'alerte contenant "Votre session a expiré"

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -207,6 +207,14 @@ Sachantque('je suis un administrateur') do
   end
 end
 
+Sachantque('ma session a expiré') do
+  page.set_rack_session(user_id: {
+    'value' => current_user!.id,
+    'expires_at' => 1.hour.ago,
+    'absolute_expires_at' => 1.hour.ago
+  })
+end
+
 Sachantque('je me connecte') do
   steps %(
     Quand je me rends sur la page d'accueil

--- a/features/support/sessions.rb
+++ b/features/support/sessions.rb
@@ -1,3 +1,5 @@
+require 'rack_session_access/capybara'
+
 OmniAuth.config.test_mode = true
 
 OmniAuth.config.before_callback_phase do |env|

--- a/spec/controllers/concerns/authentication_spec.rb
+++ b/spec/controllers/concerns/authentication_spec.rb
@@ -226,6 +226,105 @@ RSpec.describe Authentication do
     end
   end
 
+  describe '#session_expired?' do
+    context 'when idle timeout has expired (expires_at in the past)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.hour.ago,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'returns true' do
+        expect(controller.session_expired?).to be true
+      end
+    end
+
+    context 'when absolute timeout has been reached' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 12.hours.from_now,
+          'absolute_expires_at' => 1.hour.ago
+        }
+      end
+
+      it 'returns true' do
+        expect(controller.session_expired?).to be true
+      end
+    end
+
+    context 'without absolute_expires_at (legacy cookie)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 30.days.from_now
+        }
+      end
+
+      it 'returns true' do
+        expect(controller.session_expired?).to be true
+      end
+    end
+
+    context 'when session is valid' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 6.hours.from_now,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'returns false' do
+        expect(controller.session_expired?).to be false
+      end
+    end
+
+    context 'when session[:user_id] is absent (anonymous access)' do
+      before do
+        session.delete(:user_id)
+      end
+
+      it 'returns false' do
+        expect(controller.session_expired?).to be false
+      end
+    end
+  end
+
+  describe '#authenticate_user! (non connecté)' do
+    context 'when session has expired (idle timeout)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.hour.ago,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'sets flash[:info] with session expired title and redirects to sign in' do
+        get :show
+
+        expect(flash[:info]).to include('title' => I18n.t('sessions.authenticate_user.session_expired'))
+        expect(response).to redirect_to(controller.sign_in_path)
+      end
+    end
+
+    context 'when no session[:user_id] (anonymous first access)' do
+      before do
+        session.delete(:user_id)
+      end
+
+      it 'does not set flash and redirects to sign in' do
+        get :show
+
+        expect(flash[:info]).to be_nil
+        expect(response).to redirect_to(controller.sign_in_path)
+      end
+    end
+  end
+
   describe '#authenticate_user! session sliding' do
     context 'when session is valid' do
       before do

--- a/spec/controllers/concerns/authentication_spec.rb
+++ b/spec/controllers/concerns/authentication_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Authentication do
 
     session[:user_id] = {
       'value' => user.id,
-      'expires_at' => 1.month.from_now
+      'expires_at' => 12.hours.from_now,
+      'absolute_expires_at' => 24.hours.from_now
     }
 
     session[:impersonated_user_id] = another_user.id
@@ -57,6 +58,229 @@ RSpec.describe Authentication do
 
         expect(controller.current_user).to eq(another_user)
         expect(controller.true_user).to eq(user)
+      end
+    end
+  end
+
+  describe '#sign_in' do
+    subject(:do_sign_in) do
+      controller.sign_in(
+        user,
+        identity_federator: 'proconnect',
+        identity_provider_uid: '1234'
+      )
+    end
+
+    it 'sets expires_at to approximately 12 hours from now' do
+      freeze_time do
+        do_sign_in
+
+        expires_at = session[:user_id][:expires_at] || session[:user_id]['expires_at']
+        expect(expires_at).to be_within(1.minute).of(12.hours.from_now)
+      end
+    end
+
+    it 'sets absolute_expires_at to approximately 24 hours from now' do
+      freeze_time do
+        do_sign_in
+
+        absolute_expires_at = session[:user_id][:absolute_expires_at] || session[:user_id]['absolute_expires_at']
+        expect(absolute_expires_at).to be_within(1.minute).of(24.hours.from_now)
+      end
+    end
+
+    it 'sets identity_federator and identity_provider_uid' do
+      do_sign_in
+
+      identity_federator = session[:user_id][:identity_federator] || session[:user_id]['identity_federator']
+      identity_provider_uid = session[:user_id][:identity_provider_uid] || session[:user_id]['identity_provider_uid']
+      expect(identity_federator).to eq('proconnect')
+      expect(identity_provider_uid).to eq('1234')
+    end
+
+    context 'when omniauth.pc.* keys are already in the session' do
+      before do
+        session['omniauth.pc.access_token'] = 'token_access'
+        session['omniauth.pc.id_token'] = 'token_id'
+        session['omniauth.pc.refresh_token'] = 'token_refresh'
+      end
+
+      it 'preserves omniauth.pc.* keys after session rotation' do
+        do_sign_in
+
+        expect(session['omniauth.pc.access_token']).to eq('token_access')
+        expect(session['omniauth.pc.id_token']).to eq('token_id')
+        expect(session['omniauth.pc.refresh_token']).to eq('token_refresh')
+      end
+    end
+
+    context 'when return_to_after_sign_in is present in the session' do
+      before do
+        session[:return_to_after_sign_in] = 'http://test.host/demandes/42'
+      end
+
+      it 'preserves return_to_after_sign_in after session rotation' do
+        do_sign_in
+
+        expect(session[:return_to_after_sign_in]).to eq('http://test.host/demandes/42')
+      end
+    end
+  end
+
+  describe '#valid_user_session?' do
+    context 'when idle timeout has expired' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.second.ago,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'returns false' do
+        expect(controller.valid_user_session?).to be false
+      end
+    end
+
+    context 'when absolute timeout has been reached (expires_at still in the future)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 12.hours.from_now,
+          'absolute_expires_at' => 1.second.ago
+        }
+      end
+
+      it 'returns false' do
+        expect(controller.valid_user_session?).to be false
+      end
+    end
+
+    context 'without absolute_expires_at (legacy 30-day cookie)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 30.days.from_now
+        }
+      end
+
+      it 'returns false' do
+        expect(controller.valid_user_session?).to be false
+      end
+    end
+
+    context 'when session is valid (expires_at and absolute_expires_at in the future)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 6.hours.from_now,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'returns true' do
+        expect(controller.valid_user_session?).to be true
+      end
+    end
+
+    context 'when timestamps come back from the JSON cookie as ISO8601 strings' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 6.hours.from_now.iso8601(3),
+          'absolute_expires_at' => 24.hours.from_now.iso8601(3)
+        }
+      end
+
+      it 'returns true when both are in the future' do
+        expect(controller.valid_user_session?).to be true
+      end
+    end
+
+    context 'when expires_at string from the JSON cookie is in the past' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.second.ago.iso8601(3),
+          'absolute_expires_at' => 24.hours.from_now.iso8601(3)
+        }
+      end
+
+      it 'returns false' do
+        expect(controller.valid_user_session?).to be false
+      end
+    end
+
+    context 'when a timestamp is not a parseable date' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 'garbage',
+          'absolute_expires_at' => 24.hours.from_now.iso8601(3)
+        }
+      end
+
+      it 'returns false' do
+        expect(controller.valid_user_session?).to be false
+      end
+    end
+  end
+
+  describe '#authenticate_user! session sliding' do
+    context 'when session is valid' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.hour.from_now,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'slides expires_at to approximately +12 h without touching absolute_expires_at' do
+        freeze_time do
+          absolute = session[:user_id]['absolute_expires_at']
+
+          get :show
+
+          expect(session[:user_id]['expires_at']).to be_within(1.minute).of(12.hours.from_now)
+          expect(session[:user_id]['absolute_expires_at']).to eq(absolute)
+        end
+      end
+    end
+
+    context 'when expires_at + 12 h would exceed absolute_expires_at' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.hour.from_now,
+          'absolute_expires_at' => 3.hours.from_now
+        }
+      end
+
+      it 'caps expires_at at absolute_expires_at' do
+        freeze_time do
+          absolute = session[:user_id]['absolute_expires_at']
+
+          get :show
+
+          expect(session[:user_id]['expires_at']).to eq(absolute)
+        end
+      end
+    end
+
+    context 'when user is banned' do
+      before do
+        allow(controller).to receive(:current_user).and_return(
+          instance_double(User, banned?: true)
+        )
+      end
+
+      it 'raises BannedUserError without sliding the session' do
+        original_expires_at = session[:user_id]['expires_at']
+
+        expect { controller.authenticate_user! }.to raise_error(ApplicationController::BannedUserError)
+
+        expect(session[:user_id]['expires_at']).to eq(original_expires_at)
       end
     end
   end

--- a/spec/support/controllers_helpers.rb
+++ b/spec/support/controllers_helpers.rb
@@ -3,6 +3,7 @@ module ControllersHelpers
     session[:user_id] = {
       'value' => user.id,
       'expires_at' => 1.hour.from_now,
+      'absolute_expires_at' => 1.hour.from_now
     }
   end
 end

--- a/spec/support/sessions_helpers.rb
+++ b/spec/support/sessions_helpers.rb
@@ -2,7 +2,8 @@ module SessionsHelpers
   def sign_in(user)
     page.set_rack_session(user_id: {
       'value' => user.id,
-      'expires_at' => 9001.hours.from_now
+      'expires_at' => 9001.hours.from_now,
+      'absolute_expires_at' => 9001.hours.from_now
     })
   end
 end


### PR DESCRIPTION
## Contexte

La session applicative DataPass durait **30 jours en absolu**, un outlier (×60 vs le standard) alors que ProConnect expire à 12 h **sans back-channel logout** : la durée de session DataPass est la seule protection côté service en cas de cookie volé ou de poste partagé.

Ticket : [DP-1789](https://linear.app/pole-api/issue/DP-1789/reduire-la-session-datapass-a-12-h-alignement-proconnect) (projet « Sécurité applicative », Palier 1)

## Changements

- **Session idle glissante 12 h, plafonnée à 24 h absolu** : `expires_at` glisse à chaque requête, borné par `absolute_expires_at` fixé au login
- **Rotation de session au `sign_in`** (anti-fixation), en préservant les tokens ProConnect (`omniauth.pc.*`) et la redirection post-login (`return_to_after_sign_in`)
- **Invalidation immédiate des cookies 30 j déjà émis** (pas de champ `absolute_expires_at` → invalide) → reconnexion douce via ProConnect tant que sa session vit
- **Nouveau module `Authentication::SessionLifecycle`** : durées, validation, rotation, glissement ; les timestamps relus du cookie JSON sont normalisés explicitement
- **Rails Pulse aligné** : l’initializer consomme le prédicat partagé `valid_session?` au lieu de dupliquer la validation (un cookie admin legacy gardait sinon accès à `/rails_pulse`)
- **`SameSite=Lax` rendu explicite** (déjà le défaut Rails — on fige l’intention de ne jamais passer en `Strict`, qui casserait le callback ProConnect)
- **Protection CSRF figée explicitement** (`default_protect_from_forgery = true`, déjà actif via `load_defaults 7.1` — on verrouille l’intention contre un bump ou une régression future ; les endpoints API héritant d’`ActionController::API` ne sont pas concernés)

Le check de bannissement reste **avant** le glissement : la session d’un agent banni n’est jamais prolongée.

## Comment tester

Pour ne pas attendre 12 h, raccourcir temporairement les constantes en local (sans committer) dans `app/controllers/concerns/authentication/session_lifecycle.rb` :

```ruby
SESSION_IDLE_TIMEOUT = 2.minutes
SESSION_ABSOLUTE_TIMEOUT = 5.minutes
```

Lancer le serveur, se connecter via `/local-sign-in?email=user@yopmail.com`, puis dérouler :

| Scénario | Comment | Attendu |
|---|---|---|
| Glissement | Naviguer toutes les ~60 s | On reste connecté au-delà de 2 min tant qu’il y a de l’activité |
| Idle expiré | Rester inactif 2 min, recharger | Redirection vers la connexion |
| Plafond absolu | Naviguer en continu toutes les 60 s | Déconnexion à 5 min malgré l’activité |
| Redirection post-login | Déconnecté, visiter une URL profonde, se reconnecter | Retour sur l’URL demandée, pas le dashboard |
| Rails Pulse | Login `datapass@yopmail.com`, visiter `/rails_pulse` | Accessible avec une session fraîche |

**Cookie legacy (scénario migration)** : lancer le serveur sur `develop`, se connecter, relancer sur cette branche et recharger → le vieux cookie sans `absolute_expires_at` doit rediriger vers la connexion, sans erreur 500.

Après expiration en local, il suffit de repasser par `/local-sign-in?email=…` (`bypass_login` appelle le même `sign_in`, il hérite des nouvelles durées sans modification).

**Sur sandbox (vrai ProConnect)** — ce que le bypass local ne couvre pas :
- le retour du callback OAuth pose bien la session (validation du choix `SameSite=Lax`)
- session DataPass expirée + session ProConnect vivante → re-clic « S’identifier » reconnecte silencieusement
- la déconnexion DataPass déclenche toujours le logout global ProConnect (preuve que `omniauth.pc.id_token` survit à la rotation)

## Tests

- RSpec : 2764 examples, 0 failures (11 nouveaux cas sur le cycle de vie : pose 12 h/24 h, idle expiré, plafond, cookie legacy, glissement, glissement plafonné, rotation, ban, timestamps String JSON)
- Cucumber : `features/admin/bannissements_session.feature` verte
- Rubocop : clean
