### PR TITLE
Exposer les attributs d'identité d'organisation pour le moteur d'éligibilité

### DIFF
--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -51,13 +51,7 @@ class OrganizationDecorator < ApplicationDecorator
   end
 
   def code_naf
-    return unless insee_payload?
-
-    unite_legale_insee_payload['activitePrincipaleUniteLegale']
-  end
-
-  def unite_legale_insee_payload
-    etablissement_insee_payload['uniteLegale']
+    activite_principale
   end
 
   def etablissement_insee_payload

--- a/app/jobs/register_organization_with_contacts_on_crm_job.rb
+++ b/app/jobs/register_organization_with_contacts_on_crm_job.rb
@@ -193,7 +193,7 @@ class RegisterOrganizationWithContactsOnCRMJob < ApplicationJob
   def organization_categorie_juridique
     return if organization.insee_payload.blank?
 
-    CategorieJuridique.find(organization.insee_payload['etablissement']['uniteLegale']['categorieJuridiqueUniteLegale'])
+    CategorieJuridique.find(organization.categorie_juridique)
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -49,11 +49,19 @@ class Organization < ApplicationRecord
   end
 
   def personne_physique?
-    unite_legale['categorieJuridiqueUniteLegale'] == '1000'
+    categorie_juridique == '1000'
+  end
+
+  def categorie_juridique
+    unite_legale['categorieJuridiqueUniteLegale']
+  end
+
+  def activite_principale
+    unite_legale['activitePrincipaleUniteLegale']
   end
 
   def legal_category
-    LEGAL_CATEGORY_MAP.fetch(unite_legale['categorieJuridiqueUniteLegale'], :other)
+    LEGAL_CATEGORY_MAP.fetch(categorie_juridique, :other)
   end
 
   def insee_payload

--- a/app/services/entity_eligibility/rules/api_entreprise.rb
+++ b/app/services/entity_eligibility/rules/api_entreprise.rb
@@ -14,10 +14,6 @@ class EntityEligibility::Rules::APIEntreprise < EntityEligibility::Rules::Base
   private
 
   def menuiserie?
-    MENUISERIE_NAF_CODES.include?(naf_code)
-  end
-
-  def naf_code
-    organization.insee_payload.dig('etablissement', 'uniteLegale', 'activitePrincipaleUniteLegale')
+    MENUISERIE_NAF_CODES.include?(organization.activite_principale)
   end
 end

--- a/docs/technique/moteur_eligibilite.md
+++ b/docs/technique/moteur_eligibilite.md
@@ -82,10 +82,12 @@ toutes les règles :
 - builders de verdict générés depuis `Verdict::STATUSES` :
   `eligible(reason)`, `ineligible(reason)`, `likely_eligible(reason)`, etc.
 
-La lecture des données brutes de l’organisation (catégorie juridique, code NAF…)
-et les prédicats **spécifiques à une démarche** (ex. `commune?`, `menuiserie?`)
+Les **attributs nommés** de l’organisation (catégorie juridique, code NAF…) vivent
+sur `Organization` (`legal_category`, `categorie_juridique`, `activite_principale`,
+`code_commune_etablissement`…) : une règle ne replonge jamais dans `insee_payload`.
+Seuls les prédicats **spécifiques à une démarche** (ex. `commune?`, `menuiserie?`)
 vivent dans la règle concernée, pas dans `Base` : l’intelligence métier reste au
-plus près de son usage.
+plus près de son usage, mais elle s’appuie sur ces accesseurs partagés.
 
 ## Ajouter une règle
 
@@ -117,7 +119,7 @@ end
 | Démarche | Règle | Verdict |
 |----------|-------|---------|
 | `HubEECertDC` | commune (`legal_category == :commune`) | `eligible(:commune)`, sinon `ineligible(:not_a_commune)` |
-| `APIEntreprise` | menuiserie (code NAF/APE `activitePrincipaleUniteLegale` ∈ `16.23Z`, `43.32A`, `43.32B`) | `ineligible(:menuiserie)`, sinon `unknown` |
+| `APIEntreprise` | menuiserie (code NAF/APE `organization.activite_principale` ∈ `16.23Z`, `43.32A`, `43.32B`) | `ineligible(:menuiserie)`, sinon `unknown` |
 
 > La règle `APIEntreprise` colle volontairement à la spec (cas 2 : « entreprise de
 > menuiserie → invalide ») : elle ne tranche **que** ce cas précis via le code NAF,

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -142,4 +142,54 @@ RSpec.describe Organization do
       it { is_expected.to eq(:other) }
     end
   end
+
+  describe '#activite_principale' do
+    subject { organization.activite_principale }
+
+    context 'when uniteLegale carries an activitePrincipale' do
+      let(:organization) do
+        build(:organization,
+          legal_entity_registry: 'insee_sirene',
+          legal_entity_id: '12345678900010',
+          insee_payload: {
+            'etablissement' => {
+              'uniteLegale' => { 'activitePrincipaleUniteLegale' => '43.32A' },
+            },
+          })
+      end
+
+      it { is_expected.to eq('43.32A') }
+    end
+
+    context 'when insee_payload is blank' do
+      let(:organization) { build(:organization, siret: '41040946000756') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#categorie_juridique' do
+    subject { organization.categorie_juridique }
+
+    context 'when uniteLegale carries a categorieJuridique' do
+      let(:organization) do
+        build(:organization,
+          legal_entity_registry: 'insee_sirene',
+          legal_entity_id: '12345678900010',
+          insee_payload: {
+            'etablissement' => {
+              'uniteLegale' => { 'categorieJuridiqueUniteLegale' => '7210' },
+            },
+          })
+      end
+
+      it { is_expected.to eq('7210') }
+    end
+
+    context 'when insee_payload is blank' do
+      let(:organization) { build(:organization, siret: '41040946000756') }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
Expose des accesseurs INSEE nommés sur `Organization` (`activite_principale`, `categorie_juridique`) pour que les règles d'éligibilité — et le décorateur/job CRM — cessent de plonger dans `insee_payload` brut.

- `Organization` devient la source unique des lectures de `uniteLegale` (NAF, catégorie juridique)
- `Rules::APIEntreprise` consomme `activite_principale`

Closes API-6999 → https://linear.app/pole-api/issue/API-6999