### PR TITLE
Display a definition

### DIFF
--- a/app/assets/stylesheets/components/authorization_definition_action_btn.css
+++ b/app/assets/stylesheets/components/authorization_definition_action_btn.css
@@ -1,0 +1,4 @@
+.authorization-definition-action-btn {
+  width: 100%;
+  justify-content: center;
+}

--- a/app/assets/stylesheets/components/config_block.css
+++ b/app/assets/stylesheets/components/config_block.css
@@ -1,0 +1,52 @@
+.config-block {
+  border: 1px solid var(--border-default-grey);
+  border-left: 4px solid var(--border-plain-blue-france);
+  background: var(--background-default-grey);
+}
+
+.config-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: var(--background-alt-blue-france);
+  border-bottom: 1px solid var(--border-default-grey);
+}
+
+.config-block__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-title-grey);
+}
+
+.config-block__title .fr-icon-settings-5-line {
+  color: var(--text-action-high-blue-france);
+}
+
+.config-block__body {
+  padding: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.config-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  max-width: 100%;
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  color: var(--text-default-grey);
+  background: var(--background-default-grey);
+  border: 1px solid var(--border-default-grey);
+  border-radius: 0.25rem;
+  padding: 0.5rem 1rem;
+}
+
+.config-chip__value {
+  font-weight: 500;
+  color: var(--text-title-grey);
+}

--- a/app/components/atoms/action_card_component.html.erb
+++ b/app/components/atoms/action_card_component.html.erb
@@ -1,0 +1,17 @@
+<div class="fr-card fr-enlarge-link actions-block__card">
+  <div class="fr-card__body">
+    <div class="fr-card__content">
+      <h3 class="fr-card__title">
+        <%= link_to title, link %>
+      </h3>
+      <p class="fr-card__desc"><%= description %></p>
+      <% if detail %>
+        <div class="fr-card__end">
+          <p class="<%= detail_classes %>">
+            <%= detail %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/atoms/action_card_component.rb
+++ b/app/components/atoms/action_card_component.rb
@@ -1,0 +1,19 @@
+class Atoms::ActionCardComponent < ApplicationComponent
+  def initialize(title:, description:, link:, detail: nil, icon: nil)
+    @title = title
+    @description = description
+    @link = link
+    @detail = detail
+    @icon = icon
+  end
+
+  private
+
+  attr_reader :title, :description, :link, :detail, :icon
+
+  def detail_classes
+    classes = ['fr-card__detail']
+    classes << icon if icon
+    classes.join(' ')
+  end
+end

--- a/app/components/molecules/instruction/authorization_definition/card_component.html.erb
+++ b/app/components/molecules/instruction/authorization_definition/card_component.html.erb
@@ -9,23 +9,14 @@
         <% end %>
         <div class="fr-col">
           <h2 class="fr-card__title">
-            <%= link_to name_with_stage, '#' %>
+            <%= link_to name_with_stage, instruction_authorization_definition_path(authorization_definition.id) %>
           </h2>
           <p class="fr-card__desc"><%= provider.name %></p>
         </div>
       </div>
     </div>
     <div class="fr-card__footer">
-      <div class="fr-grid-row fr-grid-row--gutters">
-        <div class="fr-col-auto">
-          <span><%= validated_count %></span>
-          <span class="fr-badge fr-badge--sm fr-badge--success fr-badge--no-icon"><%= t('authorization_request.status.validated') %></span>
-        </div>
-        <div class="fr-col-auto">
-          <span><%= submitted_count %></span>
-          <span class="fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon"><%= t('authorization_request.status.submitted') %></span>
-        </div>
-      </div>
+      <%= render 'instruction/authorization_definitions/counts', validated_count:, submitted_count: %>
     </div>
   </div>
 </div>

