### PR TITLE
Validation format + existence communes + rejet transmission rétroactive (API-6728 / API-6831)

### DIFF
--- a/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
+++ b/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
@@ -77,7 +77,7 @@ module AuthorizationExtensions::CnousDataExtractionCriteria
     manual_code_insee_communes.each_with_index do |code, index|
       next if code.match?(CODE_INSEE_FORMAT)
 
-      errors.add(:manual_code_insee_communes, :invalid_code_insee_format, index:, code:)
+      errors.add(:manual_code_insee_communes, :invalid_code_insee_format, index: index + 1, code:)
     end
   end
 
@@ -90,7 +90,7 @@ module AuthorizationExtensions::CnousDataExtractionCriteria
       next unless code.match?(CODE_INSEE_FORMAT)
       next if geo_client.commune_exists?(code)
 
-      errors.add(:manual_code_insee_communes, :unknown_code_insee, index:, code:)
+      errors.add(:manual_code_insee_communes, :unknown_code_insee, index: index + 1, code:)
     end
   rescue GeoAPIGouvClient::ServerError, Faraday::Error
     nil

--- a/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
+++ b/app/models/concerns/authorization_extensions/cnous_data_extraction_criteria.rb
@@ -3,6 +3,7 @@ module AuthorizationExtensions::CnousDataExtractionCriteria
 
   ECHELONS = %w[0Bis 1 2 3 4 5 6 7].freeze
   GEOGRAPHIC_KINDS = { commune: 'commune', dept: 'departement', region: 'region' }.freeze
+  CODE_INSEE_FORMAT = /\A([013-9]\d|2[AB1-9])\d{3}\z/
 
   included do
     add_attribute :manual_code_insee_communes, type: :array
@@ -13,6 +14,9 @@ module AuthorizationExtensions::CnousDataExtractionCriteria
 
     with_options if: -> { need_complete_validation?(:cnous_data_extraction_criteria) } do
       validate :geographic_perimeter_present
+      validate :manual_communes_codes_insee_format
+      validate :manual_communes_codes_insee_existence
+      validate :premiere_date_transmission_not_in_the_past
       validates :echelon_bourse, presence: true, inclusion: { in: ECHELONS }
       validates :premiere_date_transmission, presence: true
     end
@@ -65,5 +69,39 @@ module AuthorizationExtensions::CnousDataExtractionCriteria
     return if geographic_perimeter_automatic? || manual_code_insee_communes.present?
 
     errors.add(:manual_code_insee_communes, :blank)
+  end
+
+  def manual_communes_codes_insee_format
+    return if geographic_perimeter_automatic?
+
+    manual_code_insee_communes.each_with_index do |code, index|
+      next if code.match?(CODE_INSEE_FORMAT)
+
+      errors.add(:manual_code_insee_communes, :invalid_code_insee_format, index:, code:)
+    end
+  end
+
+  def manual_communes_codes_insee_existence
+    return if geographic_perimeter_automatic?
+
+    geo_client = GeoAPIGouvClient.new
+
+    manual_code_insee_communes.each_with_index do |code, index|
+      next unless code.match?(CODE_INSEE_FORMAT)
+      next if geo_client.commune_exists?(code)
+
+      errors.add(:manual_code_insee_communes, :unknown_code_insee, index:, code:)
+    end
+  rescue GeoAPIGouvClient::ServerError, Faraday::Error
+    nil
+  end
+
+  def premiere_date_transmission_not_in_the_past
+    return if premiere_date_transmission.blank?
+
+    date = Date.parse(premiere_date_transmission)
+    errors.add(:premiere_date_transmission, :not_in_the_future) if date < Date.current
+  rescue ArgumentError, TypeError
+    errors.add(:premiere_date_transmission, :invalid_date)
   end
 end

--- a/app/services/geo_api_gouv_client.rb
+++ b/app/services/geo_api_gouv_client.rb
@@ -4,6 +4,10 @@ class GeoAPIGouvClient
   BASE_URL = 'https://geo.api.gouv.fr'.freeze
   CACHE_TTL = 24.hours
 
+  def commune_exists?(code)
+    commune(code).present?
+  end
+
   def commune(code)
     Rails.cache.fetch("geo:commune:#{code}", expires_in: CACHE_TTL) do
       body = get("/communes/#{code}", fields: 'nom,codeDepartement,codeRegion')

