### PR TITLE
DP-1820 — Durcir la session à 12 h fixes (suppression du glissement 24 h)

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -28,8 +28,8 @@ module Authentication
 
     session[:user_id] = {
       value: user.id,
-      expires_at: SESSION_IDLE_TIMEOUT.from_now,
-      absolute_expires_at: SESSION_ABSOLUTE_TIMEOUT.from_now,
+      expires_at: SESSION_MAX_DURATION.from_now,
+      max_duration: SESSION_MAX_DURATION.to_i,
       identity_federator:,
       identity_provider_uid:,
     }
@@ -54,7 +54,6 @@ module Authentication
     if user_signed_in?
       raise ApplicationController::BannedUserError if current_user.banned?
 
-      slide_session_expiry
       return
     end
 

--- a/app/controllers/concerns/authentication/session_lifecycle.rb
+++ b/app/controllers/concerns/authentication/session_lifecycle.rb
@@ -1,6 +1,5 @@
 module Authentication::SessionLifecycle
-  SESSION_IDLE_TIMEOUT = 12.hours
-  SESSION_ABSOLUTE_TIMEOUT = 24.hours
+  SESSION_MAX_DURATION = 12.hours
 
   ROTATION_PRESERVED_KEYS = %w[
     omniauth.pc.access_token
@@ -13,7 +12,11 @@ module Authentication::SessionLifecycle
     user_id_session.present? &&
       user_id_session['value'].present? &&
       future_timestamp?(user_id_session['expires_at']) &&
-      future_timestamp?(user_id_session['absolute_expires_at'])
+      valid_duration?(user_id_session['max_duration'])
+  end
+
+  def self.valid_duration?(duration)
+    duration.to_i == SESSION_MAX_DURATION.to_i
   end
 
   def self.future_timestamp?(timestamp)
@@ -45,15 +48,5 @@ module Authentication::SessionLifecycle
     preserved = session.to_hash.slice(*ROTATION_PRESERVED_KEYS)
     reset_session
     preserved.each { |key, value| session[key] = value }
-  end
-
-  def slide_session_expiry
-    session[:user_id] = user_id_session.merge(
-      'expires_at' => [SESSION_IDLE_TIMEOUT.from_now, absolute_expires_at_time].min
-    )
-  end
-
-  def absolute_expires_at_time
-    Authentication::SessionLifecycle.normalize_timestamp(user_id_session['absolute_expires_at'])
   end
 end

--- a/docs/technique/authentification_proconnect.md
+++ b/docs/technique/authentification_proconnect.md
@@ -1,56 +1,55 @@
 # Authentification des agents via ProConnect
 
-Ce document décrit le processus complet d’authentification d’un agent sur DataPass.
+Ce document décrit le processus complet d'authentification d'un agent sur DataPass.
 Il couvre le flux ProConnect (actuel), la chaîne de traitement côté DataPass, la gestion
 de session, la déconnexion, les mécanismes de sécurité, et le provider legacy MonComptePro.
 
 > Ce document se lit à deux niveaux. La section **« Le principe en bref »** ci-dessous donne
-> une vue d’ensemble accessible sans connaissance technique. Les sections suivantes entrent
-> dans le détail du code et s’adressent aux développeurs. Un **glossaire** est disponible en
+> une vue d'ensemble accessible sans connaissance technique. Les sections suivantes entrent
+> dans le détail du code et s'adressent aux développeurs. Un **glossaire** est disponible en
 > fin de page.
 
 ## Le principe en bref
 
-DataPass ne gère pas lui-même l’authentification des agents : il la délègue entièrement à
-ProConnect. ProConnect joue le rôle de fédérateur d’identité — une porte d’entrée unique qui
-s’appuie, selon l’agent, sur le fournisseur d’identité adéquat (l’annuaire de son ministère,
-ProConnect-Identité pour les agents sans annuaire dédié, etc.), choisi d’après le domaine de
+DataPass ne gère pas lui-même l'authentification des agents : il la délègue entièrement à
+ProConnect. ProConnect joue le rôle de fédérateur d'identité — une porte d'entrée unique qui
+s'appuie, selon l'agent, sur le fournisseur d'identité adéquat (l'annuaire de son ministère,
+ProConnect-Identité pour les agents sans annuaire dédié, etc.), choisi d'après le domaine de
 son email.
 
 Le déroulé est le suivant :
 
-- L’agent demande à se connecter à DataPass, qui le redirige vers ProConnect.
+- L'agent demande à se connecter à DataPass, qui le redirige vers ProConnect.
 - ProConnect vérifie son identité auprès du bon fournisseur. Lorsque ce fournisseur impose une
-  double authentification, DataPass s’assure qu’elle a bien eu lieu et la réclame activement si
-  ProConnect ne l’a pas déjà appliquée. DataPass ne voit jamais le mot de passe de l’agent.
-- Une fois l’agent authentifié, ProConnect renvoie à DataPass une preuve d’identité, que
-  DataPass échange en arrière-plan contre les informations de l’agent : nom, email, et surtout
-  le SIRET de l’organisation où il travaille.
-- DataPass en déduit trois choses : qui est l’agent, dans quelle organisation il travaille, et
+  double authentification, DataPass s'assure qu'elle a bien eu lieu et la réclame activement si
+  ProConnect ne l'a pas déjà appliquée. DataPass ne voit jamais le mot de passe de l'agent.
+- Une fois l'agent authentifié, ProConnect renvoie à DataPass une preuve d'identité, que
+  DataPass échange en arrière-plan contre les informations de l'agent : nom, email, et surtout
+  le SIRET de l'organisation où il travaille.
+- DataPass en déduit trois choses : qui est l'agent, dans quelle organisation il travaille, et
   si ce lien peut être considéré comme vérifié. Il ouvre alors une session applicative courte,
   alignée sur ProConnect.