--- a/app/components/molecules/instruction/authorization_definition/config_block_component.html.erb
+++ b/app/components/molecules/instruction/authorization_definition/config_block_component.html.erb
@@ -1,0 +1,20 @@
+<div class="config-block">
+  <div class="config-block__header">
+    <div class="config-block__title">
+      <span class="fr-icon-settings-5-line fr-icon--sm" aria-hidden="true"></span>
+      <h2 class="fr-h6 fr-mb-0"><%= t('instruction.authorization_definitions.show.config_block.title') %></h2>
+    </div>
+  </div>
+
+  <div class="config-block__body">
+    <%= render_kind_chip if kind.present? %>
+    <%= render_boolean_chip('fields.startable_by_applicant', startable_by_applicant) %>
+    <%= render_boolean_chip('fields.unique', unique) %>
+    <%= render_boolean_chip('features.messaging', feature_enabled?(:messaging)) %>
+    <%= render_boolean_chip('features.transfer', feature_enabled?(:transfer)) %>
+    <%= render_boolean_chip('features.instructor_drafts', feature_enabled?(:instructor_drafts)) %>
+    <%= render_boolean_chip('features.reopening', feature_enabled?(:reopening)) %>
+    <%= render_support_email_chip if support_email.present? %>
+    <%= render_access_link_chip if access_link.present? %>
+  </div>
+</div>

--- a/app/components/molecules/instruction/authorization_definition/config_block_component.rb
+++ b/app/components/molecules/instruction/authorization_definition/config_block_component.rb
@@ -1,0 +1,47 @@
+class Molecules::Instruction::AuthorizationDefinition::ConfigBlockComponent < ApplicationComponent
+  def initialize(authorization_definition:)
+    @authorization_definition = authorization_definition
+  end
+
+  private
+
+  attr_reader :authorization_definition
+
+  def kind_label
+    I18n.t("activerecord.attributes.habilitation_type/kind/values.#{authorization_definition.kind}", default: authorization_definition.kind)
+  end
+
+  def boolean_label(value)
+    value ? I18n.t('instruction.authorization_definitions.show.config_block.true') : I18n.t('instruction.authorization_definitions.show.config_block.false')
+  end
+
+  def feature_enabled?(feature)
+    authorization_definition.feature?(feature)
+  end
+
+  def render_chip(key, &)
+    render Molecules::Instruction::AuthorizationDefinition::ConfigChipComponent.new(
+      label: t("instruction.authorization_definitions.show.config_block.#{key}")
+    ) do |chip|
+      chip.with_value(&)
+    end
+  end
+
+  def render_boolean_chip(key, value)
+    render_chip(key) { tag.span(boolean_label(value), class: 'config-chip__value') }
+  end
+
+  def render_kind_chip
+    render_chip('fields.kind') { tag.code(kind_label, class: 'fr-code-inline') }
+  end
+
+  def render_support_email_chip
+    render_chip('fields.support_email') { mail_to(support_email, support_email, class: 'fr-link') }
+  end
+
+  def render_access_link_chip
+    render_chip('fields.access_link') { tag.code(access_link, class: 'fr-code-inline') }
+  end
+
+  delegate :kind, :startable_by_applicant, :unique, :access_link, :support_email, to: :authorization_definition
+end

--- a/app/components/molecules/instruction/authorization_definition/config_chip_component.html.erb
+++ b/app/components/molecules/instruction/authorization_definition/config_chip_component.html.erb
@@ -1,0 +1,4 @@
+<span class="config-chip">
+  <span class="config-chip__label"><%= label %> :</span>
+  <%= value %>
+</span>

--- a/app/components/molecules/instruction/authorization_definition/config_chip_component.rb
+++ b/app/components/molecules/instruction/authorization_definition/config_chip_component.rb
@@ -1,0 +1,11 @@
+class Molecules::Instruction::AuthorizationDefinition::ConfigChipComponent < ApplicationComponent
+  renders_one :value
+
+  def initialize(label:)
+    @label = label
+  end
+
+  private
+
+  attr_reader :label
+end

--- a/app/components/molecules/instruction/wide_header.html.erb
+++ b/app/components/molecules/instruction/wide_header.html.erb
@@ -8,20 +8,28 @@
       </div>
     <% end %>
 
-    <div class="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
-      <div class="fr-col-auto">
-        <% if logo_asset&.attached? %>
-          <%= image_tag logo_asset, alt: title, class: 'wide-header-logo' %>
-        <% elsif dsfr_logo %>
-          <%= dsfr_pictogram(dsfr_logo) %>
-        <% end %>
+    <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+      <div class="fr-grid-row fr-grid-row--top fr-grid-row--gutters fr-col">
+        <div class="fr-col-auto">
+          <% if logo_asset&.attached? %>
+            <%= image_tag logo_asset, alt: '', class: 'wide-header-logo' %>
+          <% elsif dsfr_logo %>
+            <%= dsfr_pictogram(dsfr_logo) %>
+          <% end %>
+        </div>
+        <div class="fr-col">
+          <h1 class="fr-mb-1v">
+            <%= title %>
+          </h1>
+          <%= subtitle_content %>
+        </div>
       </div>
