### PR TITLE
Bridge HubEE proactivité boursiers par convention (API-6938)

### DIFF
--- a/app/bridges/boursiers_dyn_bridge.rb
+++ b/app/bridges/boursiers_dyn_bridge.rb
@@ -1,0 +1,30 @@
+class BoursiersDynBridge < HubEEBaseBridge
+  PROCESS_CODE = 'ProactiviteCnousBoursiers'.freeze
+
+  def on_approve
+    create_and_store_subscription(find_or_create_organization, PROCESS_CODE)
+  end
+
+  private
+
+  def create_and_store_subscription(organization_hubee_payload, process_code)
+    subscription_hubee_payload = hubee_api_client.create_subscription(subscription_body(organization_hubee_payload, process_code))
+    authorization_request.update!(external_provider_id: subscription_hubee_payload['id'])
+  rescue HubEEAPIClient::AlreadyExistsError
+    raise unless authorization_request.external_provider_id.present? || authorization_request_reopening?
+  end
+
+  def authorization_request_reopening?
+    authorization_request.last_validated_at.present?
+  end
+
+  def local_administrator_data
+    {
+      email: authorization_request.contact_technique_email,
+      firstName: authorization_request.contact_technique_given_name,
+      lastName: authorization_request.contact_technique_family_name,
+      function: authorization_request.contact_technique_job_title,
+      phoneNumber: authorization_request.contact_technique_phone_number.gsub(/[\s.-]/, ''),
+    }
+  end
+end

--- a/app/bridges/hubee_base_bridge.rb
+++ b/app/bridges/hubee_base_bridge.rb
@@ -11,8 +11,8 @@ class HubEEBaseBridge < ApplicationBridge
       country: 'France',
       postalCode: organization_code_postal,
       territory: organization_libelle_commune,
-      email: authorization_request.administrateur_metier_email,
-      phoneNumber: authorization_request.administrateur_metier_phone_number.gsub(/[ .-]/, ''),
+      email: local_administrator_data[:email],
+      phoneNumber: local_administrator_data[:phoneNumber],
       status: 'Actif'
     }
   end
@@ -30,7 +30,7 @@ class HubEEBaseBridge < ApplicationBridge
       validateDateTime: authorization_request.last_validated_at.iso8601,
       updateDateTime: authorization_request[:updated_at].iso8601,
       status: 'Inactif',
-      email: authorization_request.administrateur_metier_email,
+      email: local_administrator_data[:email],
       localAdministrator: local_administrator_data
     }
   end

--- a/spec/bridges/boursiers_dyn_bridge_spec.rb
+++ b/spec/bridges/boursiers_dyn_bridge_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe BoursiersDynBridge do
+  subject(:perform) { described_class.new.perform(authorization_request, 'approve') }
+
+  include_context 'with mocked hubee API client'
+
+  let!(:habilitation_type) do
+    create(:habilitation_type,
+      name: 'Boursiers',
+      contact_types: ['contact_technique'],
+      blocks: [{ 'name' => 'basic_infos' }, { 'name' => 'contacts' }])
+  end
+  let(:organization) { create(:organization, siret: '21920023500014') }
+  let(:authorization_request) do
+    create(:authorization_request, :validated,
+      type: habilitation_type.authorization_request_type,
+      form_uid: habilitation_type.slug,
+      organization:,
+      external_provider_id: nil)
+  end
+  let(:organization_payload) do
+    build(:hubee_organization_payload, organization:,
+      email: 'jean.dupont.contact_technique@gouv.fr',
+      phoneNumber: '0836656565')
+  end
+  let(:subscription_response) { build(:hubee_subscription_response_payload, id: hubee_subscription_id) }
+  let(:hubee_subscription_id) { '1234567890' }
+
+  after { AuthorizationDefinition.reset! }
+
+  describe '#perform on approve' do
+    it_behaves_like 'organization creation in hubee on approve'
+
+    it 'creates a subscription linked to DataPass ID and CNOUS process code' do
+      expect(hubee_api_client).to receive(:create_subscription).with(
+        hash_including(
+          datapassId: authorization_request.id,
+          processCode: 'ProactiviteCnousBoursiers'
+        )
+      )
+
+      perform
+    end
+
+    it 'sends the contact technique as the HubEE local administrator' do
+      expect(hubee_api_client).to receive(:create_subscription).with(
+        hash_including(
+          localAdministrator: {
+            email: 'jean.dupont.contact_technique@gouv.fr',
+            firstName: 'Jean Contact technique',
+            lastName: 'Dupont Contact technique',
+            function: 'Agent Contact technique',
+            phoneNumber: '0836656565',
+          }
+        )
+      )
+
+      perform
+    end
+
+    it 'stores the HubEE subscription id as external_provider_id' do
+      perform
+
+      expect(authorization_request.reload.external_provider_id).to eq(hubee_subscription_id)
+    end
+
+    context 'when HubEE raises AlreadyExistsError on a reopening' do
+      let(:authorization_request) do
+        create(:authorization_request, :reopened,
+          type: habilitation_type.authorization_request_type,
+          form_uid: habilitation_type.slug,
+          organization:)
+      end
+
+      before do
+        allow(hubee_api_client).to receive(:create_subscription).and_raise(HubEEAPIClient::AlreadyExistsError)
+      end
+
+      it 'does not raise an error' do
+        expect { perform }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/interactors/execute_authorization_request_bridge_spec.rb
+++ b/spec/interactors/execute_authorization_request_bridge_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe ExecuteAuthorizationRequestBridge do
+  subject(:execute) { described_class.call(authorization_request:, state_machine_event: :approve) }
+
+  describe 'static forms resolved by naming convention' do
+    {
+      hubee_cert_dc: HubEECertDCBridge,
+      hubee_dila: HubEEDilaBridge,
+      api_captchetat: APICaptchEtatBridge,
+    }.each do |trait, bridge_class|
+      context "with a #{trait} authorization request" do
+        let(:authorization_request) { build(:authorization_request, trait) }
+
+        it "enqueues #{bridge_class}" do
+          expect(bridge_class).to receive(:perform_later).with(authorization_request, :approve)
+
+          execute
+        end
+      end
+    end
+
+    context 'with a static form without bridge' do
+      let(:authorization_request) { build(:authorization_request, :api_entreprise) }
+
+      it 'enqueues nothing and succeeds' do
+        expect { execute }.not_to have_enqueued_job
+
+        expect(execute).to be_a_success
+      end
+    end
+  end
+
+  describe 'dynamic forms resolved by naming convention' do
+    after { AuthorizationDefinition.reset! }
+
+    context 'when the dynamic class has a conventionally named bridge' do
+      let!(:habilitation_type) { create(:habilitation_type, name: 'Boursiers') }
+      let(:authorization_request) { AuthorizationRequest.const_get(habilitation_type.uid.classify).new }
+
+      it 'enqueues the matching bridge' do
+        expect(BoursiersDynBridge).to receive(:perform_later).with(authorization_request, :approve)
+
+        execute
+      end
+    end
+
+    context 'when the dynamic class has no matching bridge' do
+      let!(:habilitation_type) { create(:habilitation_type) }
+      let(:authorization_request) { AuthorizationRequest.const_get(habilitation_type.uid.classify).new }
+
+      it 'enqueues nothing and succeeds' do
+        expect { execute }.not_to have_enqueued_job
+
+        expect(execute).to be_a_success
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Le formulaire **proactivité boursiers** (premier formulaire dynamique via `HabilitationType`, classe runtime `AuthorizationRequest::BoursiersDyn`) ne déclenchait aucune création organisation + subscription chez HubEE à la validation : le dispatch (`ExecuteAuthorizationRequestBridge`) résout le bridge par **convention de nom** (`Kernel.const_get("#{class}Bridge")`) et personne n’avait écrit le bridge correspondant → **no-op silencieux** (incident H551, cf. API-6938).