-- La session suit un modèle **idle glissant** : chaque requête repousse l’échéance à 12 h
-  d’inactivité, sans jamais dépasser un **plafond absolu de 24 h** depuis la connexion. Au-delà —
-  12 h sans activité ou 24 h au total — ou après une déconnexion, le parcours complet recommence.
-  Cet alignement sur les 12 h de ProConnect réduit la fenêtre d’exposition (poste partagé, cookie
-  volé).
+- La session suit un modèle à **plafond absolu de 12 h** : `expires_at` est fixé à la connexion
+  (`signed_in_at + 12 h`) et n'est jamais prolongé. Au-delà de 12 h — ou après une déconnexion
+  — le parcours complet recommence. Cet alignement sur les 12 h de ProConnect réduit la fenêtre
+  d'exposition (poste partagé, cookie volé).
 
-Les sections suivantes détaillent l’implémentation de ce parcours.
+Les sections suivantes détaillent l'implémentation de ce parcours.
 
-## Vue d’ensemble
+## Vue d'ensemble
 
 ```mermaid
 flowchart LR
-    N["Navigateur de l’agent"] <--> DP["DataPass (app Rails)"]
-    DP <--> PC["ProConnect (le fédérateur d’identité)"]
-    PC <--> FI["Fournisseur d’Identité réel<br/>ex: ministère, MonComptePro"]
+    N["Navigateur de l'agent"] <--> DP["DataPass (app Rails)"]
+    DP <--> PC["ProConnect (le fédérateur d'identité)"]
+    PC <--> FI["Fournisseur d'Identité réel<br/>ex: ministère, MonComptePro"]
 ```
 
-Idée centrale : **DataPass ne gère aucun mot de passe.** Il délègue la preuve d’identité à
+Idée centrale : **DataPass ne gère aucun mot de passe.** Il délègue la preuve d'identité à
 ProConnect, qui est un *fédérateur* : un seul bouton « ProConnect » côté DataPass, mais
-plusieurs fournisseurs d’identité (FI) derrière (l’IdP d’un ministère, ProConnect-Identité
+plusieurs fournisseurs d'identité (FI) derrière (l'IdP d'un ministère, ProConnect-Identité
 ex-MonComptePro pour les agents sans IdP dédié, etc.). ProConnect choisit le bon FI selon le
-domaine de l’email de l’agent.
+domaine de l'email de l'agent.
 
 Le protocole est **OpenID Connect (OIDC)**, dans sa variante « Authorization Code Flow ».
 
@@ -62,44 +61,44 @@ sequenceDiagram
     participant N as Navigateur
     participant DP as DataPass
     participant PC as ProConnect
-    participant FI as Fournisseur d’Identité
+    participant FI as Fournisseur d'Identité
 
     N->>DP: POST /auth/proconnect (clic sur le bouton)
     Note over DP: Découvre les endpoints ProConnect<br/>Génère state + nonce
     DP-->>N: Redirige vers ProConnect<br/>client_id, redirect_uri, scope, state, nonce
     N->>PC: authorization_endpoint
-    PC->>FI: Demande d’authentifier l’agent
-    FI-->>N: L’agent s’authentifie (mot de passe, MFA…)
+    PC->>FI: Demande d'authentifier l'agent
+    FI-->>N: L'agent s'authentifie (mot de passe, MFA…)
     PC-->>N: Redirige vers /auth/proconnect/callback?code=XXX&state=…
     N->>DP: GET /auth/proconnect/callback
     Note over DP: Vérifie le state
     DP->>PC: Échange code → tokens (back-channel, client_secret)
     PC-->>DP: access_token + id_token + refresh_token
     DP->>PC: GET userinfo (Bearer access_token)
-    PC-->>DP: Infos de l’agent (un JWT)
+    PC-->>DP: Infos de l'agent (un JWT)
     Note over DP: Crée user + organisation<br/>+ session DataPass
     DP-->>N: Redirige vers le dashboard (connecté)
 ```
 
 Étapes détaillées :
 
-1. **Départ.** L’agent clique sur le bouton (`_pro_connect.html.erb` →
+1. **Départ.** L'agent clique sur le bouton (`_pro_connect.html.erb` →
    `POST /auth/proconnect`). La gem `omniauth-proconnect` intercepte cette route. Elle
    interroge ProConnect pour découvrir ses endpoints (`discover_endpoint!` sur
    `.well-known/openid-configuration`), génère un `state` et un `nonce` stockés en session.
-2. **Redirection.** La gem renvoie le navigateur vers l’`authorization_endpoint` de
+2. **Redirection.** La gem renvoie le navigateur vers l'`authorization_endpoint` de
    ProConnect avec `client_id`, `redirect_uri`, `scope`, `state`, `nonce`.
-3. **Authentification chez ProConnect.** L’agent choisit son organisation, s’authentifie,
+3. **Authentification chez ProConnect.** L'agent choisit son organisation, s'authentifie,
    fait éventuellement une double authentification. DataPass ne voit rien de cette étape.
 4. **Retour avec un code.** ProConnect renvoie le navigateur vers
    `/auth/proconnect/callback` avec un `code` à usage unique et le `state`. DataPass vérifie
-   d’abord que le `state` correspond à celui qu’il avait émis (`verify_state!`).
+   d'abord que le `state` correspond à celui qu'il avait émis (`verify_state!`).
 5. **Échange code → tokens (back-channel).** Le `code` seul est inutile. DataPass rappelle
-   ProConnect **de serveur à serveur** (le navigateur n’est pas dans la boucle), avec son
+   ProConnect **de serveur à serveur** (le navigateur n'est pas dans la boucle), avec son
    `client_secret`, pour échanger le code contre des tokens (`access_token`, `id_token`,
    `refresh_token`), stockés en session sous `omniauth.pc.*`.
 6. **Récupération des infos agent.** DataPass appelle le `userinfo_endpoint` avec
-   l’`access_token`. Particularité ProConnect : la réponse est un **JWT** (jeton signé), pas
+   l'`access_token`. Particularité ProConnect : la réponse est un **JWT** (jeton signé), pas
    du JSON brut. Il est décodé dans `@userinfo`. Claims utiles : `sub` (identifiant unique),
    `email`, `given_name`, `usual_name`, `siret`, `idp_id` (quel FI a servi), `phone_number`.
 7. **Construction côté DataPass.** Voir la section suivante.
@@ -107,119 +106,122 @@ sequenceDiagram
 ## Traitement côté DataPass (étape 7)
 
 Le `SessionsController#create` reçoit le callback OmniAuth, aiguille vers
