### PR TITLE
Aligner le form_uid sur le type lors d'un restore d'autorisation

### DIFF
--- a/app/interactors/restore_authorization_request_to_authorization.rb
+++ b/app/interactors/restore_authorization_request_to_authorization.rb
@@ -17,11 +17,16 @@ class RestoreAuthorizationRequestToAuthorization < ApplicationInteractor
       authorization_request_params:,
       skip_validation: true,
     )
-    authorization_request.type = authorization.authorization_request_class
+    restore_type_and_form_from_authorization!
 
     return if interactor.success?
 
     context.fail!
+  end
+
+  def restore_type_and_form_from_authorization!
+    authorization_request.type = authorization.authorization_request_class
+    authorization_request.form_uid = authorization.form_uid if authorization.form_uid.present?
   end
 
   def authorization_request_params

--- a/spec/interactors/restore_authorization_request_to_latest_authorization_spec.rb
+++ b/spec/interactors/restore_authorization_request_to_latest_authorization_spec.rb
@@ -41,5 +41,61 @@ RSpec.describe RestoreAuthorizationRequestToLatestAuthorization, type: :interact
         expect { restore }.to change { authorization_request.reload.scopes }.to([])
       end
     end
+
+    context 'when a sandbox authorization was validated more recently than the production one' do
+      let(:authorization_request) { create(:authorization_request, :api_sfip_stationnement_residentiel_production, :validated) }
+
+      before do
+        authorization_request.authorizations.create!(
+          applicant: authorization_request.applicant,
+          authorization_request_class: 'AuthorizationRequest::APISFiPSandbox',
+          form_uid: 'api-sfip-stationnement-residentiel-sandbox',
+          data: authorization_request.data,
+          created_at: 1.day.from_now,
+        )
+      end
+
+      it 'restores to the most recently validated authorization (the sandbox)' do
+        restore
+
+        expect(AuthorizationRequest.find(authorization_request.id).type).to eq('AuthorizationRequest::APISFiPSandbox')
+      end
+
+      it 'aligns the form_uid with the restored sandbox stage so type and form_uid stay coherent' do
+        restore
+
+        restored = AuthorizationRequest.find(authorization_request.id)
+        expect(restored.form_uid).to eq('api-sfip-stationnement-residentiel-sandbox')
+        expect(restored.form.authorization_request_class.to_s).to eq(restored.type)
+      end
+    end
+
+    context 'when an older production authorization exists but the sandbox was validated more recently' do
+      let(:authorization_request) { create(:authorization_request, :api_sfip_stationnement_residentiel_sandbox, :validated) }
+
+      before do
+        authorization_request.authorizations.create!(
+          applicant: authorization_request.applicant,
+          authorization_request_class: 'AuthorizationRequest::APISFiP',
+          form_uid: 'api-sfip-stationnement-residentiel-production',
+          data: authorization_request.data,
+          created_at: 1.day.ago,
+        )
+      end
+
+      it 'restores to the most recently validated authorization (the sandbox), not the most advanced stage' do
+        restore
+
+        expect(AuthorizationRequest.find(authorization_request.id).type).to eq('AuthorizationRequest::APISFiPSandbox')
+      end
+
+      it 'keeps type and form_uid coherent on the sandbox stage' do
+        restore
+
+        restored = AuthorizationRequest.find(authorization_request.id)
+        expect(restored.form_uid).to eq('api-sfip-stationnement-residentiel-sandbox')
+        expect(restored.form.authorization_request_class.to_s).to eq(restored.type)
+      end
+    end
   end
 end


### PR DESCRIPTION
Ça va faire plaisir qu'on clean tout ça :upside_down_face: 

En résumé ici : une demande dgfip avait un cycle "sandbox+production" validé, on lance une réouverture de la sandbox, cette réouverture est validée, on continue avec la réouverture de production mais on l'annule -> plantage.

Le comportement avec cette PR : on annule la réouverture de production, on retombe sur la dernière sandbox validée qui propose de poursuivre avec l'étape de production.

---

Pour une demande multi-stage (sandbox/production), annuler une réouverture (ou refuser une demande) restaure la demande vers sa dernière autorisation validée. Le restore réaffectait le `type` depuis cette autorisation mais ne touchait jamais le `form_uid` : quand la dernière autorisation validée est sur un autre stage que le `form_uid` courant (p. ex. une sandbox revalidée pendant une réouverture alors que le form_uid était passé en production), `type` et `form_uid` divergeaient.

Conséquence : le contrôleur résout `form_uid` → classe production puis `Production.find(id)` ne matche pas une ligne typée Sandbox → RecordNotFound → 404, l'utilisateur ne peut plus accéder à sa demande.

Le choix de l'autorisation cible (la plus récemment validée) est correct et inchangé : annuler doit ramener au dernier stage validé pour pouvoir poursuivre le processus. Le seul défaut était que le `form_uid` ne suivait pas le `type`.

RestoreAuthorizationRequestToAuthorization aligne désormais le `form_uid` sur le snapshot de l'autorisation restaurée, en plus du `type`, pour que les deux restent cohérents (garde `if present?` pour ne pas blanchir les anciennes autorisations sans snapshot form_uid).

Specs de non-régression : après restore, type et form_uid restent cohérents sur le stage de la dernière autorisation validée, qu'une sandbox plus récente coexiste avec une production ou l'inverse.

Fixes https://linear.app/pole-api/issue/DP-1817/erreur-404-a-la-consultation-dune-demande-de-maj