### PR TITLE
Update MFA_ACR_VALUES in OmniAuth Proconnect

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -40,10 +40,10 @@ module OmniAuth
   module Strategies
     class Proconnect
       MFA_ACR_VALUES = [
+        'eidas0-mfa',
+        'eidas1-mfa',
         'eidas2',
-        'eidas3',
-        'https://proconnect.gouv.fr/assurance/self-asserted-2fa',
-        'https://proconnect.gouv.fr/assurance/consistency-checked-2fa'
+        'eidas3'
       ].freeze
 
       def self.authorization_uri_with_mfa(session:, login_hint:)


### PR DESCRIPTION
ACR values has evolved in ProConnect.

See https://github.com/proconnect-gouv/proconnect-espace-partenaires/pull/352