-`create_from_proconnect`, vérifie le MFA (voir plus bas), puis appelle l’organizer
+`create_from_proconnect`, vérifie le MFA (voir plus bas), puis appelle l'organizer
 `AuthenticateUserThroughProConnect` :
 
 ```mermaid
 flowchart TD
     B["before — idp_id, identity_federator,<br/>lien de confiance (siret_verified ?)"]
-    B --> S1["1. FindOrCreateOrganizationThroughProConnect<br/>cherche/crée l’organisation via le SIRET"]
+    B --> S1["1. FindOrCreateOrganizationThroughProConnect<br/>cherche/crée l'organisation via le SIRET"]
     S1 --> S2["2. UpdateOrganizationINSEEPayload<br/>enrichit avec les données INSEE Sirene"]
-    S2 --> S3["3. FindOrCreateUserThroughProConnect<br/>cherche/crée l’agent via l’email"]
+    S2 --> S3["3. FindOrCreateUserThroughProConnect<br/>cherche/crée l'agent via l'email"]
     S3 --> S4["4. AddUserToOrganization<br/>relie agent ↔ organisation (verified ?)"]
-    S4 --> S5["5. ChangeUserCurrentOrganization<br/>définit l’organisation courante"]
+    S4 --> S5["5. ChangeUserCurrentOrganization<br/>définit l'organisation courante"]
     S5 --> A["after — sauvegarde organisation + user"]
 ```
 
-Trois objets distincts en sortent : **qui** est l’agent (User, via email), **où** il travaille
+Trois objets distincts en sortent : **qui** est l'agent (User, via email), **où** il travaille
 (Organization, via SIRET enrichi INSEE), et le **lien de confiance** entre les deux (`verified`
 ou non, selon le FI).
 
 Le controller appelle ensuite `sign_in`, qui crée la **session applicative DataPass**. La logique
-de cycle de vie est isolée dans le concern `Authentication::SessionLifecycle` (durées, validation,
-glissement, rotation). Au login, `rotate_session` régénère l’identifiant de session (protection
+de cycle de vie est isolée dans le concern `Authentication::SessionLifecycle` (durée, validation,
+rotation). Au login, `rotate_session` régénère l'identifiant de session (protection
 contre la *fixation de session*) tout en préservant les tokens ProConnect (`omniauth.pc.*`) et le
-chemin de retour. La session porte deux échéances : `expires_at` (12 h glissantes,
-`SESSION_IDLE_TIMEOUT`) et `absolute_expires_at` (plafond fixe 24 h, `SESSION_ABSOLUTE_TIMEOUT`) :
+chemin de retour. La session porte un unique plafond absolu : `expires_at` fixé à la connexion
+(`SESSION_MAX_DURATION = 12.hours`) :
 
 ```ruby
 rotate_session
 
 session[:user_id] = {
   value: user.id,
-  expires_at: SESSION_IDLE_TIMEOUT.from_now,
-  absolute_expires_at: SESSION_ABSOLUTE_TIMEOUT.from_now,
+  expires_at: SESSION_MAX_DURATION.from_now,
   identity_federator:,
   identity_provider_uid:,
 }
 ```
 
 Enfin, si le FI a `choose_organization_on_sign_in?` à vrai (agent multi-organisations), DataPass
-redirige vers la page de choix d’organisation (`user_organizations_path`). Sinon, direction le
+redirige vers la page de choix d'organisation (`user_organizations_path`). Sinon, direction le
 dashboard.
 
-## Connexions suivantes : ProConnect n’est plus sollicité
+## Connexions suivantes : ProConnect n'est plus sollicité
 
 ```mermaid
 flowchart TD
-    A["Requête de l’agent"] --> B["before_action :authenticate_user!<br/>(concern Authentication)"]
-    B --> C{"session valide ?<br/>value + expires_at (idle) + absolute_expires_at<br/>tous deux dans le futur"}
-    C -- Oui --> D["Glisse expires_at à +12 h<br/>(plafonné à absolute_expires_at)<br/>puis accès autorisé"]
+    A["Requête de l'agent"] --> B["before_action :authenticate_user!<br/>(concern Authentication)"]
+    B --> C{"session valide ?<br/>value + expires_at dans le futur"}
+    C -- Oui --> D["Accès autorisé<br/>(expires_at non modifié)"]
     C -- Non --> E["Redirige vers la connexion<br/>relance tout le flux ProConnect"]
 ```
 
