### PR TITLE
DP-1806 — Flash « session expirée » à la redirection vers la connexion

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -58,13 +58,18 @@ module Authentication
       return
     end
 
-    session[:return_to_after_sign_in] = request.url
-    redirect_to sign_in_path
+    redirect_to_sign_in
   end
 
   def user_signed_in?
     valid_user_session? &&
       current_user.present?
+  end
+
+  def redirect_to_sign_in
+    info_message(title: t('sessions.authenticate_user.session_expired')) if session_expired?
+    save_redirect_path
+    redirect_to sign_in_path
   end
 
   def save_redirect_path

--- a/app/controllers/concerns/authentication/session_lifecycle.rb
+++ b/app/controllers/concerns/authentication/session_lifecycle.rb
@@ -31,6 +31,10 @@ module Authentication::SessionLifecycle
 
   def valid_user_session? = Authentication::SessionLifecycle.valid_session?(user_id_session)
 
+  def session_expired?
+    user_id_session.present? && !valid_user_session?
+  end
+
   def user_id_session
     session[:user_id]
   end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -195,6 +195,7 @@ fr:
     authenticate_user:
       success:
         title: Vous êtes connecté
+      session_expired: "Votre session a expiré. Veuillez vous reconnecter."
       errors:
         banned: "Votre accès à DataPass a été suspendu. Si vous pensez qu’il s’agit d’une erreur, contactez notre support à l’adresse suivante : datapass@api.gouv.fr"
     change_current_organization:

--- a/features/session_expiree.feature
+++ b/features/session_expiree.feature
@@ -1,0 +1,15 @@
+# language: fr
+
+Fonctionnalité: Message flash lors de l'expiration de session
+  En tant qu'utilisateur dont la session a expiré
+  Je suis informé que ma session a expiré lorsque je suis redirigé vers la connexion
+
+  Scénario: Un utilisateur dont la session a expiré est redirigé avec un message d'info
+    Étant donné que je suis un demandeur
+    Et que ma session a expiré
+    Quand je me rends sur mon tableau de bord
+    Alors il y a un message d'info contenant "Votre session a expiré"
+
+  Scénario: Un visiteur anonyme est redirigé sans message d'alerte
+    Quand je me rends sur mon tableau de bord
+    Alors il n'y a pas de message d'alerte contenant "Votre session a expiré"

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -207,6 +207,14 @@ Sachantque('je suis un administrateur') do
   end
 end
 
+Sachantque('ma session a expiré') do
+  page.set_rack_session(user_id: {
+    'value' => current_user!.id,
+    'expires_at' => 1.hour.ago,
+    'absolute_expires_at' => 1.hour.ago
+  })
+end
+
 Sachantque('je me connecte') do
   steps %(
     Quand je me rends sur la page d'accueil

--- a/features/support/sessions.rb
+++ b/features/support/sessions.rb
@@ -1,3 +1,5 @@
+require 'rack_session_access/capybara'
+
 OmniAuth.config.test_mode = true
 
 OmniAuth.config.before_callback_phase do |env|

--- a/spec/controllers/concerns/authentication_spec.rb
+++ b/spec/controllers/concerns/authentication_spec.rb
@@ -226,6 +226,105 @@ RSpec.describe Authentication do
     end
   end
 
+  describe '#session_expired?' do
+    context 'when idle timeout has expired (expires_at in the past)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.hour.ago,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'returns true' do
+        expect(controller.session_expired?).to be true
+      end
+    end
+
+    context 'when absolute timeout has been reached' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 12.hours.from_now,
+          'absolute_expires_at' => 1.hour.ago
+        }
+      end
+
+      it 'returns true' do
+        expect(controller.session_expired?).to be true
+      end
+    end
+
+    context 'without absolute_expires_at (legacy cookie)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 30.days.from_now
+        }
+      end
+
+      it 'returns true' do
+        expect(controller.session_expired?).to be true
+      end
+    end
+
+    context 'when session is valid' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 6.hours.from_now,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'returns false' do
+        expect(controller.session_expired?).to be false
+      end
+    end
+
+    context 'when session[:user_id] is absent (anonymous access)' do
+      before do
+        session.delete(:user_id)
+      end
+
+      it 'returns false' do
+        expect(controller.session_expired?).to be false
+      end
+    end
+  end
+
+  describe '#authenticate_user! (non connecté)' do
+    context 'when session has expired (idle timeout)' do
+      before do
+        session[:user_id] = {
+          'value' => user.id,
+          'expires_at' => 1.hour.ago,
+          'absolute_expires_at' => 24.hours.from_now
+        }
+      end
+
+      it 'sets flash[:info] with session expired title and redirects to sign in' do
+        get :show
+
+        expect(flash[:info]).to include('title' => I18n.t('sessions.authenticate_user.session_expired'))
+        expect(response).to redirect_to(controller.sign_in_path)
+      end
+    end
+
+    context 'when no session[:user_id] (anonymous first access)' do
+      before do
+        session.delete(:user_id)
+      end
+
+      it 'does not set flash and redirects to sign in' do
+        get :show
+
+        expect(flash[:info]).to be_nil
+        expect(response).to redirect_to(controller.sign_in_path)
+      end
+    end
+  end
+
   describe '#authenticate_user! session sliding' do
     context 'when session is valid' do
       before do


