### PR TITLE
Ajoute la démarche DDMariage au formulaire HubEE DILA

### DIFF
--- a/app/bridges/hubee_dila_bridge.rb
+++ b/app/bridges/hubee_dila_bridge.rb
@@ -4,7 +4,8 @@ class HubEEDilaBridge < HubEEBaseBridge
     depot_dossier_pacs: 'depotDossierPACS',
     recensement_citoyen: 'recensementCitoyen',
     hebergement_tourisme: 'HebergementTourisme',
-    je_change_de_coordonnees: 'JeChangeDeCoordonnees'
+    je_change_de_coordonnees: 'JeChangeDeCoordonnees',
+    depot_dossier_mariage: 'DDMariage'
   }.freeze
 
   def on_approve

--- a/config/authorization_definitions/hubee.yml
+++ b/config/authorization_definitions/hubee.yml
@@ -42,4 +42,6 @@ hubee_dila:
     - name: "JCC - Déclaration de Changement de Coordonnées"
       value: "je_change_de_coordonnees"
       group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
-
+    - name: "DDMariage - Pré-dépôt de dossier de mariage"
+      value: "depot_dossier_mariage"
+      group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"

--- a/config/authorization_request_forms/others.yml
+++ b/config/authorization_request_forms/others.yml
@@ -20,6 +20,8 @@ hubee-dila:
     ● RCO - Recensement Citoyen Obligatoire
     <br />
     ● JCC - Déclaration de Changement de Coordonnées
+    <br />
+    ● DDMariage - Pré-dépôt de dossier de mariage
   authorization_request: "HubEEDila"
   service_provider_id: hubee
   scopes:
@@ -28,6 +30,7 @@ hubee-dila:
     - recensement_citoyen
     - hebergement_tourisme
     - je_change_de_coordonnees
+    - depot_dossier_mariage
 
 api-captchetat:
   authorization_request: "APICaptchEtat"

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -291,6 +291,12 @@ fr:
               étudiera la faisabilité juridique (demande réalisée via le portail du
               Hub d’Échange de l’État).
             </p>
+            <p>
+              <strong>DDMariage - Pré-dépôt de dossier de mariage</strong> : Ce service permet à
+              des usagers souhaitant contracter un mariage de compléter en ligne les informations
+              nécessaires à cette union et de télécharger leurs pièces justificatives constituant
+              leur dossier. L’ensemble est envoyé à la commune chargée de célébrer le mariage.
+            </p>
 
     api_pro_sante_connect:
       scopes:

--- a/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
+++ b/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
@@ -11,6 +11,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation Démarches du bouquet d
     * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
     * je coche "RCO - Recensement Citoyen Obligatoire"
     * je coche "JCC - Déclaration de Changement de Coordonnées"
+    * je coche "DDMariage - Pré-dépôt de dossier de mariage"
 
     * je remplis les informations du contact "Administrateur local" avec :
       | Nom    | Prénom | Email               | Téléphone   | Fonction              |
@@ -33,11 +34,12 @@ Fonctionnalité: Soumission d'une demande d'habilitation Démarches du bouquet d
     Et je suis sur la page "Démarches du bouquet de services (service-public.fr)"
 
   Scénario: Je remplis une demande d’habilitation avec un champ du contact manquant
-    Quand je démarre une nouvelle demande d’habilitation "Démarches du bouquet de services (service-public.fr)"
+    Quand je démarre une nouvelle demande d'habilitation "Démarches du bouquet de services (service-public.fr)"
     * je coche "AEC - Acte d’Etat Civil"
     * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
     * je coche "RCO - Recensement Citoyen Obligatoire"
     * je coche "JCC - Déclaration de Changement de Coordonnées"
+    * je coche "DDMariage - Pré-dépôt de dossier de mariage"
 
     * je remplis les informations du contact "Administrateur local" avec :
       | Nom    | Prénom | Email               | Téléphone   | Fonction de l'administrateur local |


### PR DESCRIPTION
Permet aux communes de s’abonner à la démarche « Pré-dépôt de dossier de mariage » (code DILA DDMariage) depuis le formulaire « Démarches du bouquet de services (service-public.fr) ».

La case, son libellé dans l’introduction et sa description dans le bloc « En quoi consistent ces démarches » sont ajoutés, et le scope est mappé vers le processCode HubEE DDMariage à l’approbation.

<img width="3024" height="6514" alt="screencapture-localhost-3000-formulaires-hubee-dila-demande-commencer-2026-06-29-13_02_07" src="https://github.com/user-attachments/assets/5aefb601-2f4d-4eec-9e91-4a089c082cce" />

<img width="2166" height="1002" alt="Capture d’écran 2026-06-29 à 13 02 30" src="https://github.com/user-attachments/assets/6af89df0-8d4d-4f3f-8a33-0a5e8400e4c8" />
