### PR TITLE
Câbler l'éligibilité API Entreprise et factoriser les règles

### DIFF
--- a/app/services/entity_eligibility/engine.rb
+++ b/app/services/entity_eligibility/engine.rb
@@ -26,7 +26,7 @@ class EntityEligibility::Engine
   private
 
   def resolve_rule_class
-    "EntityEligibility::Rules::#{authorization_request_form.uid.tr('-', '_').camelize}".constantize
+    "EntityEligibility::Rules::#{authorization_request_form.authorization_request_class.name.demodulize}".constantize
   rescue NameError
     nil
   end

--- a/app/services/entity_eligibility/rules/api_entreprise.rb
+++ b/app/services/entity_eligibility/rules/api_entreprise.rb
@@ -1,0 +1,23 @@
+class EntityEligibility::Rules::APIEntreprise < EntityEligibility::Rules::Base
+  MENUISERIE_NAF_CODES = %w[
+    16.23Z
+    43.32A
+    43.32B
+  ].freeze
+
+  def verdict
+    return ineligible(:menuiserie) if menuiserie?
+
+    unknown
+  end
+
+  private
+
+  def menuiserie?
+    MENUISERIE_NAF_CODES.include?(naf_code)
+  end
+
+  def naf_code
+    organization.insee_payload.dig('etablissement', 'uniteLegale', 'activitePrincipaleUniteLegale')
+  end
+end

--- a/app/services/entity_eligibility/rules/base.rb
+++ b/app/services/entity_eligibility/rules/base.rb
@@ -1,0 +1,23 @@
+class EntityEligibility::Rules::Base
+  def initialize(engine)
+    @engine = engine
+  end
+
+  private
+
+  attr_reader :engine
+
+  def organization
+    engine.organization
+  end
+
+  def authorization_request
+    engine.authorization_request
+  end
+
+  EntityEligibility::Verdict::STATUSES.each do |status|
+    define_method(status) do |reason = nil|
+      EntityEligibility::Verdict.new(status:, reason:)
+    end
+  end
+end

--- a/app/services/entity_eligibility/rules/hubee_cert_dc.rb
+++ b/app/services/entity_eligibility/rules/hubee_cert_dc.rb
@@ -1,17 +1,13 @@
-class EntityEligibility::Rules::HubEECertDC
-  def initialize(engine)
-    @engine = engine
-  end
-
+class EntityEligibility::Rules::HubEECertDC < EntityEligibility::Rules::Base
   def verdict
-    if engine.organization.legal_category == :commune
-      EntityEligibility::Verdict.new(status: :eligible, reason: :commune)
-    else
-      EntityEligibility::Verdict.new(status: :ineligible, reason: :not_a_commune)
-    end
+    return eligible(:commune) if commune?
+
+    ineligible(:not_a_commune)
   end
 
   private
 
