### PR TITLE
Résout le bridge HubEE par bloc plutôt que par nom de classe (API-6938)

### DIFF
--- a/app/bridges/hubee_proactivite_bridge.rb
+++ b/app/bridges/hubee_proactivite_bridge.rb
@@ -1,4 +1,4 @@
-class BoursiersDynBridge < HubEEBaseBridge
+class HubEEProactiviteBridge < HubEEBaseBridge
   PROCESS_CODE = 'ProactiviteCnousBoursiers'.freeze
 
   def on_approve

--- a/app/interactors/execute_authorization_request_bridge.rb
+++ b/app/interactors/execute_authorization_request_bridge.rb
@@ -1,20 +1,35 @@
 class ExecuteAuthorizationRequestBridge < ApplicationInteractor
+  BLOCK_BRIDGES = {
+    'cnous_data_extraction_criteria' => HubEEProactiviteBridge,
+  }.freeze
+
   def call
-    return unless bridge_exists?
+    bridge = conventional_bridge || block_bridge
+    return if bridge.nil?
 
     bridge.perform_later(context.authorization_request, context.state_machine_event)
   end
 
   private
 
-  def bridge_exists?
-    bridge.present?
-  end
-
-  def bridge
+  def conventional_bridge
     Kernel.const_get(:"#{authorization_request_class}Bridge")
   rescue NameError
     nil
+  end
+
+  def block_bridge
+    BLOCK_BRIDGES[block_name_with_bridge]
+  end
+
+  def block_name_with_bridge
+    (definition_block_names & BLOCK_BRIDGES.keys).first
+  end
+
+  def definition_block_names
+    context.authorization_request.definition.blocks.filter_map do |block|
+      block.is_a?(Hash) ? (block[:name] || block['name']) : block
+    end
   end
 
   def authorization_request_class

--- a/spec/bridges/hubee_proactivite_bridge_spec.rb
+++ b/spec/bridges/hubee_proactivite_bridge_spec.rb
@@ -1,13 +1,13 @@
-RSpec.describe BoursiersDynBridge do
+RSpec.describe HubEEProactiviteBridge do
   subject(:perform) { described_class.new.perform(authorization_request, 'approve') }
 
   include_context 'with mocked hubee API client'
 
   let!(:habilitation_type) do
     create(:habilitation_type,
-      name: 'Boursiers',
+      name: 'Test proactividad',
       contact_types: ['contact_technique'],
-      blocks: [{ 'name' => 'basic_infos' }, { 'name' => 'contacts' }])
+      blocks: [{ 'name' => 'basic_infos' }, { 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }])
   end
   let(:organization) { create(:organization, siret: '21920023500014') }
   let(:authorization_request) do
@@ -25,7 +25,15 @@ RSpec.describe BoursiersDynBridge do
   let(:subscription_response) { build(:hubee_subscription_response_payload, id: hubee_subscription_id) }
   let(:hubee_subscription_id) { '1234567890' }
 
-  after { AuthorizationDefinition.reset! }
+  before do
+    AuthorizationDefinition.reset!
+    AuthorizationRequestForm.reset!
+  end
+
+  after do
+    AuthorizationDefinition.reset!
+    AuthorizationRequestForm.reset!
+  end
 
   describe '#perform on approve' do
     it_behaves_like 'organization creation in hubee on approve'

--- a/spec/interactors/execute_authorization_request_bridge_spec.rb
+++ b/spec/interactors/execute_authorization_request_bridge_spec.rb
@@ -29,21 +29,34 @@ RSpec.describe ExecuteAuthorizationRequestBridge do
     end
   end
 
-  describe 'dynamic forms resolved by naming convention' do
-    after { AuthorizationDefinition.reset! }
+  describe 'dynamic forms resolved by their blocks' do
+    before do
+      AuthorizationDefinition.reset!
+      AuthorizationRequestForm.reset!
+    end
 
