### PR TITLE
Improve wordings of cas d'usage EAJE for api particulier

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -2076,7 +2076,7 @@ api-particulier-arpege-concerto-petite-enfance:
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d'acceuil du jeune enfant en backoffice par des agents habilités
-    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l’administration qui fixe le cadre général qui oblige l’administration à échanger des données lors d’une démarche d’un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"
+    cadre_juridique_nature: "\n- Cadre légal général  L’article L114-8 du Code des relations entre le public et l’administration qui fixe le cadre général qui oblige l’administration à échanger des données lors d’une démarche d’un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants
@@ -2127,7 +2127,7 @@ api-particulier-aiga-petite-enfance:
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d’acceuil du jeune enfant en backoffice par des agents habilités
-    cadre_juridique_nature: Cadre légal général L’article L114-8 du Code des relations entre le public et l’administration qui fixe le cadre général qui oblige l’administration à échanger des données lors d’une démarche d’un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"_eaje
+    cadre_juridique_nature: "Cadre légal général L’article L114-8 du Code des relations entre le public et l’administration qui fixe le cadre général qui oblige l’administration à échanger des données lors d’une démarche d’un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants
@@ -2163,7 +2163,7 @@ api-particulier-teamnet-axel-petite-enfance:
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d'acceuil du jeune enfant en backoffice par des agents habilités
-    cadre_juridique_nature: Cadre légal général L'article L114-8 du Code des relations entre le public et l’administration qui fixe le cadre général qui oblige l’administration à échanger des données lors d’une démarche d’un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"_eaje
+    cadre_juridique_nature: "Cadre légal général L’article L114-8 du Code des relations entre le public et l’administration qui fixe le cadre général qui oblige l’administration à échanger des données lors d’une démarche d’un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants
@@ -2520,7 +2520,7 @@ api-particulier-tarification-eaje:
     - name: contacts
   initialize_with:
     intitule: Tarification sociale des établissements d'accueil du jeune enfant
-    cadre_juridique_nature: "\n- Cadre légal général : L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"
+    cadre_juridique_nature: "\n- Cadre légal général : L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager."
     scopes: *tarification_eaje_fixed_scopes
 
 
@@ -2548,7 +2548,7 @@ api-particulier-technocarte-babicarte:
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d'acceuil du jeune enfant par des agents habilités
-    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"
+    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants
@@ -2581,7 +2581,7 @@ api-particulier-sigec-maelis-petite-enfance:
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d'acceuil du jeune enfant par des agents habilités
-    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"
+    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants
@@ -2614,7 +2614,7 @@ api-particulier-city-family-mushroom-software-petite-enfance:
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d'acceuil du jeune enfant par des agents habilités
-    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"
+    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants
@@ -2647,7 +2647,7 @@ api-particulier-carte-plus-petite-enfance:
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d'acceuil du jeune enfant par des agents habilités
-    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"
+    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants
@@ -2680,7 +2680,7 @@ api-particulier-familea-petite-enfance: &api_particulier_familea_petite_enfance
     intitule: Tarification des services municipaux liés à la petite enfance
     description: |
       Gestion de la tarification des établissement d'acceuil du jeune enfant par des agents habilités
-    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager.\r\n- Délibération.[À FOURNIR CI-DESSOUS - TEXTE À CITER ICI]"
+    cadre_juridique_nature: "\n- Cadre légal général  L'article L114-8 du Code des relations entre le public et l'administration qui fixe le cadre général qui oblige l'administration à échanger des données lors d'une démarche d'un usager."
     scopes:
       - cnav_participation_familiale_eaje_allocataires
       - cnav_participation_familiale_eaje_enfants

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -445,13 +445,20 @@ fr:
     api_particulier_tarification_eaje_cadre_juridique: &api_particulier_tarification_eaje_cadre_juridique
       cadre_juridique:
         justificatif:
-          description: "Veuillez joindre la délibération autorisant le maire à signer la convention d'objectif et de financement ou la convention d'objectif signée. Vous pouvez nous transmettre un document ou nous fournir un lien."
-          document_label: Veuillez joindre la délibération ou la convention d'objectif signée
-          url_label: Veuillez nous indiquer l'url d'accès à votre délibération ou à votre convention d'objectif signée
+          description: |
+            <p>Veuillez joindre :</p>
+            <ul>
+              <li>la convention d'objectif et de financement</li>
+            <p class="fr-m-0">ou</p>
+              <li>la convention d'objectif signée</li>
+            </ul>
+            <p>Vous pouvez nous transmettre un document ou nous fournir un lien.</p>
+          document_label: Veuillez joindre la convention d'objectif signée
+          url_label: Veuillez nous indiquer l'url d'accès à votre convention d'objectif signée
       cadre_juridique_document:
-        label: Ajoutez votre délibération ou votre convention d'objectif signée
+        label: Ajoutez votre convention d'objectif signée
       cadre_juridique_url:
-        title: Veuillez nous indiquer l'url d'accès à votre délibération ou à votre convention d'objectif signée
+        title: Veuillez nous indiquer l'url d'accès à votre convention d'objectif signée
         label: URL
     api_particulier_tarification_eaje_editor: &api_particulier_tarification_eaje_editor_wordings
       <<: [*api_particulier_tarification_eaje_cadre_juridique, *api_particulier_editor_common_wordings]


### PR DESCRIPTION
closes https://linear.app/pole-api/issue/DP-1651/modification-du-cadre-juridique-pour-cas-dusage-tarification-des-eaje

La [dernière PR](https://github.com/etalab/data_pass/pull/1497) que j'avais faite, c'était pas bon. Voici les véritables wordings demandés par Miryad :

<img width="1846" height="2320" alt="screencapture-localhost-3000-formulaires-api-particulier-tarification-eaje-demande-665-etapes-cadre-juridique-2026-06-25-11_06_24" src="https://github.com/user-attachments/assets/4586e831-1ddd-4d4b-b246-79b3bd912004" />