### PR DESCRIPTION
## Contexte

Follow-up de DP-1789 (réduction de session 12 h idle / 24 h plafond). Les déconnexions devenant bien plus fréquentes, un agent renvoyé vers la connexion sans explication risque d’être désorienté → charge de support évitable.

⚠️ **Base = `feature/dp-1789`** (pas encore mergée). À rebaser/merger sur develop une fois DP-1789 intégrée.

Linear : https://linear.app/pole-api/issue/DP-1806

## Ce que fait la PR

Pose un flash `:info` « Votre session a expiré. Veuillez vous reconnecter. » quand `authenticate_user!` redirige une **session expirée** vers la connexion.

- Détection via le prédicat `session_expired?` (`SessionLifecycle`) = `user_id_session.present? && !valid_user_session?` — couvre idle 12 h, plafond 24 h, et cookie ancien format sans `absolute_expires_at`.
- **Pas** de flash sur premier accès anonyme (`session[:user_id]` absent) ni après logout volontaire (`sign_out` fait `session.delete(:user_id)`).
- Message unique et neutre (décision PO). Type `:info`.
- Rendu par l’alerte DSFR partagée (`shared/_alerts` → `FlashAlertComponent` → `dsfr_alert`, `.fr-alert--info`). Aucune vue/layout modifié : la home passe par le layout `container` qui rend déjà `shared/alerts`. Pattern identique à `reject_banned_user`.

## Tests automatisés

- RSpec : +7 (5 cas `session_expired?` + 2 cas `authenticate_user!` non connecté) — 24/24 verts.
- Cucumber : `features/session_expiree.feature` (expiration → message / anonyme → rien) — 2/2 verts.
- Rubocop propre.


<img width="3016" height="1970" alt="Capture d’écran 2026-06-17 à 14 48 29" src="https://github.com/user-attachments/assets/06518f53-d7dc-4b73-bb35-54c499b9a4d4" />


## Test manuel

La session expire à 12 h : pour la tester rapidement, abaisser temporairement le timeout idle.

1. Dans `app/controllers/concerns/authentication/session_lifecycle.rb`, mettre `SESSION_IDLE_TIMEOUT = 10.seconds` (à ne pas committer).
2. Lancer le serveur, puis se connecter : `/local-sign-in?email=user@yopmail.com`.
3. Attendre ~11 s **sans aucune requête** (chaque requête repousse l’échéance via `slide_session_expiry`), puis recharger une page protégée (ex. le tableau de bord) → redirigé vers l’accueil avec le bandeau info **« Votre session a expiré. Veuillez vous reconnecter. »**
4. Cas négatifs :
   - fenêtre privée (jamais connecté) → page protégée → redirigé **sans** bandeau ;
   - se reconnecter puis **déconnexion volontaire** → **pas** de bandeau.
5. Remettre `SESSION_IDLE_TIMEOUT = 12.hours`.

## Revue

Audit `code-reviewer` : 0 bloquant. Retouche appliquée (`redirect_to sign_in_path` au lieu de `root_path`).