-    context 'when the dynamic class has a conventionally named bridge' do
-      let!(:habilitation_type) { create(:habilitation_type, name: 'Boursiers') }
+    after do
+      AuthorizationDefinition.reset!
+      AuthorizationRequestForm.reset!
+    end
+
+    context 'when the form carries the CNOUS proactivité block, whatever its name' do
+      let!(:habilitation_type) do
+        create(:habilitation_type,
+          name: 'Test proactividad',
+          blocks: [{ 'name' => 'basic_infos' }, { 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }],
+          contact_types: ['contact_technique'])
+      end
       let(:authorization_request) { AuthorizationRequest.const_get(habilitation_type.uid.classify).new }
 
-      it 'enqueues the matching bridge' do
-        expect(BoursiersDynBridge).to receive(:perform_later).with(authorization_request, :approve)
+      it 'enqueues the HubEE proactivité bridge regardless of the class name' do
+        expect(HubEEProactiviteBridge).to receive(:perform_later).with(authorization_request, :approve)
 
         execute
       end
     end
 
-    context 'when the dynamic class has no matching bridge' do
+    context 'when the form does not carry a block tied to a bridge' do
       let!(:habilitation_type) { create(:habilitation_type) }
       let(:authorization_request) { AuthorizationRequest.const_get(habilitation_type.uid.classify).new }
 


### PR DESCRIPTION
## Contexte

PR #1626 a branché la proactivité boursiers sur HubEE **par convention de nom de classe** (`AuthorizationRequest::BoursiersDyn` → `BoursiersDynBridge`). En pratique ce couplage slug ↔ nom de classe est trop fragile : sur staging le `HabilitationType` s’appelle « Test proactividad » (slug `test-proactividad-dyn` → classe `TestProactividadDyn` → bridge inexistant) et n’était donc **pas branché** — aucune subscription HubEE, silencieusement (mode de défaillance H551). Le formulaire prod aura encore un autre slug.

L’hypothèse « un seul type, nom stable » qui justifiait la convention ne tient pas : ces formulaires sont nommés librement par les admins. Ils se définissent par leur **bloc**, pas par leur nom.

## Changement

`ExecuteAuthorizationRequestBridge` résout le bridge depuis les **blocs** du formulaire (après la convention de nom, conservée pour les formulaires statiques) :

```ruby
BLOCK_BRIDGES = { 'cnous_data_extraction_criteria' => HubEEProactiviteBridge }.freeze
```

Tout formulaire portant `cnous_data_extraction_criteria` est branché sur HubEE, **quel que soit son nom**. La lecture passe par `definition.blocks` (délégué à travers le décorateur Draper de l’AR côté instruction). `BoursiersDynBridge` → `HubEEProactiviteBridge`, nommé d’après la démarche, cohérent avec la famille `HubEE*Bridge`.

processCode unique confirmé (`ProactiviteCnousBoursiers`) → pas de config par formulaire, le bloc suffit.

## Tests

- `spec/interactors/execute_authorization_request_bridge_spec.rb` : un formulaire dynamique nommé « Test proactividad » portant le bloc → `HubEEProactiviteBridge` enqueued **indépendamment du nom de classe** ; sans bloc tié à un bridge → no-op ; régression statique conservée (CertDC / Dila / CaptchEtat).
- `spec/bridges/hubee_proactivite_bridge_spec.rb` : comportement du bridge inchangé (subscription `ProactiviteCnousBoursiers`, localAdministrator dérivé du contact technique, stockage `external_provider_id`, idempotence réouverture).

97 exemples verts (bridges, interactor dispatch, organizers approve/revoke, registrar dynamique), rubocop clean.

## Suites

- Le formulaire staging « Test proactividad » sera branché dès cette PR mergée (il porte déjà le bloc).
- Reste à faire côté API-6938 : confirmer processCode + autorisation client HubEE, rejeu H551 staging, question prod du destinataire localAdministrator.