-      <div class="fr-col">
-        <h1 class="fr-mb-1v">
-          <%= title %>
-        </h1>
-        <%= subtitle_content %>
-      </div>
+
+      <% if right_content %>
+        <div class="fr-col-auto">
+          <%= right_content %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/components/molecules/instruction/wide_header.rb
+++ b/app/components/molecules/instruction/wide_header.rb
@@ -1,5 +1,6 @@
 class Molecules::Instruction::WideHeader < ApplicationComponent
   renders_one :subtitle_content
+  renders_one :right_content
 
   def initialize(title:, logo_asset: nil, dsfr_logo: nil, back_link: nil)
     @title = title

--- a/app/controllers/instruction/authorization_definitions_controller.rb
+++ b/app/controllers/instruction/authorization_definitions_controller.rb
@@ -5,6 +5,12 @@ class Instruction::AuthorizationDefinitionsController < Instruction::FormManagem
     @counts_by_definition = preload_counts(@authorization_definitions)
   end
 
+  def show
+    @authorization_definition = AuthorizationDefinition.find(params.expect(:id))
+    authorize [:instruction, @authorization_definition], :show?
+    @counts = preload_counts([@authorization_definition])[@authorization_definition.id]
+  end
+
   private
 
   def accessible_definitions

--- a/app/controllers/instruction/instructor_draft_requests_controller.rb
+++ b/app/controllers/instruction/instructor_draft_requests_controller.rb
@@ -99,7 +99,7 @@ class Instruction::InstructorDraftRequestsController < InstructionController
 
   def extract_available_definitions
     @definitions = current_user.authorization_definition_roles_as(:instructor)
-      .select { |definition| definition.feature?('instructor_drafts', default: false) }
+      .select(&:instructor_drafts_enabled?)
   end
 
   def instructor_draft_request_params

--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -96,6 +96,10 @@ class AuthorizationDefinition < StaticApplicationRecord
     features.fetch(name.to_sym, default)
   end
 
+  def instructor_drafts_enabled?
+    feature?(:instructor_drafts, default: false)
+  end
+
   def need_homologation?
     %w[api_entreprise api_particulier].include?(id)
   end

--- a/app/models/concerns/user_roles.rb
+++ b/app/models/concerns/user_roles.rb
@@ -35,6 +35,10 @@ module UserRoles
     roles_for(:developer).any?
   end
 
+  alias can_read? reporter?
+  alias can_manage? manager?
+  alias can_instruct? instructor?
+
   def definition_ids_for(kind)
     roles_for(kind).definition_ids
   end

--- a/app/policies/instruction/authorization_definition_policy.rb
+++ b/app/policies/instruction/authorization_definition_policy.rb
@@ -2,4 +2,13 @@ class Instruction::AuthorizationDefinitionPolicy < ApplicationPolicy
   def index?
     user.reporter?
   end
+
+  def show?
+    user.can_read?(record.id)
+  end
+
+  def initiate_request?
+    record.instructor_drafts_enabled? &&
+      user.can_instruct?(record.authorization_request_type)
+  end
 end

--- a/app/policies/instruction/instructor_draft_request_policy.rb
+++ b/app/policies/instruction/instructor_draft_request_policy.rb
@@ -38,9 +38,7 @@ class Instruction::InstructorDraftRequestPolicy < ApplicationPolicy
   private
 
   def authorization_definitions_with_instructor_draft_feature
-    AuthorizationDefinition.all.select do |definition|
-      definition.feature?('instructor_drafts', default: false)
-    end
+    AuthorizationDefinition.all.select(&:instructor_drafts_enabled?)
   end
 
   class Scope < Scope

--- a/app/services/skip_links_implemented_checker.rb
+++ b/app/services/skip_links_implemented_checker.rb
@@ -88,6 +88,7 @@ class SkipLinksImplementedChecker
     instruction/user_rights#update
 
     instruction/authorization_definitions#index
+    instruction/authorization_definitions#show
 
     admin#index
     admin/user_rights#index

