### PR TITLE
Corrige la suppression sans effet d’une ligne de droit utilisateur

### DIFF
--- a/app/components/molecules/instruction/user_rights/right_field_component.html.erb
+++ b/app/components/molecules/instruction/user_rights/right_field_component.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="fr-fieldset nested-fields fr-grid-row fr-grid-row--gutters fr-grid-row--bottom fr-mb-2w">
+<fieldset class="fr-fieldset nested-fields fr-grid-row fr-grid-row--gutters fr-grid-row--bottom fr-mb-2w" data-new-record="true">
   <legend class="fr-sr-only"><%= legend_label %></legend>
   <div class="fr-col-12 fr-col-md-5">
     <div class="fr-select-group">


### PR DESCRIPTION
La fieldset du RightFieldComponent ne portait pas data-new-record="true". Le NestedFormController de stimulus-library s’en sert pour décider, au clic sur la corbeille, entre retirer la ligne du DOM (data-new-record="true") et la masquer en marquant un champ _destroy. Sans cet attribut, la ligne était seulement masquée : ses selects (scope, role_type) restaient soumis, donc UserRightForm reconstruisait la même liste de rôles et le droit n’était jamais supprimé.