-Une fois connecté, DataPass vit sur **sa propre session** (cookie chiffré, 12 h glissantes
-plafonnées à 24 h). À chaque requête authentifiée, `slide_session_expiry` repousse `expires_at` à
-12 h, borné par `absolute_expires_at`. Un ancien cookie « 1 mois » dépourvu d’`absolute_expires_at`
-est désormais considéré invalide → reconnexion douce (re-clic silencieux si la session ProConnect
-est encore active). DataPass ne rappelle pas ProConnect à chaque page ; ProConnect ne sert qu’à
-prouver l’identité au moment du login.
+Une fois connecté, DataPass vit sur **sa propre session** (cookie chiffré, plafond absolu de
+12 h). À chaque requête authentifiée, `expires_at` est vérifié mais jamais prolongé : un seul
+timer fixe depuis la connexion. Un ancien cookie sans `expires_at` futur est invalide →
+reconnexion douce (re-clic silencieux si la session ProConnect est encore active). DataPass ne
+rappelle pas ProConnect à chaque page ; ProConnect ne sert qu'à prouver l'identité au moment du
+login.
+
+> **DP-1820** a simplifié le modèle introduit par DP-1789 : l'ancien mécanisme de fenêtre
+> glissante (`slide_session_expiry`) et le plafond secondaire de 24 h (`SESSION_ABSOLUTE_TIMEOUT`,
+> `absolute_expires_at`) sont supprimés. Il reste un seul timer absolu : `expires_at`.
 
 Il y a donc **deux sessions distinctes** :
 
 - les **tokens ProConnect** (`omniauth.pc.*`) — utilisés au login et conservés surtout pour la
   déconnexion globale ;
-- la **session applicative DataPass** (`session[:user_id]`) — c’est elle qui maintient l’agent
-  connecté tant qu’il reste actif (≤ 12 h entre deux requêtes, 24 h au total).
+- la **session applicative DataPass** (`session[:user_id]`) — c'est elle qui maintient l'agent
+  connecté (plafond absolu 12 h depuis la connexion, sans prolongation par l'activité).
 
 ## Mécanismes de sécurité
 
-**Le `state` — éviter qu’une connexion soit détournée.**
-Au moment d’envoyer l’agent vers ProConnect, DataPass génère un identifiant aléatoire propre à
+**Le `state` — éviter qu'une connexion soit détournée.**
+Au moment d'envoyer l'agent vers ProConnect, DataPass génère un identifiant aléatoire propre à
 cette tentative de connexion, le conserve dans la session et le transmet à ProConnect, qui le
 renvoie inchangé. Au retour, DataPass vérifie que les deux correspondent (`verify_state!`). Sans
-ce contrôle, un tiers pourrait forger une réponse d’authentification et la faire traiter par le
+ce contrôle, un tiers pourrait forger une réponse d'authentification et la faire traiter par le
 navigateur de la victime (attaque CSRF) ; le `state` garantit que la réponse traitée répond bien
 à une demande émise depuis ce navigateur. En cas de différence, la connexion est rejetée.
 
-**Le `nonce` — empêcher la réutilisation d’un ancien jeton.**
+**Le `nonce` — empêcher la réutilisation d'un ancien jeton.**
 DataPass insère un second identifiant aléatoire dans la demande ; ProConnect le réinscrit à
-l’intérieur de l’`id_token` qu’il délivre. DataPass vérifie ainsi que le jeton reçu a bien été
-émis pour cette demande précise, et non rejoué à partir d’un échange antérieur intercepté. Là où
-le `state` protège l’aller-retour de la requête, le `nonce` protège le contenu du jeton.
+l'intérieur de l'`id_token` qu'il délivre. DataPass vérifie ainsi que le jeton reçu a bien été
+émis pour cette demande précise, et non rejoué à partir d'un échange antérieur intercepté. Là où
+le `state` protège l'aller-retour de la requête, le `nonce` protège le contenu du jeton.
 
-**Le MFA conditionnel — exiger la double authentification quand le fournisseur l’impose.**
-(Ajouté en janvier 2026.) Certains fournisseurs d’identité imposent une authentification à deux
-facteurs, mais ProConnect ne l’applique pas systématiquement. Au retour, DataPass lit dans
-l’`id_token` le champ `amr` (`proconnect_id_token_amr`) — la liste des méthodes d’authentification
+**Le MFA conditionnel — exiger la double authentification quand le fournisseur l'impose.**
+(Ajouté en janvier 2026.) Certains fournisseurs d'identité imposent une authentification à deux
+facteurs, mais ProConnect ne l'applique pas systématiquement. Au retour, DataPass lit dans
+l'`id_token` le champ `amr` (`proconnect_id_token_amr`) — la liste des méthodes d'authentification
 réellement employées. Si le fournisseur exige le MFA (`identity_provider.mfa_required?`) alors que
-`amr` n’en porte pas la trace, DataPass relance une tentative ProConnect en réclamant explicitement
+`amr` n'en porte pas la trace, DataPass relance une tentative ProConnect en réclamant explicitement
 ce niveau de garantie (`authorization_uri_with_mfa`, qui force les valeurs attendues listées dans
-`MFA_ACR_VALUES`). L’agent doit alors compléter sa double authentification avant d’accéder à
-DataPass. C’est la partie la plus subtile de `config/initializers/omniauth.rb`.
+`MFA_ACR_VALUES`). L'agent doit alors compléter sa double authentification avant d'accéder à
+DataPass. C'est la partie la plus subtile de `config/initializers/omniauth.rb`.
 
-> Repères : `amr` (*Authentication Methods References*) = les méthodes d’authentification
+> Repères : `amr` (*Authentication Methods References*) = les méthodes d'authentification
 > employées ; `acr` (*Authentication Context Class Reference*) = le niveau de garantie atteint.
 
 **La rotation de session — empêcher la fixation de session.**