--- a/app/views/instruction/authorization_definitions/_counts.html.erb
+++ b/app/views/instruction/authorization_definitions/_counts.html.erb
@@ -1,0 +1,10 @@
+<div class="fr-grid-row fr-grid-row--gutters">
+  <div class="fr-col-auto fr-grid-row fr-grid-row--middle">
+    <span class="authorization-definition-card-count fr-mr-1w"><%= validated_count %></span>
+    <span class="fr-badge fr-badge--sm fr-badge--success fr-badge--no-icon"><%= t('authorization_request.status.validated') %></span>
+  </div>
+  <div class="fr-col-auto fr-grid-row fr-grid-row--middle">
+    <span class="authorization-definition-card-count fr-mr-1w"><%= submitted_count %></span>
+    <span class="fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon"><%= t('authorization_request.status.submitted') %></span>
+  </div>
+</div>

--- a/app/views/instruction/authorization_definitions/show.html.erb
+++ b/app/views/instruction/authorization_definitions/show.html.erb
@@ -1,0 +1,77 @@
+<% set_title! t('page_titles.instruction_definition', definition_name: @authorization_definition.name) %>
+
+<%= render Molecules::Instruction::WideHeader.new(
+      logo_asset: @authorization_definition.provider.logo,
+      title: @authorization_definition.name,
+      back_link: { path: instruction_authorization_definitions_path, text: t('page_titles.instruction_definitions') }) do |component| %>
+
+  <% component.with_subtitle_content do %>
+    <p class="fr-my-1w">
+      <span class="fr-text--sm">
+        <%= t('.slug_label') %>
+        <code class="fr-code-inline"><%= @authorization_definition.id %></code>
+      </span>
+    </p>
+    <%= render 'instruction/authorization_definitions/counts', validated_count: @counts[:validated], submitted_count: @counts[:submitted] %>
+  <% end %>
+
+  <% component.with_right_content do %>
+    <div>
+      <% if policy([:instruction, @authorization_definition]).initiate_request? %>
+        <div class="fr-mb-1w">
+          <%= link_to t('.initiate_request'),
+                start_instruction_instructor_draft_requests_path(form_uid: @authorization_definition.default_form.uid),
+                class: 'fr-btn fr-btn--icon-left fr-icon-draft-line authorization-definition-action-btn' %>
+        </div>
+      <% end %>
+      <div data-controller="clipboard"
+           data-clipboard-content-value="<%= new_authorization_request_url(@authorization_definition.id) %>"
+           data-clipboard-original-message-value="<%= t('.copy_request_link') %>">
+        <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-clipboard-line authorization-definition-action-btn"
+                data-action="click->clipboard#copy">
+          <%= t('.copy_request_link') %>
+        </button>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
+<div class="fr-container fr-my-5w">
+  <%= render Molecules::Instruction::AuthorizationDefinition::ConfigBlockComponent.new(authorization_definition: @authorization_definition) %>
+
+  <section class="fr-my-5w">
+    <div class="fr-mb-1w">
+      <h2 class="fr-h4"><%= t('.actions_block.title') %></h2>
+      <p class="fr-text--sm fr-text-mention--grey"><%= t('.actions_block.subtitle') %></p>
+    </div>
+
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <div class="fr-col-12 fr-col-md-4">
+        <%= render Atoms::ActionCardComponent.new(
+              title: t('.actions_block.blocks.title'),
+              description: t('.actions_block.blocks.description'),
+              link: '#',
+              detail: t('.actions_block.blocks.count', count: @authorization_definition.blocks.size),
+              icon: 'fr-icon-draft-line') %>
+      </div>
+
+      <% if @authorization_definition.available_forms.size > 1 %>
+        <div class="fr-col-12 fr-col-md-4">
+          <%= render Atoms::ActionCardComponent.new(
+                title: t('.actions_block.cas_usages.title'),
+                description: t('.actions_block.cas_usages.description'),
+                link: '#',
+                detail: t('.actions_block.cas_usages.count', count: @authorization_definition.available_forms.size),
+                icon: 'fr-icon-file-text-line') %>
+        </div>
+      <% end %>
+
+      <div class="fr-col-12 fr-col-md-4">
+        <%= render Atoms::ActionCardComponent.new(
+              title: t('.actions_block.emails.title'),
+              description: t('.actions_block.emails.description'),
+              link: '#') %>
+      </div>
+    </div>
+  </section>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -150,6 +150,7 @@ ignore_unused:
   - 'authorization_requests.show.{reopening_,}{changes_requested,refused}.*'
   - 'instruction.revoke_authorizations.create.*'
   - 'instruction.user_rights.{create,update}.error'
