### PR TITLE
Introduire le moteur d'éligibilité des entités

### DIFF
--- a/app/services/entity_eligibility/engine.rb
+++ b/app/services/entity_eligibility/engine.rb
@@ -1,0 +1,33 @@
+class EntityEligibility::Engine
+  attr_reader :organization, :authorization_request_form, :authorization_request
+
+  def self.from_request(authorization_request)
+    new(
+      organization: authorization_request.organization,
+      authorization_request_form: authorization_request.form,
+      authorization_request:,
+    )
+  end
+
+  def initialize(organization:, authorization_request_form:, authorization_request: nil)
+    @organization = organization
+    @authorization_request_form = authorization_request_form
+    @authorization_request = authorization_request
+  end
+
+  def verdict
+    rule_class = resolve_rule_class
+
+    return EntityEligibility::Verdict.unknown unless rule_class
+
+    rule_class.new(self).verdict
+  end
+
+  private
+
+  def resolve_rule_class
+    "EntityEligibility::Rules::#{authorization_request_form.uid.tr('-', '_').camelize}".constantize
+  rescue NameError
+    nil
+  end
+end

--- a/app/services/entity_eligibility/rules/hubee_cert_dc.rb
+++ b/app/services/entity_eligibility/rules/hubee_cert_dc.rb
@@ -1,0 +1,17 @@
+class EntityEligibility::Rules::HubEECertDC
+  def initialize(engine)
+    @engine = engine
+  end
+
+  def verdict
+    if engine.organization.legal_category == :commune
+      EntityEligibility::Verdict.new(status: :eligible, reason: :commune)
+    else
+      EntityEligibility::Verdict.new(status: :ineligible, reason: :not_a_commune)
+    end
+  end
+
+  private
+
+  attr_reader :engine
+end

--- a/app/services/entity_eligibility/verdict.rb
+++ b/app/services/entity_eligibility/verdict.rb
@@ -1,0 +1,20 @@
+class EntityEligibility::Verdict
+  STATUSES = %i[eligible likely_eligible likely_ineligible ineligible unknown].freeze
+
+  attr_reader :status, :reason
+
+  def self.unknown
+    new(status: :unknown)
+  end
+
+  def initialize(status:, reason: nil)
+    raise ArgumentError, "unknown status: #{status}" unless STATUSES.include?(status)
+
+    @status = status
+    @reason = reason
+  end
+
+  STATUSES.each do |candidate|
+    define_method(:"#{candidate}?") { status == candidate }
+  end
+end

--- a/spec/services/entity_eligibility/engine_spec.rb
+++ b/spec/services/entity_eligibility/engine_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe EntityEligibility::Engine do
+  let(:organization) do
+    build(:organization,
+      legal_entity_registry: 'insee_sirene',
+      legal_entity_id: '12345678900010',
+      insee_payload: {
+        'etablissement' => {
+          'uniteLegale' => { 'categorieJuridiqueUniteLegale' => '7210' },
+        },
+      })
+  end
+
+  describe '#verdict' do
+    subject(:verdict) do
+      described_class.new(organization:, authorization_request_form:).verdict
+    end
+
+    context 'when a rule is defined for the use case' do
+      let(:authorization_request_form) { AuthorizationRequestForm.find('hubee-cert-dc') }
+
+      it 'delegates to the matching rule' do
+        expect(verdict).to be_eligible
+      end
+    end
+
+    context 'when no rule is defined for the use case' do
+      let(:authorization_request_form) { AuthorizationRequestForm.find('api-entreprise-socle-de-base') }
+
+      it 'returns an unknown verdict' do
+        expect(verdict).to be_unknown
+      end
+    end
+  end
+
+  describe '.from_request' do
+    subject(:verdict) { described_class.from_request(authorization_request).verdict }
+
+    let(:authorization_request) do
+      AuthorizationRequest::HubEECertDC.new(form_uid: 'hubee-cert-dc', organization:)
+    end
+
+    it 'builds the engine from the demande' do
+      expect(verdict).to be_eligible
+    end
+  end
+end

--- a/spec/services/entity_eligibility/rules/hubee_cert_dc_spec.rb
+++ b/spec/services/entity_eligibility/rules/hubee_cert_dc_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe EntityEligibility::Rules::HubEECertDC do
+  subject(:verdict) { described_class.new(engine).verdict }
+
+  let(:engine) do
+    EntityEligibility::Engine.new(
+      organization:,
+      authorization_request_form: AuthorizationRequestForm.find('hubee-cert-dc'),
+    )
+  end
+
+  let(:organization) do
+    build(:organization,
+      legal_entity_registry: 'insee_sirene',
+      legal_entity_id: '12345678900010',
+      insee_payload: {
+        'etablissement' => {
+          'uniteLegale' => { 'categorieJuridiqueUniteLegale' => categorie },
+        },
+      })
+  end
+
+  context 'when the organization is a commune' do
+    let(:categorie) { '7210' }
+
+    it 'is eligible' do
+      expect(verdict).to be_eligible
+      expect(verdict.reason).to eq(:commune)
+    end
+  end
+
+  context 'when the organization is another collectivité' do
+    let(:categorie) { '7220' }
+
+    it 'is ineligible' do
+      expect(verdict).to be_ineligible
+      expect(verdict.reason).to eq(:not_a_commune)
+    end
+  end
+
+  context 'when the organization is a private entity' do
+    let(:categorie) { '5710' }
+
+    it 'is ineligible' do
+      expect(verdict).to be_ineligible
+    end
+  end
+end


### PR DESCRIPTION
Bootstrap d'un moteur de règles déterminant l'éligibilité d'une organisation à un cas d'usage (verdict valide / invalide / likely, cf. labels « Semble valide / invalide » côté instruction).

EntityEligibility::Engine prend le couple (organization, authorization_request_form) — et optionnellement la demande pour de futurs checks pré-soumission, d'où le constructeur .from_request. Il résout la règle par convention sur l'uid du formulaire (constantize → unknown si absente) et se passe lui-même comme contexte à la règle, évitant un objet de contexte dédié.

Premier cas câblé (API-7005) : HubEECertDC éligible si l'organisation est une commune, via Organization#legal_category existant — la logique métier reste dans le service, pas sur les attributs bruts du modèle.