-Au moment du login (`sign_in`), DataPass régénère l’identifiant de session (`rotate_session` →
-`reset_session`) pour qu’un identifiant éventuellement connu d’un attaquant avant authentification
+Au moment du login (`sign_in`), DataPass régénère l'identifiant de session (`rotate_session` →
+`reset_session`) pour qu'un identifiant éventuellement connu d'un attaquant avant authentification
 ne donne aucun accès après. Les clés strictement nécessaires sont préservées : les tokens
 ProConnect (`omniauth.pc.access_token`, `id_token`, `refresh_token`, indispensables au logout
-global) et `return_to_after_sign_in`. La durée de session courte (12 h / 24 h) complète ce
-durcissement en réduisant la fenêtre d’exploitation d’un cookie volé.
+global) et `return_to_after_sign_in`. Le plafond absolu de 12 h complète ce durcissement en
+réduisant la fenêtre d'exploitation d'un cookie volé.
 
-**La durée de session courte — réduire la fenêtre d’exposition.**
-L’ordre des contrôles dans `authenticate_user!` est volontaire : validité de session, puis
-bannissement (`BannedUserError`), puis seulement `slide_session_expiry` — pour ne jamais prolonger
-la session d’un agent banni. Limites de ce palier *stateless* (cookie store, sans store serveur) :
-pas de révocation à distance ni de « déconnecter partout », un cookie volé reste valide jusqu’à son
-expiration (12-24 h). Ces points seront traités par **DP-1790** (store serveur révocable).
+**La durée de session courte — réduire la fenêtre d'exposition.**
+L'ordre des contrôles dans `authenticate_user!` est volontaire : validité de session, puis
+bannissement (`BannedUserError`), puis `return` — pour ne jamais autoriser l'accès d'un agent
+banni. Limites de ce palier *stateless* (cookie store, sans store serveur) : pas de révocation à
+distance ni de « déconnecter partout », un cookie volé reste valide jusqu'à son expiration (12 h).
+Ces points seront traités par **DP-1790** (store serveur révocable).
 
 ## Validation partagée avec Rails Pulse
 
 Le tableau de bord Rails Pulse (`/rails_pulse`) est réservé aux admins. Pour vérifier la
-session, il réutilise le même prédicat que l’app : `Authentication::SessionLifecycle.valid_session?`
+session, il réutilise le même prédicat que l'app : `Authentication::SessionLifecycle.valid_session?`
 (voir `config/initializers/rails_pulse.rb`). Une seule logique de validation, pas de doublon.
 
 ## Déconnexion
@@ -233,23 +235,23 @@ flowchart TD
 
 ## Provider legacy MonComptePro
 
-Un second provider existe dans `config/initializers/omniauth.rb` : `mon_compte_pro` (l’ancêtre,
-AgentConnect/MonComptePro). Même logique générale, mais c’est l’ancienne porte d’entrée, en voie
-d’extinction — les utilisateurs sont migrés vers ProConnect (cf. le commit de forçage MFA de
-janvier 2026). C’est ce provider qui demande le scope `organization`. Le
+Un second provider existe dans `config/initializers/omniauth.rb` : `mon_compte_pro` (l'ancêtre,
+AgentConnect/MonComptePro). Même logique générale, mais c'est l'ancienne porte d'entrée, en voie
+d'extinction — les utilisateurs sont migrés vers ProConnect (cf. le commit de forçage MFA de
+janvier 2026). C'est ce provider qui demande le scope `organization`. Le
 `SessionsController#create` aiguille entre les deux providers selon `params[:provider]`
 (`mon_compte_pro_connect?`).
 
 Chaîne MonComptePro équivalente : `AuthenticateUserThroughMonComptePro`, avec
 `FindOrCreateOrganizationThroughMonComptePro` et `FindOrCreateUserThroughMonComptePro`. Deux
 prompts spécifiques MonComptePro sont gérés au retour : `select_organization` (changer
-d’organisation courante) et `update_userinfo` (rafraîchir les infos de l’agent).
+d'organisation courante) et `update_userinfo` (rafraîchir les infos de l'agent).
 
 ## En une phrase
 
-ProConnect prouve l’identité une fois (OIDC code flow) ; DataPass en tire trois objets — agent,
-organisation, lien de confiance — puis vit sur sa propre session courte (idle glissant 12 h,
-plafonné à 24 h).
+ProConnect prouve l'identité une fois (OIDC code flow) ; DataPass en tire trois objets — agent,
+organisation, lien de confiance — puis vit sur sa propre session courte (plafond absolu 12 h
+depuis la connexion, sans prolongation par l'activité).
 
 ## Fichiers de référence
 
@@ -261,29 +263,29 @@ plafonné à 24 h).
 | Bouton de connexion | `app/views/pages/shared/unauthenticated_pages/_pro_connect.html.erb` |
 | Aiguillage du callback, MFA, logout | `app/controllers/sessions_controller.rb` |
 | Session applicative (sign_in/out) | `app/controllers/concerns/authentication.rb` |
-| Cycle de vie de session (durées, glissement, rotation) | `app/controllers/concerns/authentication/session_lifecycle.rb` |
+| Cycle de vie de session (durée, validation, rotation) | `app/controllers/concerns/authentication/session_lifecycle.rb` |
 | Organizer ProConnect | `app/organizers/authenticate_user_through_pro_connect.rb` |
 | Organisation depuis le SIRET | `app/interactors/find_or_create_organization_through_pro_connect.rb` |
 | Enrichissement INSEE | `app/interactors/update_organization_insee_payload.rb` |
-| User depuis l’email | `app/interactors/find_or_create_user_through_pro_connect.rb` |
+| User depuis l'email | `app/interactors/find_or_create_user_through_pro_connect.rb` |
 | Lien agent ↔ organisation | `app/interactors/add_user_to_organization.rb` |
 | Organisation courante | `app/interactors/change_user_current_organization.rb` |
-| Caractéristiques d’un FI | `app/models/identity_provider.rb` + `config/identity_providers.yml` |
+| Caractéristiques d'un FI | `app/models/identity_provider.rb` + `config/identity_providers.yml` |
 | Provider legacy | `app/organizers/authenticate_user_through_mon_compte_pro.rb` |
 
 ## Glossaire
 
 | Terme | En clair |
 |---|---|