+  - 'instruction.authorization_definitions.show.config_block.{fields,features}.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/instruction.fr.yml
+++ b/config/locales/instruction.fr.yml
@@ -20,6 +20,45 @@ fr:
             zero: Aucun formulaire
             one: "%{count} formulaire"
             other: "%{count} formulaires"
+      show:
+        slug_label: Identifiant du formulaire
+        initiate_request: Initier une demande pour autrui
+        copy_request_link: Copier le lien de demande
+        config_block:
+          title: Configuration
+          "true": Oui
+          "false": Non
+          fields:
+            kind: Type
+            startable_by_applicant: Démarrable par le demandeur
+            unique: Habilitation unique par organisation
+            access_link: Lien d'accès après validation
+            support_email: Email de support
+          features:
+            messaging: Messagerie via DataPass active
+            transfer: Transfert de demandeur possible
+            instructor_drafts: Initiable par un instructeur
+            reopening: Demande de modification possible
+        actions_block:
+          title: Que souhaitez-vous configurer ?
+          subtitle: Choisissez la partie du formulaire à configurer. Chaque espace est indépendant.
+          blocks:
+            title: Modifier les étapes du formulaire
+            description: Ajoutez, réorganisez ou supprimez les étapes et les questions présentées au demandeur.
+            count:
+              zero: Aucune étape
+              one: 1 étape
+              other: "%{count} étapes"
+          cas_usages:
+            title: Gérer les cas d'usage
+            description: Facilitez votre instruction ainsi que les demandes en préremplissant votre formulaire avec des cas d'usage.
+            count:
+              zero: Aucun cas d'usage
+              one: 1 cas d'usage
+              other: "%{count} cas d'usage"
+          emails:
+            title: Gérer les emails automatiques
+            description: Consultez le contenu et les destinataires des emails automatiques envoyés durant tout le cycle de vie d'une demande.
     dashboard:
       authorization_requests:
         search:

--- a/config/locales/page_titles.fr.yml
+++ b/config/locales/page_titles.fr.yml
@@ -37,6 +37,7 @@ fr:
 
     instruction_dashboard: Tableau de bord instructeur
     instruction_definitions: Formulaires - Instruction
+    instruction_definition: "%{definition_name} - Formulaires - Instruction"
     instruction_show: "Instruction %{definition_name} - %{authorization_request_name}"
     instruction_initiated_requests: Demandes initiées par les instructeurs
     instruction_draft_requests_new: Initier une demande d’habilitation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Rails.application.routes.draw do
   namespace :instruction do
     get '/tableau-de-bord/:id', to: 'dashboard#show', as: :dashboard_show
 
-    resources :authorization_definitions, only: [:index], path: 'formulaires'
+    resources :authorization_definitions, only: %i[index show], path: 'formulaires'
 
     resources :message_templates, only: %i[index new create edit update destroy], path: 'modeles-messages'
 