--- a/app/views/authorization_request_forms/blocks/default/_cnous_communes_manual.html.erb
+++ b/app/views/authorization_request_forms/blocks/default/_cnous_communes_manual.html.erb
@@ -1,9 +1,12 @@
+<% communes_errors = @authorization_request.errors.where(:manual_code_insee_communes) %>
+<% group_errors = communes_errors.reject { |error| error.options.key?(:index) } %>
 <fieldset class="fr-fieldset__element fr-input-group"
           data-controller="nested-form nested-form-focus"
           data-nested-form-focus-input-selector-value='input[name$="[manual_code_insee_communes][]"]'
           data-nested-form-focus-aria-label-template-value="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %> n°NEW_RECORD">
   <legend class="fr-fieldset__legend">
     <%= t('activerecord.attributes.authorization_request.communes_codes_insee') %>
+    <span class="fr-ml-1w fr-text-error">*</span>
     <span class="fr-hint-text">
       <%= t('activerecord.hints.authorization_request.communes_codes_insee') %>
     </span>
@@ -24,9 +27,17 @@
 
   <div data-nested-form-target="target" data-nested-form-focus-target="target">
     <% (@authorization_request.manual_code_insee_communes.presence || ['']).each_with_index do |code, index| %>
+      <% chip_errors = communes_errors.select { |error| error.options[:index] == index + 1 } %>
       <div class="nested-fields fr-grid-row fr-grid-row--gutters fr-mb-2w" data-new-record="true">
-        <div class="fr-col-8">
-          <input type="text" inputmode="text" pattern="[0-9AB]{5}" maxlength="5" name="<%= f.object_name %>[manual_code_insee_communes][]" value="<%= code %>" class="fr-input" placeholder="75056" aria-label="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %> n°<%= index + 1 %>">
+        <div class="fr-col-8 <%= 'fr-input-group fr-input-group--error' if chip_errors.any? %>">
+          <input type="text" inputmode="text" pattern="[0-9AB]{5}" maxlength="5" name="<%= f.object_name %>[manual_code_insee_communes][]" value="<%= code %>" class="fr-input <%= 'fr-input--error' if chip_errors.any? %>" placeholder="75056" aria-label="<%= t('activerecord.attributes.authorization_request.communes_codes_insee') %> n°<%= index + 1 %>">
+          <% if chip_errors.any? %>
+            <p class="fr-messages-group">
+              <% chip_errors.each do |error| %>
+                <span class="fr-message fr-message--error"><%= error.message %></span>
+              <% end %>
+            </p>
+          <% end %>
         </div>
         <div class="fr-col-4">
           <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" data-action="click->nested-form-focus#focusAfterRemove click->nested-form#remove" aria-label="<%= code.present? ? t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria', code: code) : t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.remove_aria_blank') %>">
@@ -36,6 +47,14 @@
       </div>
     <% end %>
   </div>
+
+  <% if group_errors.any? %>
+    <p class="fr-messages-group">
+      <% group_errors.each do |error| %>
+        <span class="fr-message fr-message--error"><%= error.message %></span>
+      <% end %>
+    </p>
+  <% end %>
 
   <button type="button" class="fr-btn fr-btn--secondary fr-btn--sm" data-nested-form-focus-target="addButton" data-action="click->nested-form#add click->nested-form-focus#focusNew">
     <%= t('authorization_request_forms.default.cnous_data_extraction_criteria.communes_codes_insee.add') %>

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -242,6 +242,12 @@ fr:
           attributes:
             scopes:
               blank: "ne sont pas cochées : il faut au moins qu'une des données soit sélectionnée."
+            manual_code_insee_communes:
+              invalid_code_insee_format: "n’est pas un code INSEE valide : « %{code} »."
+              unknown_code_insee: "ne correspond à aucune commune connue : « %{code} »."
+            premiere_date_transmission:
+              not_in_the_future: "ne peut pas être dans le passé."
+              invalid_date: "n’est pas une date valide."
             safety_certification_begin_date:
               comparison: doit être supérieure à la date de début
             france_connect_authorization_id:

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -243,8 +243,8 @@ fr:
             scopes:
               blank: "ne sont pas cochées : il faut au moins qu'une des données soit sélectionnée."
             manual_code_insee_communes:
-              invalid_code_insee_format: "n’est pas un code INSEE valide : « %{code} »."
-              unknown_code_insee: "ne correspond à aucune commune connue : « %{code} »."
+              invalid_code_insee_format: "n°%{index} n’est pas un code INSEE valide : « %{code} »."
+              unknown_code_insee: "n°%{index} ne correspond à aucune commune connue : « %{code} »."
             premiere_date_transmission:
               not_in_the_future: "ne peut pas être dans le passé."
               invalid_date: "n’est pas une date valide."

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -5,6 +5,8 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
 
   Scénario: Je soumets une demande Boursiers CNOUS valide
     Sachant que je suis un demandeur
+    Et que l’API géo connaît la commune "75056" nommée "Paris"
+    Et que l’API géo connaît la commune "69123" nommée "Lyon"
     Et que je me connecte
     Et qu'un type d'habilitation "Boursiers" expose le bloc "cnous_data_extraction_criteria"
 
@@ -84,6 +86,8 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
 
   Scénario: Le formulaire accepte les codes INSEE Corse et à zéro de tête
     Sachant que je suis un demandeur
+    Et que l’API géo connaît la commune "2A004" nommée "Ajaccio"
+    Et que l’API géo connaît la commune "01001" nommée "L’Abergement-Clémenciat"
     Et que je me connecte
     Et qu'un type d'habilitation "Boursiers" expose le bloc "cnous_data_extraction_criteria"
 

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -37,6 +37,29 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Alors il y a un message de succès contenant "soumise avec succès"
     Et la demande contient les conditions d'extraction CNOUS attendues
 
+  Scénario: Un code INSEE invalide est signalé visuellement sur le champ concerné
+    Sachant que je suis un demandeur
+    Et que l’API géo connaît la commune "75056" nommée "Paris"
+    Et que je me connecte
+    Et qu'un type d'habilitation "Boursiers" expose le bloc "cnous_data_extraction_criteria"
+
+    Quand je démarre une nouvelle demande d'habilitation "Boursiers"
+
+    * je renseigne les infos de bases du projet
+    * je clique sur "Suivant"
+
+    * l’astérisque signale que les communes sont obligatoires
+
+    * je clique sur "Ajouter une commune"
+    * je remplis "Communes (codes INSEE) n°1" avec "75056"
+    * je remplis "Communes (codes INSEE) n°2" avec "20000"
+    * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
+    * je remplis la première date de transmission avec une date future
+    * je clique sur "Suivant"
+
+    Alors le champ commune INSEE contenant "20000" est signalé en erreur
+    Et le champ commune INSEE contenant "75056" n’est pas signalé en erreur
+
   Scénario: Une collectivité identifiée comme commune voit son périmètre pré-rempli en lecture seule
     Sachant que je suis un demandeur de la commune de Clamart
     Et que je me connecte

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -19,7 +19,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     * je remplis "Communes (codes INSEE) n°1" avec "75056"
     * je remplis "Communes (codes INSEE) n°2" avec "69123"
     * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
-    * je remplis "Première date de transmission" avec "2026-09-01"
+    * je remplis la première date de transmission avec une date future
     * je clique sur "Suivant"
     * la page contient "Contact technique"
 
@@ -52,7 +52,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Et le périmètre ne propose pas de voir toutes les communes
 
     Quand je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
-    Et je remplis "Première date de transmission" avec "2026-09-01"
+    Et je remplis la première date de transmission avec une date future
     Et je clique sur "Suivant"
 
     * je renseigne les informations du contact technique
@@ -104,7 +104,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Quand je remplis "Communes (codes INSEE) n°1" avec "2A004"
     Et je remplis "Communes (codes INSEE) n°2" avec "01001"
     Et je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
-    Et je remplis "Première date de transmission" avec "2026-09-01"
+    Et je remplis la première date de transmission avec une date future
     Et je clique sur "Suivant"
 
     * je renseigne les informations du contact technique