-| **ProConnect** | Le service de l’État qui authentifie les agents publics pour le compte de nombreuses applications. DataPass lui délègue entièrement la connexion. |
-| **Fournisseur d’identité (FI)** | Le service qui détient et vérifie réellement l’identité de l’agent (annuaire d’un ministère, ProConnect-Identité…). ProConnect choisit le bon selon l’email de l’agent. |
-| **OIDC (OpenID Connect)** | Le protocole standard d’authentification déléguée utilisé entre DataPass et ProConnect pour échanger une preuve d’identité de façon sécurisée. |
-| **Fédérateur d’identité** | Un intermédiaire qui regroupe plusieurs fournisseurs d’identité derrière une seule porte d’entrée. ProConnect en est un. |
-| **Token (jeton)** | Une donnée signée délivrée par ProConnect qui atteste que l’agent a été authentifié et permet à DataPass de récupérer ses informations. |
-| **Scope** | La liste des informations que DataPass a le droit de demander sur l’agent (nom, email, SIRET…). |
-| **SIRET** | Le numéro qui identifie officiellement l’organisation (l’employeur) de l’agent. DataPass s’en sert pour reconnaître l’organisation. |
-| **INSEE Sirene** | Le registre officiel des entreprises et administrations. DataPass y récupère les informations détaillées d’une organisation à partir de son SIRET. |
-| **Session** | L’état de connexion maintenu par DataPass après authentification (idle glissant 12 h, plafonné à 24 h), qui évite de repasser par ProConnect à chaque page. |
-| **MFA (double authentification)** | Une vérification supplémentaire (code sur téléphone, application…) exigée par certains fournisseurs d’identité en plus du mot de passe. |
-| **Back-channel** | Un échange direct de serveur à serveur entre DataPass et ProConnect, sans passer par le navigateur de l’agent — donc non exposé côté client. |
-| **state / nonce** | Deux identifiants aléatoires générés par DataPass pour s’assurer que la réponse reçue de ProConnect est authentique et n’est pas rejouée. |
+| **ProConnect** | Le service de l'État qui authentifie les agents publics pour le compte de nombreuses applications. DataPass lui délègue entièrement la connexion. |
+| **Fournisseur d'identité (FI)** | Le service qui détient et vérifie réellement l'identité de l'agent (annuaire d'un ministère, ProConnect-Identité…). ProConnect choisit le bon selon l'email de l'agent. |
+| **OIDC (OpenID Connect)** | Le protocole standard d'authentification déléguée utilisé entre DataPass et ProConnect pour échanger une preuve d'identité de façon sécurisée. |
+| **Fédérateur d'identité** | Un intermédiaire qui regroupe plusieurs fournisseurs d'identité derrière une seule porte d'entrée. ProConnect en est un. |
+| **Token (jeton)** | Une donnée signée délivrée par ProConnect qui atteste que l'agent a été authentifié et permet à DataPass de récupérer ses informations. |
+| **Scope** | La liste des informations que DataPass a le droit de demander sur l'agent (nom, email, SIRET…). |
+| **SIRET** | Le numéro qui identifie officiellement l'organisation (l'employeur) de l'agent. DataPass s'en sert pour reconnaître l'organisation. |
+| **INSEE Sirene** | Le registre officiel des entreprises et administrations. DataPass y récupère les informations détaillées d'une organisation à partir de son SIRET. |
+| **Session** | L'état de connexion maintenu par DataPass après authentification (plafond absolu 12 h depuis la connexion, sans prolongation), qui évite de repasser par ProConnect à chaque page. |
+| **MFA (double authentification)** | Une vérification supplémentaire (code sur téléphone, application…) exigée par certains fournisseurs d'identité en plus du mot de passe. |
+| **Back-channel** | Un échange direct de serveur à serveur entre DataPass et ProConnect, sans passer par le navigateur de l'agent — donc non exposé côté client. |
+| **state / nonce** | Deux identifiants aléatoires générés par DataPass pour s'assurer que la réponse reçue de ProConnect est authentique et n'est pas rejouée. |

--- a/docs/technique/authentification_proconnect.md
+++ b/docs/technique/authentification_proconnect.md
@@ -137,6 +137,7 @@ rotate_session
 session[:user_id] = {
   value: user.id,
   expires_at: SESSION_MAX_DURATION.from_now,
+  max_duration: SESSION_MAX_DURATION.to_i,
   identity_federator:,
   identity_provider_uid:,
 }
@@ -151,15 +152,16 @@ dashboard.
 ```mermaid
 flowchart TD
     A["Requête de l'agent"] --> B["before_action :authenticate_user!<br/>(concern Authentication)"]
-    B --> C{"session valide ?<br/>value + expires_at dans le futur"}
+    B --> C{"session valide ?<br/>value + expires_at futur + max_duration = 12 h"}
     C -- Oui --> D["Accès autorisé<br/>(expires_at non modifié)"]
     C -- Non --> E["Redirige vers la connexion<br/>relance tout le flux ProConnect"]
 ```
 
 Une fois connecté, DataPass vit sur **sa propre session** (cookie chiffré, plafond absolu de
 12 h). À chaque requête authentifiée, `expires_at` est vérifié mais jamais prolongé : un seul
-timer fixe depuis la connexion. Un ancien cookie sans `expires_at` futur est invalide →
-reconnexion douce (re-clic silencieux si la session ProConnect est encore active). DataPass ne
+timer fixe depuis la connexion. Un ancien cookie sans marqueur `max_duration` valide (cookie
+antérieur à DP-1820) est rejeté → reconnexion douce (re-clic silencieux si la session ProConnect
+est encore active). DataPass ne
 rappelle pas ProConnect à chaque page ; ProConnect ne sert qu'à prouver l'identité au moment du
 login.
 

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -210,8 +210,7 @@ end
 Sachantque('ma session a expiré') do
   page.set_rack_session(user_id: {
     'value' => current_user!.id,
-    'expires_at' => 1.hour.ago,
-    'absolute_expires_at' => 1.hour.ago
+    'expires_at' => 1.hour.ago
   })
 end
 