## Décision (revue PR)

La première version passait par un mécanisme déclaratif en base (colonnes `bridge_class_name` / `bridge_config` sur `habilitation_types`, résolution par configuration — API-6939). En revue, un seul type HubEE est concerné : la **convention suffit et reste le rails-way**. Le mécanisme en base est **abandonné** (convention over configuration), API-6939 repasse en dette avec follow-up daté. Cette PR implémente donc directement le branchement (API-6938).

## Changements

- **`BoursiersDynBridge`** (`app/bridges/`) : écrit à la main sur le modèle des bridges HubEE existants, résolu **tel quel** par le dispatch existant — aucun changement au dispatch, aucune colonne, aucune migration. `on_approve` crée/active l’organisation et la subscription HubEE avec le processCode `ProactiviteCnousBoursiers`, stocke `external_provider_id`, idempotent sur réouverture (`AlreadyExistsError`).
- **localAdministrator = contact technique** : le formulaire boursiers n’expose pas `administrateur_metier` (seulement `contact_technique`). Le bridge override `local_administrator_data` vers les champs `contact_technique_*` (décision 1 API-6938).
- **Seam `local_administrator_data` dans `HubEEBaseBridge`** : les champs email/téléphone du payload organisation passent désormais par `local_administrator_data`, pour qu’un override unique redirige toute la source du contact. Comportement inchangé pour CertDC / Dila (la méthode renvoie toujours `administrateur_metier_*` pour eux).

## Tests

- `spec/bridges/boursiers_dyn_bridge_spec.rb` : création organisation, subscription au processCode `ProactiviteCnousBoursiers`, localAdministrator dérivé du contact technique, stockage `external_provider_id`, idempotence réouverture.
- `spec/interactors/execute_authorization_request_bridge_spec.rb` (le dispatch n’avait aucune spec) : régression statique (CertDC / Dila / CaptchEtat → bridge enqueued, type sans bridge → no-op) **et** dynamique — un formulaire DB dont la classe runtime a un bridge homonyme (`BoursiersDyn` → `BoursiersDynBridge`) est bien enqueued par convention (clôt le no-op H551), sans bridge homonyme → no-op.

110 exemples verts sur les suites liées (bridges, interactor dispatch, organizers approve/revoke, HubEE client, registrar dynamique), rubocop clean.

## Reste à faire (API-6938, hors code)

- Confirmer le processCode + autorisation client HubEE (gate externe).
- Déclarer / vérifier le contact technique comme destinataire localAdministrator (question prod : qui reçoit l’invitation portail commune), email `+1@` en staging.
- Rejeu H551 en staging + vérif subscription côté HubEE sandbox.

## Linear

https://linear.app/pole-api/issue/API-6938/bridge-hubee-pour-le-formulaire-proactivite-dynamique-org-subscription