--- a/features/step_definitions/cnous_data_extraction_criteria_steps.rb
+++ b/features/step_definitions/cnous_data_extraction_criteria_steps.rb
@@ -60,6 +60,23 @@ Alors('chaque champ commune INSEE est annoncé avec sa position aux lecteurs d�
   expect(page).to have_css('input[name$="[manual_code_insee_communes][]"][aria-label="Communes (codes INSEE) n°2"]', visible: :all)
 end
 
+Alors('l’astérisque signale que les communes sont obligatoires') do
+  expect(page).to have_css('legend.fr-fieldset__legend .fr-text-error', text: '*', visible: :all)
+end
+
+Alors('le champ commune INSEE contenant {string} est signalé en erreur') do |value|
+  field = find(:xpath, "//input[@value='#{value}']", visible: :all)
+  expect(field[:class]).to include('fr-input--error')
+
+  group = field.find(:xpath, "ancestor::div[contains(@class, 'fr-input-group--error')][1]", visible: :all)
+  expect(group).to have_css('.fr-message--error', text: value, visible: :all)
+end
+
+Alors('le champ commune INSEE contenant {string} n’est pas signalé en erreur') do |value|
+  field = find(:xpath, "//input[@value='#{value}']", visible: :all)
+  expect(field[:class]).not_to include('fr-input--error')
+end
+
 Alors('le groupe de codes INSEE utilise la légende DSFR conforme') do
   expect(page).to have_css('legend.fr-fieldset__legend', text: /Communes \(codes INSEE\)/, visible: :all)
 end

--- a/features/step_definitions/cnous_data_extraction_criteria_steps.rb
+++ b/features/step_definitions/cnous_data_extraction_criteria_steps.rb
@@ -1,3 +1,11 @@
+def cnous_future_transmission_date
+  2.months.from_now.to_date
+end
+
+Quand('je remplis la première date de transmission avec une date future') do
+  fill_in 'Première date de transmission', with: cnous_future_transmission_date.iso8601, wait: true
+end
+
 Sachantque('l’API géo connaît la commune {string} nommée {string}') do |code, nom|
   stub_request(:get, "https://geo.api.gouv.fr/communes/#{code}?fields=nom,codeDepartement,codeRegion")
     .to_return(
@@ -60,7 +68,7 @@ Alors("la demande contient les conditions d'extraction CNOUS attendues") do
   authorization_request = AuthorizationRequest.last
   expect(authorization_request.manual_code_insee_communes).to match_array(%w[75056 69123])
   expect(authorization_request.echelon_bourse).to eq('5')
-  expect(authorization_request.premiere_date_transmission).to eq('2026-09-01')
+  expect(authorization_request.premiere_date_transmission).to eq(cnous_future_transmission_date.iso8601)
 end
 
 Alors('les champs de codes INSEE acceptent les caractères alphanumériques de longueur 5') do

--- a/spec/services/dynamic_authorization_request_registrar_spec.rb
+++ b/spec/services/dynamic_authorization_request_registrar_spec.rb
@@ -137,7 +137,22 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
         let(:demande) { klass.new(**params) }
         let(:params) { {} }
 
-        before { valid? }
+        let(:known_communes) { %w[75056 69123] }
+
+        before do
+          known_communes.each do |code|
+            stub_request(:get, "https://geo.api.gouv.fr/communes/#{code}?fields=nom,codeDepartement,codeRegion")
+              .to_return(
+                status: 200,
+                body: { 'code' => code, 'nom' => 'X', 'codeDepartement' => '75', 'codeRegion' => '11' }.to_json,
+                headers: { 'Content-Type' => 'application/json' }
+              )
+          end
+          stub_request(:get, %r{https://geo\.api\.gouv\.fr/communes/(?!(#{known_communes.join('|')})\?)})
+            .to_return(status: 404, body: '')
+
+          valid?
+        end
 
         context 'without any field' do
           it { expect(demande.errors[:manual_code_insee_communes]).to be_present }
@@ -150,7 +165,7 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
             {
               manual_code_insee_communes: %w[75056 69123],
               echelon_bourse: '5',
-              premiere_date_transmission: '2026-09-01',
+              premiere_date_transmission: 1.month.from_now.to_date.iso8601,
             }
           end
 
@@ -169,6 +184,48 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
           let(:params) { { echelon_bourse: '0Bis' } }
 
           it { expect(demande.errors[:echelon_bourse]).to be_empty }
+        end
+
+        context 'with a malformed code INSEE in the communes list' do
+          let(:params) { { manual_code_insee_communes: %w[ABCDE] } }
+
+          it { expect(demande.errors[:manual_code_insee_communes]).to be_present }
+        end
+
+        context 'with a well-formatted but unknown code INSEE' do
+          let(:params) { { manual_code_insee_communes: %w[99999] } }
+
+          it { expect(demande.errors[:manual_code_insee_communes]).to be_present }
+        end
+
+        context 'with duplicate codes INSEE' do
+          let(:params) { { manual_code_insee_communes: %w[75056 75056] } }
+
+          it { expect(demande.manual_code_insee_communes).to eq(%w[75056]) }
+        end
+
+        context 'with a premiere_date_transmission in the past' do
+          let(:params) { { premiere_date_transmission: 1.day.ago.to_date.iso8601 } }
+
+          it { expect(demande.errors[:premiere_date_transmission]).to be_present }
+        end
+
+        context 'with premiere_date_transmission set to today' do
+          let(:params) { { premiere_date_transmission: Date.current.iso8601 } }
+
+          it { expect(demande.errors[:premiere_date_transmission]).to be_empty }
+        end
+
+        context 'with a premiere_date_transmission in the future' do
+          let(:params) { { premiere_date_transmission: 1.month.from_now.to_date.iso8601 } }
+
+          it { expect(demande.errors[:premiere_date_transmission]).to be_empty }
+        end
+
+        context 'with a non-parseable premiere_date_transmission' do
+          let(:params) { { premiere_date_transmission: 'pas-une-date' } }
+
+          it { expect(demande.errors[:premiere_date_transmission]).to be_present }
         end
       end
     end

--- a/spec/services/dynamic_authorization_request_registrar_spec.rb
+++ b/spec/services/dynamic_authorization_request_registrar_spec.rb
@@ -187,15 +187,23 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
         end
 
         context 'with a malformed code INSEE in the communes list' do
-          let(:params) { { manual_code_insee_communes: %w[ABCDE] } }
+          let(:params) { { manual_code_insee_communes: %w[75056 ABCDE] } }
 
           it { expect(demande.errors[:manual_code_insee_communes]).to be_present }
+
+          it 'identifies the faulty chip by its position' do
+            expect(demande.errors[:manual_code_insee_communes].join).to include('n°2', 'ABCDE')
+          end
         end
 
         context 'with a well-formatted but unknown code INSEE' do
-          let(:params) { { manual_code_insee_communes: %w[99999] } }
+          let(:params) { { manual_code_insee_communes: %w[75056 99999] } }
 
           it { expect(demande.errors[:manual_code_insee_communes]).to be_present }
+
+          it 'identifies the faulty chip by its position' do
+            expect(demande.errors[:manual_code_insee_communes].join).to include('n°2', '99999')
+          end
         end
 
         context 'with duplicate codes INSEE' do

--- a/spec/services/geo_api_gouv_client_spec.rb
+++ b/spec/services/geo_api_gouv_client_spec.rb
@@ -46,4 +46,24 @@ RSpec.describe GeoAPIGouvClient do
       expect(stub).to have_been_requested.once
     end
   end
+
+  describe '#commune_exists?' do
+    let(:url) { "#{base_url}/communes/69123?fields=nom,codeDepartement,codeRegion" }
+
+    it 'is true when the commune is known' do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: { 'code' => '69123', 'nom' => 'Lyon', 'codeDepartement' => '69', 'codeRegion' => '84' }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+      expect(client.commune_exists?('69123')).to be(true)
+    end
+
+    it 'is false when the commune is unknown (404)' do
+      stub_request(:get, url).to_return(status: 404, body: '')
+
+      expect(client.commune_exists?('69123')).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Appaire **API-6728** (validation de format) et **API-6831** (mode manuel cas « autre » + existence) — même concern, même surface de validation, un seul pass.

## Ce que ça fait
Le bloc `cnous_data_extraction_criteria` ne faisait qu'une validation de présence. On ajoute, dans `AuthorizationExtensions::CnousDataExtractionCriteria` (gated par `need_complete_validation?`) :

- **Format code INSEE** : `/\A([013-9]\d|2[AB1-9])\d{3}\z/` (5 chiffres + Corse 2A/2B), avec la **position de la commune fautive** (n°N, alignée sur le numéro affiché des chips) surfacée dans le message d'erreur.
- **Existence des communes** via `GeoAPIGouvClient#commune_exists?` (ajouté en wrapper d'une ligne sur `commune` existant) — dégrade gracieusement si geo indisponible.
- **`premiere_date_transmission`** : parseable en Date **et** `>= Date.current`. Décision métier (Thomas, 2026-06-23) : pas de transmission rétroactive, jour même accepté, passé rejeté.

L'inclusion `echelon_bourse` (constante `ECHELONS`) était déjà shipée ; la dédup des codes est déjà gérée par l'array writer.

## Tests
- RSpec : 0 failures
- Cucumber : 5 scenarios, 89 steps, tous verts — la date de transmission des scénarios est dérivée de `Date.current` (`2.months.from_now`) pour ne pas casser une fois la date butoir passée.
- Rubocop : clean
