### PR TITLE
Exercer likely_eligible via la règle d'éligibilité aide financière

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,6 +8,12 @@ class Organization < ApplicationRecord
   }.freeze
   private_constant :LEGAL_CATEGORY_MAP
 
+  ENTITY_TYPE_MAP = {
+    '7' => :administration,
+    '4' => :gray_zone,
+  }.freeze
+  private_constant :ENTITY_TYPE_MAP
+
   validates :legal_entity_id, presence: true, uniqueness: { scope: :legal_entity_registry }
   validates :legal_entity_id, siret: true, if: -> { legal_entity_registry == 'insee_sirene' }
 
@@ -62,6 +68,10 @@ class Organization < ApplicationRecord
 
   def legal_category
     LEGAL_CATEGORY_MAP.fetch(categorie_juridique, :other)
+  end
+
+  def entity_type
+    ENTITY_TYPE_MAP.fetch(categorie_juridique.to_s[0], :other)
   end
 
   def insee_payload

--- a/app/services/entity_eligibility/rules/aide_financiere.rb
+++ b/app/services/entity_eligibility/rules/aide_financiere.rb
@@ -1,0 +1,9 @@
+class EntityEligibility::Rules::AideFinanciere < EntityEligibility::Rules::Base
+  def verdict
+    case organization.entity_type
+    when :administration then eligible(:administration)
+    when :gray_zone      then likely_eligible(:public_commercial)
+    else                      ineligible(:not_administration)
+    end
+  end
+end

--- a/docs/technique/moteur_eligibilite.md
+++ b/docs/technique/moteur_eligibilite.md
@@ -84,7 +84,11 @@ toutes les règles :
 
 Les **attributs nommés** de l’organisation (catégorie juridique, code NAF…) vivent
 sur `Organization` (`legal_category`, `categorie_juridique`, `activite_principale`,
-`code_commune_etablissement`…) : une règle ne replonge jamais dans `insee_payload`.
+`code_commune_etablissement`, `entity_type`…) : une règle ne replonge jamais dans
+`insee_payload`. `entity_type` (`:administration | :gray_zone | :other`) dérive la
+typologie d’entité du **niveau 1 de la catégorie juridique** (`7…` administratif →
+`:administration`, `4…` public à caractère commercial type EPIC → `:gray_zone`, sinon
+`:other`) — c’est le signal qui motive un verdict `likely_eligible` pour la zone grise.
 Seuls les prédicats **spécifiques à une démarche** (ex. `commune?`, `menuiserie?`)
 vivent dans la règle concernée, pas dans `Base` : l’intelligence métier reste au
 plus près de son usage, mais elle s’appuie sur ces accesseurs partagés.
@@ -120,6 +124,7 @@ end
 |----------|-------|---------|
 | `HubEECertDC` | commune (`legal_category == :commune`) | `eligible(:commune)`, sinon `ineligible(:not_a_commune)` |
 | `APIEntreprise` | menuiserie (code NAF/APE `organization.activite_principale` ∈ `16.23Z`, `43.32A`, `43.32B`) | `ineligible(:menuiserie)`, sinon `unknown` |
+| `AideFinanciere` | typologie d’entité (`organization.entity_type`) | `:administration` → `eligible(:administration)` ; `:gray_zone` → `likely_eligible(:public_commercial)` ; sinon `ineligible(:not_administration)` |
 
 > La règle `APIEntreprise` colle volontairement à la spec (cas 2 : « entreprise de
 > menuiserie → invalide ») : elle ne tranche **que** ce cas précis via le code NAF,
@@ -132,9 +137,11 @@ end
 - **Couverture partielle d’`APIEntreprise`** : seule la menuiserie est tranchée.
   La généralisation (qui est éligible / inéligible / `likely_*`) reste à
   construire sur des cas concrets.