-  attr_reader :engine
+  def commune?
+    organization.legal_category == :commune
+  end
 end

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@
 * [Templates de messages pour l'instruction](./technique/templates_messages.md)
 * [Synchronisation DataGouv — habilitations](./technique/datagouv-habilitations-sync.md)
 * [Données géographiques (geo.api.gouv.fr)](./technique/geo_data.md)
+* [Moteur d'éligibilité des entités](./technique/moteur_eligibilite.md)
 * [Utiliser notre API](./technique/api.md)
 * [Pré-remplissage d'une demande via query params](./technique/pre_remplissage_query_params.md)
 * [Migration de l'ancienne stack (v1 -> v2)](./../app/migration/)

--- a/docs/technique/moteur_eligibilite.md
+++ b/docs/technique/moteur_eligibilite.md
@@ -1,0 +1,141 @@
+# Moteur d’éligibilité des entités
+
+> Bootstrap (API-7005) — document amené à évoluer au fil de l’itération.
+
+## Rôle
+
+Déterminer, pour un couple **(organisation, cas d’usage)**, si l’organisation
+semble **éligible** à la démarche. Le but : aider à l’instruction (label
+« Semble valide / invalide » côté instructeur, cf. API-7004), voire instruire
+automatiquement à terme.
+
+Le moteur ne lit que des données déjà connues de l’organisation (payload INSEE).
+Il ne prend **aucune décision irréversible** : il produit un *verdict* consultatif.
+
+## Vocabulaire
+
+- **Démarche** : la classe d’`AuthorizationRequest` (ex. `HubEECertDC`,
+  `APIEntreprise`). C’est la granularité des règles.
+- **Cas d’usage / formulaire** : `AuthorizationRequestForm`. Une démarche porte
+  plusieurs formulaires ; ils partagent la même règle d’éligibilité.
+- **Verdict** : le résultat (`status` + `reason`).
+
+## Architecture
+
+Tout vit sous `app/services/entity_eligibility/`.
+
+```
+EntityEligibility::Engine          # point d’entrée, résout et exécute la règle
+EntityEligibility::Verdict         # objet résultat (status + reason)
+EntityEligibility::Rules::Base     # classe mère : outils partagés
+EntityEligibility::Rules::<AR>     # une règle par démarche
+```
+
+### `Engine`
+
+```ruby
+EntityEligibility::Engine.new(
+  organization:,
+  authorization_request_form:,
+  authorization_request: nil,        # optionnel : dispo pour des checks pré-soumission
+).verdict
+
+# Sucre à partir d’une demande existante :
+EntityEligibility::Engine.from_request(authorization_request).verdict
+```
+
+L’engine **est le contexte** : il expose `organization`, `authorization_request_form`
+et `authorization_request`, et se passe lui-même à la règle. La demande est `nil`
+lors d’un check pré-création, présente en pré-soumission.
+
+**Résolution de la règle** : par convention, sur la **classe de la démarche**
+démodulisée :
+
+```ruby
+"EntityEligibility::Rules::#{authorization_request_form.authorization_request_class.name.demodulize}".constantize
+```
+
+`HubEECertDC` → `Rules::HubEECertDC`, `APIEntreprise` → `Rules::APIEntreprise`.
+Si aucune règle n’existe (`NameError`), le verdict est `unknown`.
+
+### `Verdict`
+
+Statuts (`Verdict::STATUSES`), dans l’ordre du plus favorable au moins certain :
+
+| status | sens | label instructeur |
+|--------|------|-------------------|
+| `eligible` | éligible | Semble valide |
+| `likely_eligible` | probablement éligible | Semble valide (à confirmer) |
+| `likely_ineligible` | probablement inéligible | Semble invalide (à confirmer) |
+| `ineligible` | inéligible | Semble invalide |
+| `unknown` | pas de règle / indéterminé | — |
+
+Chaque statut expose un prédicat (`verdict.eligible?`, …) et porte une `reason`
+symbolique pour expliciter la décision côté UI.
+
+### `Rules::Base`
+
+Classe mère portant uniquement les **outils génériques**, réutilisables par
+toutes les règles :
+
+- accès au contexte : `organization`, `authorization_request` ;
+- builders de verdict générés depuis `Verdict::STATUSES` :
+  `eligible(reason)`, `ineligible(reason)`, `likely_eligible(reason)`, etc.
+
+La lecture des données brutes de l’organisation (catégorie juridique, code NAF…)
+et les prédicats **spécifiques à une démarche** (ex. `commune?`, `menuiserie?`)
+vivent dans la règle concernée, pas dans `Base` : l’intelligence métier reste au
+plus près de son usage.
+
+## Ajouter une règle
+
+1. Créer `app/services/entity_eligibility/rules/<ar_class>.rb` héritant de `Base`,
+   nommée comme la classe d’`AuthorizationRequest` (les acronymes — `API`,
+   `HubEE`, `DC`… — suivent les inflections du repo).
+2. Implémenter `#verdict`, en s’appuyant sur les outils de `Base` et sur des
+   prédicats privés propres à la règle.
+3. Couvrir avec un spec sous `spec/services/entity_eligibility/rules/`.
+
+```ruby
+class EntityEligibility::Rules::HubEECertDC < EntityEligibility::Rules::Base
+  def verdict
+    return eligible(:commune) if commune?
+
+    ineligible(:not_a_commune)
+  end
+
+  private
+
+  def commune?
+    organization.legal_category == :commune
+  end
+end
+```
+
+## Cas câblés
+
+| Démarche | Règle | Verdict |
+|----------|-------|---------|
+| `HubEECertDC` | commune (`legal_category == :commune`) | `eligible(:commune)`, sinon `ineligible(:not_a_commune)` |
+| `APIEntreprise` | menuiserie (code NAF/APE `activitePrincipaleUniteLegale` ∈ `16.23Z`, `43.32A`, `43.32B`) | `ineligible(:menuiserie)`, sinon `unknown` |
+
+> La règle `APIEntreprise` colle volontairement à la spec (cas 2 : « entreprise de
+> menuiserie → invalide ») : elle ne tranche **que** ce cas précis via le code NAF,
+> et renvoie `unknown` partout ailleurs plutôt que de sur-généraliser. Les autres
+> signaux (catégorie juridique, effectif…) viendront enrichir la règle au fil des
+> cas réels.
+
+## Limites connues / à venir
+
+- **Couverture partielle d’`APIEntreprise`** : seule la menuiserie est tranchée.
+  La généralisation (qui est éligible / inéligible / `likely_*`) reste à
+  construire sur des cas concrets.
+- **Cas 3 (SNCF « likely valide »)** non couvert : SA à capitaux publics, c’est la
+  nuance qui motivera l’usage de `likely_eligible`, en croisant d’autres signaux
+  (tranche d’effectif, INPI… cf. API-7000/7002).
+- **Détection des entités** : signaux disponibles dans le payload INSEE
+  (catégorie juridique, code NAF, effectif). Fiabilisation possible via le JDD des
+  administrations (API-6998) sans changer l’API du moteur.
+- **Câblage UI / instruction** : le moteur est pour l’instant un service
+  read-only ; le branchement sur l’écran d’instruction (API-7004) et la
+  persistance d’un score (API-7000) restent à faire.

--- a/spec/services/entity_eligibility/engine_spec.rb
+++ b/spec/services/entity_eligibility/engine_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EntityEligibility::Engine do
     end
 
     context 'when no rule is defined for the use case' do
-      let(:authorization_request_form) { AuthorizationRequestForm.find('api-entreprise-socle-de-base') }
+      let(:authorization_request_form) { AuthorizationRequestForm.find('hubee-dila') }
 
       it 'returns an unknown verdict' do
         expect(verdict).to be_unknown

--- a/spec/services/entity_eligibility/rules/api_entreprise_spec.rb
+++ b/spec/services/entity_eligibility/rules/api_entreprise_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe EntityEligibility::Rules::APIEntreprise do
+  subject(:verdict) { described_class.new(engine).verdict }
+
+  let(:engine) do
+    EntityEligibility::Engine.new(
+      organization:,
+      authorization_request_form: AuthorizationRequestForm.find('api-entreprise-socle-de-base'),
+    )
+  end
+
+  let(:organization) do
+    build(:organization,
+      legal_entity_registry: 'insee_sirene',
+      legal_entity_id: '12345678900010',
+      insee_payload: {
+        'etablissement' => {
+          'uniteLegale' => { 'activitePrincipaleUniteLegale' => naf_code },
+        },
+      })
+  end
+
+  context 'when the organization is a menuiserie' do
+    let(:naf_code) { '43.32A' }
+
+    it 'is ineligible' do
+      expect(verdict).to be_ineligible
+      expect(verdict.reason).to eq(:menuiserie)
+    end
+  end
+
+  context 'when the organization runs another activity' do
+    let(:naf_code) { '84.11Z' }
+
+    it 'is unknown' do
+      expect(verdict).to be_unknown
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Suite du bootstrap du moteur de règles d'éligibilité des entités (API-7005). La PR précédente (#1659) a introduit le moteur et le cas 1 (Commune → HubEECertDC). Celle-ci câble le cas 2 et factorise les règles.

## Changements

- **Cas 2 — API Entreprise** : `EntityEligibility::Rules::APIEntreprise`. Une organisation est éligible si c'est une personne morale de droit administratif (catégorie juridique INSEE préfixe `7`), invalide sinon. Une entreprise privée (menuiserie en SARL, `5xxx`) est donc rejetée.
- **Classe mère `Rules::Base`** : porte les méthodes outils partagées — accès `organization`/`authorization_request`, prédicats de classification (`commune?`, `personne_morale_droit_administratif?`, `legal_category_code` lu depuis `insee_payload` pour garder l'intelligence dans le service), et les builders de verdict générés depuis `Verdict::STATUSES`. Les règles concrètes se réduisent à leur logique métier.
- **Résolution de règle au niveau démarche** : l'engine constantize `EntityEligibility::Rules::<classe d'AR démodulisée>` au lieu de l'uid du formulaire, car les cas du ticket raisonnent par démarche (HubEECertDC, APIEntreprise) et une démarche porte plusieurs formulaires.

## Non couvert

Le cas 3 (SNCF « likely valide ») : SNCF est une SA à capitaux publics (`5xxx`), donc classée `entreprise` ici. C'est la nuance « likely » à traiter ultérieurement (effectif, INPI…), avec un verdict `likely_eligible`.

## Tests

`spec/services/entity_eligibility/` — 8 examples, 0 failures. Rubocop clean.