### PR TITLE
DP-1798 — Ajout de doc technique manquant

### DIFF
--- a/docs/technique/authentification_proconnect.md
+++ b/docs/technique/authentification_proconnect.md
@@ -216,6 +216,12 @@ la session d’un agent banni. Limites de ce palier *stateless* (cookie store, s
 pas de révocation à distance ni de « déconnecter partout », un cookie volé reste valide jusqu’à son
 expiration (12-24 h). Ces points seront traités par **DP-1790** (store serveur révocable).
 
+## Validation partagée avec Rails Pulse
+
+Le tableau de bord Rails Pulse (`/rails_pulse`) est réservé aux admins. Pour vérifier la
+session, il réutilise le même prédicat que l’app : `Authentication::SessionLifecycle.valid_session?`
+(voir `config/initializers/rails_pulse.rb`). Une seule logique de validation, pas de doublon.
+
 ## Déconnexion
 
 ```mermaid


### PR DESCRIPTION
Ajoute la section « Validation partagée avec Rails Pulse » dans `docs/technique/authentification_proconnect.md`.

Comble le dernier écart du ticket DP-1798 (CA-2) : le prédicat `Authentication::SessionLifecycle.valid_session?` est réutilisé par l’initializer Rails Pulse (`config/initializers/rails_pulse.rb`) pour réserver le tableau de bord aux admins sans dupliquer la validation de session. Ce couplage n’était pas documenté.

Closes DP-1798