--- a/spec/controllers/concerns/authentication_spec.rb
+++ b/spec/controllers/concerns/authentication_spec.rb
@@ -18,14 +18,19 @@ RSpec.describe Authentication do
   let(:user) { create(:user, :admin) }
   let(:another_user) { create(:user) }
 
+  def user_session(expires_at:, max_duration: 12.hours.to_i)
+    {
+      'value' => user.id,
+      'expires_at' => expires_at
+    }.tap do |attributes|
+      attributes['max_duration'] = max_duration unless max_duration.nil?
+    end
+  end
+
   before do
     routes.draw { get 'show' => 'anonymous#show' }
 
-    session[:user_id] = {
-      'value' => user.id,
-      'expires_at' => 12.hours.from_now,
-      'absolute_expires_at' => 24.hours.from_now
-    }
+    session[:user_id] = user_session(expires_at: 12.hours.from_now)
 
     session[:impersonated_user_id] = another_user.id
   end
@@ -80,13 +85,11 @@ RSpec.describe Authentication do
       end
     end
 
-    it 'sets absolute_expires_at to approximately 24 hours from now' do
-      freeze_time do
-        do_sign_in
+    it 'sets max_duration to 12 hours' do
+      do_sign_in
 
-        absolute_expires_at = session[:user_id][:absolute_expires_at] || session[:user_id]['absolute_expires_at']
-        expect(absolute_expires_at).to be_within(1.minute).of(24.hours.from_now)
-      end
+      max_duration = session[:user_id][:max_duration] || session[:user_id]['max_duration']
+      expect(max_duration).to eq(12.hours.to_i)
     end
 
     it 'sets identity_federator and identity_provider_uid' do
@@ -128,13 +131,9 @@ RSpec.describe Authentication do
   end
 
   describe '#valid_user_session?' do
-    context 'when idle timeout has expired' do
+    context 'when session has expired' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 1.second.ago,
-          'absolute_expires_at' => 24.hours.from_now
-        }
+        session[:user_id] = user_session(expires_at: 1.second.ago)
       end
 
       it 'returns false' do
@@ -142,13 +141,9 @@ RSpec.describe Authentication do
       end
     end
 
-    context 'when absolute timeout has been reached (expires_at still in the future)' do
+    context 'without max_duration (legacy 30-day cookie)' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 12.hours.from_now,
-          'absolute_expires_at' => 1.second.ago
-        }
+        session[:user_id] = user_session(expires_at: 30.days.from_now, max_duration: nil)
       end
 
       it 'returns false' do
@@ -156,12 +151,9 @@ RSpec.describe Authentication do
       end
     end
 
-    context 'without absolute_expires_at (legacy 30-day cookie)' do
+    context 'with a different max_duration' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 30.days.from_now
-        }
+        session[:user_id] = user_session(expires_at: 30.days.from_now, max_duration: 30.days.to_i)
       end
 
       it 'returns false' do
@@ -169,13 +161,9 @@ RSpec.describe Authentication do
       end
     end
 
-    context 'when session is valid (expires_at and absolute_expires_at in the future)' do
+    context 'when session is valid' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 6.hours.from_now,
-          'absolute_expires_at' => 24.hours.from_now
-        }
+        session[:user_id] = user_session(expires_at: 6.hours.from_now)
       end
 
       it 'returns true' do
@@ -185,25 +173,17 @@ RSpec.describe Authentication do
 
     context 'when timestamps come back from the JSON cookie as ISO8601 strings' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 6.hours.from_now.iso8601(3),
-          'absolute_expires_at' => 24.hours.from_now.iso8601(3)
-        }
+        session[:user_id] = user_session(expires_at: 6.hours.from_now.iso8601(3))
       end
 
-      it 'returns true when both are in the future' do
+      it 'returns true when expires_at is in the future' do
         expect(controller.valid_user_session?).to be true
       end
     end
 
     context 'when expires_at string from the JSON cookie is in the past' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 1.second.ago.iso8601(3),
-          'absolute_expires_at' => 24.hours.from_now.iso8601(3)
-        }
+        session[:user_id] = user_session(expires_at: 1.second.ago.iso8601(3))
       end
 
       it 'returns false' do
@@ -213,11 +193,7 @@ RSpec.describe Authentication do
 
     context 'when a timestamp is not a parseable date' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 'garbage',
-          'absolute_expires_at' => 24.hours.from_now.iso8601(3)
-        }
+        session[:user_id] = user_session(expires_at: 'garbage')
       end
 
       it 'returns false' do
@@ -227,13 +203,9 @@ RSpec.describe Authentication do
   end
 
   describe '#session_expired?' do
-    context 'when idle timeout has expired (expires_at in the past)' do
+    context 'when session has expired (expires_at in the past)' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 1.hour.ago,
-          'absolute_expires_at' => 24.hours.from_now
-        }
+        session[:user_id] = user_session(expires_at: 1.hour.ago)
       end
 
       it 'returns true' do
@@ -241,26 +213,9 @@ RSpec.describe Authentication do
       end
     end
 
-    context 'when absolute timeout has been reached' do
+    context 'without max_duration (legacy cookie)' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 12.hours.from_now,
-          'absolute_expires_at' => 1.hour.ago
-        }
-      end
-
-      it 'returns true' do
-        expect(controller.session_expired?).to be true
-      end
-    end
-
-    context 'without absolute_expires_at (legacy cookie)' do
-      before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 30.days.from_now
-        }
+        session[:user_id] = user_session(expires_at: 30.days.from_now, max_duration: nil)
       end
 
       it 'returns true' do