--- a/features/instructeurs/gestion_des_formulaires/detail_formulaire.feature
+++ b/features/instructeurs/gestion_des_formulaires/detail_formulaire.feature
@@ -1,0 +1,39 @@
+# language: fr
+
+Fonctionnalité: Détail d'un formulaire
+  En tant qu'instructeur, je peux consulter le détail d'un formulaire
+  afin de voir les informations associées à ce formulaire.
+
+  Contexte:
+    Soit un fournisseur de données "DINUM" existe
+    Sachant que je suis un rapporteur "API Entreprise"
+    Et que je me connecte
+
+  Scénario: L'en-tête affiche le nom du formulaire avec le logo du fournisseur
+    Quand je me rends sur le formulaire "API Entreprise"
+    Alors la page contient "API Entreprise"
+
+  Scénario: Le lien de retour mène vers la liste des formulaires
+    Quand je me rends sur le formulaire "API Entreprise"
+    Alors le lien retour mène vers la liste des formulaires
+
+  Scénario: Je peux accéder au détail d'un formulaire depuis la liste
+    Quand je me rends sur la liste des formulaires
+    Et je clique sur "API Entreprise"
+    Alors la page contient "API Entreprise"
+    Et le lien retour mène vers la liste des formulaires
+
+  Scénario: Le lien d'initiation de demande est visible pour un instructeur sur un type d'habilitation qui l'active
+    Sachant que je suis un instructeur "API Entreprise"
+    Quand je me rends sur le formulaire "API Entreprise"
+    Alors la page contient "Initier une demande pour autrui"
+
+  Scénario: Le lien d'initiation de demande n'est pas visible pour un rapporteur
+    Quand je me rends sur le formulaire "API Entreprise"
+    Alors la page ne contient pas "Initier une demande pour autrui"
+
+  Scénario: Le lien d'initiation de demande n'est pas visible si la fonctionnalité n'est pas activée
+    Soit un fournisseur de données "DILA" existe
+    Sachant que je suis un instructeur "Démarches du bouquet de services (service-public.fr)"
+    Quand je me rends sur le formulaire "Démarches du bouquet de services (service-public.fr)"
+    Alors la page ne contient pas "Initier une demande pour autrui"

--- a/features/step_definitions/instructions_steps.rb
+++ b/features/step_definitions/instructions_steps.rb
@@ -6,6 +6,15 @@ Quand('je me rends sur la liste des formulaires') do
   visit instruction_authorization_definitions_path
 end
 
+Quand('je me rends sur le formulaire {string}') do |definition_name|
+  definition = find_authorization_definition_from_name(definition_name)
+  visit instruction_authorization_definition_path(definition.id)
+end
+
+Alors('le lien retour mène vers la liste des formulaires') do
+  expect(page).to have_link(href: instruction_authorization_definitions_path)
+end
+
 Alors('le formulaire {string} affiche {int} demande(s) validée(s) et {int} demande(s) en cours') do |name, validated_count, submitted_count|
   definition = find_authorization_definition_from_name(name)
 

--- a/spec/components/previews/atoms/action_card_component_preview.rb
+++ b/spec/components/previews/atoms/action_card_component_preview.rb
@@ -1,0 +1,19 @@
+class Atoms::ActionCardComponentPreview < ApplicationPreview
+  def with_detail
+    render Atoms::ActionCardComponent.new(
+      title: 'Modifier les étapes du formulaire',
+      description: 'Ajoutez, réorganisez ou supprimez les étapes et les questions présentées au demandeur.',
+      link: '#',
+      detail: '5 étapes',
+      icon: 'fr-icon-draft-line'
+    )
+  end
+
+  def without_detail
+    render Atoms::ActionCardComponent.new(
+      title: 'Gérer les emails automatiques',
+      description: 'Consultez le contenu et les destinataires des emails automatiques.',
+      link: '#'
+    )
+  end
+end

--- a/spec/components/previews/molecules/instruction/authorization_definition/config_block_component_preview.rb
+++ b/spec/components/previews/molecules/instruction/authorization_definition/config_block_component_preview.rb
@@ -1,0 +1,22 @@
+class Molecules::Instruction::AuthorizationDefinition::ConfigBlockComponentPreview < ApplicationPreview
+  def api_entreprise
+    definition = AuthorizationDefinition.find('api_entreprise')
+    render Molecules::Instruction::AuthorizationDefinition::ConfigBlockComponent.new(
+      authorization_definition: definition
+    )
+  end
+
+  def api_impot_particulier
+    definition = AuthorizationDefinition.find('api_impot_particulier')
+    render Molecules::Instruction::AuthorizationDefinition::ConfigBlockComponent.new(
+      authorization_definition: definition
+    )
+  end
+
+  def hubee_dila
+    definition = AuthorizationDefinition.find('hubee_dila')
+    render Molecules::Instruction::AuthorizationDefinition::ConfigBlockComponent.new(
+      authorization_definition: definition
+    )
+  end
+end