-- **Cas 3 (SNCF « likely valide »)** non couvert : SA à capitaux publics, c’est la
-  nuance qui motivera l’usage de `likely_eligible`, en croisant d’autres signaux
-  (tranche d’effectif, INPI… cf. API-7000/7002).
+- **`likely_eligible` (zone grise)** désormais exercé par `AideFinanciere` via
+  `entity_type == :gray_zone` (EPIC, public à caractère commercial). La règle est
+  démontrée **par spec** : aucune démarche `AuthorizationRequest::AideFinanciere`
+  n’existe encore, donc l’`Engine` ne la résout pas end-to-end. L’affinage du signal
+  (SA à capitaux publics, tranche d’effectif, INPI… cf. API-7000/7002) reste à venir.
 - **Détection des entités** : signaux disponibles dans le payload INSEE
   (catégorie juridique, code NAF, effectif). Fiabilisation possible via le JDD des
   administrations (API-6998) sans changer l’API du moteur.

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -192,4 +192,43 @@ RSpec.describe Organization do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#entity_type' do
+    subject { organization.entity_type }
+
+    let(:organization) do
+      build(:organization,
+        legal_entity_registry: 'insee_sirene',
+        legal_entity_id: '12345678900010',
+        insee_payload: {
+          'etablissement' => {
+            'uniteLegale' => { 'categorieJuridiqueUniteLegale' => categorie },
+          },
+        })
+    end
+
+    context 'when the catégorie juridique is administrative (7210, commune)' do
+      let(:categorie) { '7210' }
+
+      it { is_expected.to eq(:administration) }
+    end
+
+    context 'when the catégorie juridique is public commercial (4120, EPIC)' do
+      let(:categorie) { '4120' }
+
+      it { is_expected.to eq(:gray_zone) }
+    end
+
+    context 'when the catégorie juridique is a private company (5710, SA)' do
+      let(:categorie) { '5710' }
+
+      it { is_expected.to eq(:other) }
+    end
+
+    context 'when insee_payload is blank' do
+      let(:organization) { build(:organization, siret: '41040946000756') }
+
+      it { is_expected.to eq(:other) }
+    end
+  end
 end

--- a/spec/services/entity_eligibility/rules/aide_financiere_spec.rb
+++ b/spec/services/entity_eligibility/rules/aide_financiere_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe EntityEligibility::Rules::AideFinanciere do
+  subject(:verdict) { described_class.new(engine).verdict }
+
+  let(:engine) do
+    EntityEligibility::Engine.new(organization:, authorization_request_form: nil)
+  end
+
+  let(:organization) do
+    build(:organization,
+      legal_entity_registry: 'insee_sirene',
+      legal_entity_id: '12345678900010',
+      insee_payload: {
+        'etablissement' => {
+          'uniteLegale' => { 'categorieJuridiqueUniteLegale' => categorie },
+        },
+      })
+  end
+
+  context 'when the organization is an administration (7210, commune)' do
+    let(:categorie) { '7210' }
+
+    it 'is eligible' do
+      expect(verdict).to be_eligible
+      expect(verdict.reason).to eq(:administration)
+    end
+  end
+
+  context 'when the organization is in the gray zone (4120, EPIC)' do
+    let(:categorie) { '4120' }
+
+    it 'is likely eligible' do
+      expect(verdict).to be_likely_eligible
+      expect(verdict.reason).to eq(:public_commercial)
+    end
+  end
+
+  context 'when the organization is a private company (5710, SA)' do
+    let(:categorie) { '5710' }
+
+    it 'is ineligible' do
+      expect(verdict).to be_ineligible
+      expect(verdict.reason).to eq(:not_administration)
+    end
+  end
+end


### PR DESCRIPTION
Exerce enfin `likely_eligible` dans le moteur d’éligibilité, via une règle dédiée `AideFinanciere` adossée à une typologie d’entité.

- `Organization#entity_type` (administration / zone grise / autre) dérivée du niveau 1 de la catégorie juridique
- `Rules::AideFinanciere` : administration → eligible, zone grise (EPIC) → likely_eligible, sinon ineligible (démontré par spec)

Closes API-7005 → https://linear.app/pole-api/issue/API-7005/bootstrap-moteur-de-regles
