### PR TITLE
Ne plus masquer le request de ViewComponent dans UserAlertsComponent

### DIFF
--- a/app/components/habilitation/user_alerts_component.rb
+++ b/app/components/habilitation/user_alerts_component.rb
@@ -3,7 +3,7 @@ class Habilitation::UserAlertsComponent < ApplicationComponent
 
   CALLOUT_CLASSES = 'fr-my-16v'.freeze
 
-  delegate :request, to: :authorization
+  delegate :request, to: :authorization, prefix: true
 
   def initialize(authorization:, current_user:)
     @authorization = authorization
@@ -31,7 +31,7 @@ class Habilitation::UserAlertsComponent < ApplicationComponent
   end
 
   def show_update_in_progress_alert?
-    authorization.latest? && request.reopening?
+    authorization.latest? && authorization_request.reopening?
   end
 
   def access_callout
@@ -55,7 +55,7 @@ class Habilitation::UserAlertsComponent < ApplicationComponent
   def access_callout_button
     link_to(
       I18n.t('authorization_requests.show.access_callout.button'),
-      request.access_link,
+      authorization_request.access_link,
       class: 'fr-btn fr-btn--icon-right fr-icon-external-link-line',
       target: '_blank',
       rel: 'noopener external',
@@ -64,14 +64,14 @@ class Habilitation::UserAlertsComponent < ApplicationComponent
   end
 
   def access_callout_content
-    I18n.t('authorization_requests.show.access_callout.content', access_name: request.name)
+    I18n.t('authorization_requests.show.access_callout.content', access_name: authorization_request.name)
   end
 
   def show_access_callout?
-    request.access_link.present? && request.validated? && current_user_is_applicant?
+    authorization_request.access_link.present? && authorization_request.validated? && current_user_is_applicant?
   end
 
   def current_user_is_applicant?
-    current_user == request.applicant
+    current_user == authorization_request.applicant
   end
 end

--- a/spec/components/habilitation/user_alerts_component_spec.rb
+++ b/spec/components/habilitation/user_alerts_component_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe Habilitation::UserAlertsComponent, type: :component do
       end
     end
 
+    context 'when rendered with view file annotations enabled (development setting)' do
+      let(:authorization_request) { create(:authorization_request, :api_entreprise, :validated) }
+      let(:authorization) { authorization_request.latest_authorization }
+
+      around do |example|
+        previous = ActionView::Base.annotate_rendered_view_with_filenames
+        ActionView::Base.annotate_rendered_view_with_filenames = true
+        example.run
+      ensure
+        ActionView::Base.annotate_rendered_view_with_filenames = previous
+      end
+
+      it 'renders without delegating format to the authorization request' do
+        expect { render_inline(component) }.not_to raise_error
+        expect(page).to have_css('.fr-callout')
+      end
+    end
+
     context 'when user is not applicant' do
       let(:authorization_request) { create(:authorization_request, :api_entreprise, :validated) }
       let(:authorization) { authorization_request.latest_authorization }


### PR DESCRIPTION
Linear : [DP-1840](https://linear.app/pole-api/issue/DP-1840)

Habilitation::UserAlertsComponent déléguait `request` vers son `authorization`, ce qui masquait le `request` HTTP natif de ViewComponent. Quand le composant s'affiche (rendu inline via `call`), ViewComponent évalue `request&.format == :html` pour l'annotation des fichiers de vue (activée en développement) : `format` était alors appelé sur le AuthorizationRequestDecorator (méthode privée Kernel#format) → 500 sur /habilitations/:id en développement (sans impact en production, où l'annotation est désactivée).

La délégation est renommée (`prefix: true` → `authorization_request`) pour ne plus masquer `request`. Test de non-régression : rendu du composant avec annotate_rendered_view_with_filenames activé.