--- a/spec/components/previews/molecules/instruction/authorization_definition/config_chip_component_preview.rb
+++ b/spec/components/previews/molecules/instruction/authorization_definition/config_chip_component_preview.rb
@@ -1,0 +1,25 @@
+class Molecules::Instruction::AuthorizationDefinition::ConfigChipComponentPreview < ApplicationPreview
+  def boolean_value
+    render Molecules::Instruction::AuthorizationDefinition::ConfigChipComponent.new(
+      label: 'Démarrable par le demandeur'
+    ) do |chip|
+      chip.with_value { tag.span('Oui', class: 'config-chip__value') }
+    end
+  end
+
+  def code_value
+    render Molecules::Instruction::AuthorizationDefinition::ConfigChipComponent.new(
+      label: 'Type'
+    ) do |chip|
+      chip.with_value { tag.code('api', class: 'fr-code-inline') }
+    end
+  end
+
+  def link_value
+    render Molecules::Instruction::AuthorizationDefinition::ConfigChipComponent.new(
+      label: 'Email de support'
+    ) do |chip|
+      chip.with_value { tag.a('support@example.com', href: 'mailto:support@example.com', class: 'fr-link') }
+    end
+  end
+end

--- a/spec/components/previews/molecules/instruction/wide_header_preview.rb
+++ b/spec/components/previews/molecules/instruction/wide_header_preview.rb
@@ -14,6 +14,14 @@ class Molecules::Instruction::WideHeaderPreview < ApplicationPreview
     end
   end
 
+  def with_right_content
+    render Molecules::Instruction::WideHeader.new(title: 'Fournisseurs de données') do |component|
+      component.with_right_content do
+        tag.button('Ajouter des choses aux trucs', class: 'fr-btn fr-btn--sm fr-icon-add-line fr-btn--icon-left')
+      end
+    end
+  end
+
   # @label Data Provider's Definitions
   def data_provider_definitions
     data_provider = DataProvider.first!

--- a/spec/policies/instruction/authorization_definition_policy_spec.rb
+++ b/spec/policies/instruction/authorization_definition_policy_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe Instruction::AuthorizationDefinitionPolicy do
-  subject(:policy) { described_class.new(UserContext.new(user), AuthorizationDefinition) }
-
   describe '#index?' do
-    subject { policy.index? }
+    subject { described_class.new(UserContext.new(user), AuthorizationDefinition).index? }
 
     context 'when user is an admin' do
       let(:user) { create(:user, :admin) }
@@ -30,6 +28,73 @@ RSpec.describe Instruction::AuthorizationDefinitionPolicy do
 
     context 'when user has no role' do
       let(:user) { create(:user) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#show?' do
+    subject { described_class.new(UserContext.new(user), authorization_definition).show? }
+
+    let(:authorization_definition) { AuthorizationDefinition.find('api_entreprise') }
+
+    context 'when user is an admin' do
+      let(:user) { create(:user, :admin) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user is a reporter on the definition' do
+      let(:user) { create(:user, :reporter, authorization_request_types: %w[api_entreprise]) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user is an instructor on the definition' do
+      let(:user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user is a manager on the definition' do
+      let(:user) { create(:user, :manager, authorization_request_types: %w[api_entreprise]) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user is a reporter on another definition' do
+      let(:user) { create(:user, :reporter, authorization_request_types: %w[hubee_cert_dc]) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when user has no role' do
+      let(:user) { create(:user) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#initiate_request?' do
+    subject { described_class.new(UserContext.new(user), authorization_definition).initiate_request? }
+
+    let(:authorization_definition) { AuthorizationDefinition.find('api_entreprise') }
+
+    context 'when user is an instructor on the definition' do
+      let(:user) { create(:user, :instructor, authorization_request_types: %w[api_entreprise]) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user is a reporter on the definition' do
+      let(:user) { create(:user, :reporter, authorization_request_types: %w[api_entreprise]) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when user is an instructor on a definition without the instructor_drafts feature' do
+      let(:authorization_definition) { AuthorizationDefinition.find('hubee_dila') }
+      let(:user) { create(:user, :instructor, authorization_request_types: %w[hubee_dila]) }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
Affichage d'une définition, ça ressemble à ça : 

<img width="1846" height="1522" alt="screencapture-localhost-3000-instruction-fournisseurs-donnees-dinum-formulaires-api-entreprise-2026-06-19-11_43_40" src="https://github.com/user-attachments/assets/1973d299-f90e-4289-8696-396adfd902d1" />

## Notes

Les alias de rôles interviennent suite à une discussion avec JB sur le nommage des méthodes `reporter?` `manager?` que je trouve confusantes (et claude aussi).