@@ -270,11 +225,7 @@ RSpec.describe Authentication do
 
     context 'when session is valid' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 6.hours.from_now,
-          'absolute_expires_at' => 24.hours.from_now
-        }
+        session[:user_id] = user_session(expires_at: 6.hours.from_now)
       end
 
       it 'returns false' do
@@ -294,13 +245,9 @@ RSpec.describe Authentication do
   end
 
   describe '#authenticate_user! (non connecté)' do
-    context 'when session has expired (idle timeout)' do
+    context 'when session has expired' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 1.hour.ago,
-          'absolute_expires_at' => 24.hours.from_now
-        }
+        session[:user_id] = user_session(expires_at: 1.hour.ago)
       end
 
       it 'sets flash[:info] with session expired title and redirects to sign in' do
@@ -325,44 +272,19 @@ RSpec.describe Authentication do
     end
   end
 
-  describe '#authenticate_user! session sliding' do
+  describe '#authenticate_user!' do
     context 'when session is valid' do
       before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 1.hour.from_now,
-          'absolute_expires_at' => 24.hours.from_now
-        }
+        session[:user_id] = user_session(expires_at: 1.hour.from_now)
       end
 
-      it 'slides expires_at to approximately +12 h without touching absolute_expires_at' do
+      it 'does not change expires_at' do
         freeze_time do
-          absolute = session[:user_id]['absolute_expires_at']
+          expires_at = session[:user_id]['expires_at']
 
           get :show
 
-          expect(session[:user_id]['expires_at']).to be_within(1.minute).of(12.hours.from_now)
-          expect(session[:user_id]['absolute_expires_at']).to eq(absolute)
-        end
-      end
-    end
-
-    context 'when expires_at + 12 h would exceed absolute_expires_at' do
-      before do
-        session[:user_id] = {
-          'value' => user.id,
-          'expires_at' => 1.hour.from_now,
-          'absolute_expires_at' => 3.hours.from_now
-        }
-      end
-
-      it 'caps expires_at at absolute_expires_at' do
-        freeze_time do
-          absolute = session[:user_id]['absolute_expires_at']
-
-          get :show
-
-          expect(session[:user_id]['expires_at']).to eq(absolute)
+          expect(session[:user_id]['expires_at']).to eq(expires_at)
         end
       end
     end
@@ -374,7 +296,7 @@ RSpec.describe Authentication do
         )
       end
 
-      it 'raises BannedUserError without sliding the session' do
+      it 'raises BannedUserError without changing the session expiry' do
         original_expires_at = session[:user_id]['expires_at']
 
         expect { controller.authenticate_user! }.to raise_error(ApplicationController::BannedUserError)

--- a/spec/support/controllers_helpers.rb
+++ b/spec/support/controllers_helpers.rb
@@ -3,7 +3,7 @@ module ControllersHelpers
     session[:user_id] = {
       'value' => user.id,
       'expires_at' => 1.hour.from_now,
-      'absolute_expires_at' => 1.hour.from_now
+      'max_duration' => 12.hours.to_i
     }
   end
 end

--- a/spec/support/sessions_helpers.rb
+++ b/spec/support/sessions_helpers.rb
@@ -3,7 +3,7 @@ module SessionsHelpers
     page.set_rack_session(user_id: {
       'value' => user.id,
       'expires_at' => 9001.hours.from_now,
-      'absolute_expires_at' => 9001.hours.from_now
+      'max_duration' => 12.hours.to_i
     })
   end
 end


### PR DESCRIPTION
## Contexte

Suite de DP-1789 qui avait introduit un modèle de session « idle glissant 12 h plafonné à 24 h ». À l’usage, le glissement jusqu’à 24 h n’est pas nécessaire : on simplifie en une déconnexion unique à **12 h fixes depuis la connexion**, pour tous, quoi qu’il arrive.

Ticket : DP-1820

## Ce que fait la PR

- Remplace le modèle « idle glissant 12 h + plafond 24 h » par un **plafond absolu unique de 12 h** : `expires_at = SESSION_MAX_DURATION.from_now`, jamais glissé.
- Suppression de `slide_session_expiry`, `absolute_expires_at_time`, de la constante `SESSION_ABSOLUTE_TIMEOUT` et de la clé de session `absolute_expires_at`.
- Chaque session est estampillée d’un marqueur `max_duration` à la connexion ; `valid_session?` exige `expires_at` futur **ET** `max_duration = 12 h`. Sans ce garde-fou, les cookies antérieurs à DP-1789 (30 jours, sans marqueur) repasseraient valides.
- `authenticate_user!` ne prolonge plus la session à chaque requête.
- **Message d’expiration inchangé** (« Votre session a expiré. Veuillez vous reconnecter. ») — décision produit.
- Doc technique `authentification_proconnect.md` mise à jour (modèle 12 h fixe + marqueur `max_duration` + diagrammes mermaid).

## Hors périmètre

- Flux ProConnect (anti-fixation, reconnexion silencieuse) : inchangé.

## Tests

- RSpec : `spec/controllers/concerns/authentication_spec.rb` ajusté (contextes absolute/sliding supprimés, ajout du cookie legacy sans `max_duration` et du `max_duration` divergent → rejetés). Verts.
- Cucumber : `features/session_expiree.feature` verte (2/2).
- À valider : `make e2e` (flux ProConnect complet, logout global, MFA).

## Note déploiement

Cookie store stateless → pas de migration. Les sessions récentes alignées sur 12 h continuent jusqu’à leur `expires_at`. Les cookies legacy sans marqueur `max_duration` valide sont rejetés et forcent une ré-authentification (re-clic silencieux si la session ProConnect est encore active).