### PR TITLE
Auto-instruire les demandes selon le verdict d'éligibilité

### DIFF
--- a/app/interactors/auto_instruct_authorization_request.rb
+++ b/app/interactors/auto_instruct_authorization_request.rb
@@ -1,0 +1,36 @@
+class AutoInstructAuthorizationRequest < ApplicationInteractor
+  REFUSAL_REASON = 'Refus automatique : au regard de son identité juridique, ' \
+                   'votre organisation n’apparaît pas éligible à cette démarche.'.freeze
+
+  def call
+    return unless authorization_request.submitted?
+    return unless authorization_request.definition.auto_instruction?
+
+    verdict = EntityEligibility::Engine.from_request(authorization_request).verdict
+
+    approve if verdict.eligible?
+    refuse if verdict.ineligible?
+  end
+
+  private
+
+  def approve
+    ApproveAuthorizationRequest.call(authorization_request:, user: system_user)
+  end
+
+  def refuse
+    RefuseAuthorizationRequest.call(
+      authorization_request:,
+      user: system_user,
+      denial_of_authorization_params: { reason: REFUSAL_REASON },
+    )
+  end
+
+  def authorization_request
+    context.authorization_request
+  end
+
+  def system_user
+    User.find_or_create_by!(email: 'systeme@datapass.api.gouv.fr')
+  end
+end

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -147,9 +147,9 @@ class Seeds
     end
 
     {
-      'Aide financière — commune (semble valide)' => clamart_organization,
-      'Aide financière — EPIC (zone grise, à confirmer)' => epic_organization,
-      'Aide financière — société privée (semble invalide)' => private_company_organization,
+      'Aide financière — commune (validée automatiquement)' => clamart_organization,
+      'Aide financière — EPIC (zone grise, revue humaine)' => epic_organization,
+      'Aide financière — société privée (refusée automatiquement)' => private_company_organization,
     }.each do |intitule, organization|
       create_submitted_authorization_request(:aide_financiere, attributes: { intitule:, applicant: demandeur, organization: })
     end

--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -15,7 +15,8 @@ class AuthorizationDefinition < StaticApplicationRecord
 
   attr_writer :startable_by_applicant,
     :public,
-    :unique
+    :unique,
+    :auto_instruction
 
   def self.backend
     yaml_records + db_records
@@ -69,6 +70,7 @@ class AuthorizationDefinition < StaticApplicationRecord
         :kind,
         :startable_by_applicant,
         :unique,
+        :auto_instruction,
       ).merge(
         id: uid.to_s,
         provider_slug: hash[:provider],
@@ -159,6 +161,10 @@ class AuthorizationDefinition < StaticApplicationRecord
 
   def unique
     value_or_default(@unique, false)
+  end
+
+  def auto_instruction?
+    value_or_default(@auto_instruction, false)
   end
 
   def startable_by_applicant

--- a/app/organizers/submit_authorization_request.rb
+++ b/app/organizers/submit_authorization_request.rb
@@ -17,5 +17,7 @@ class SubmitAuthorizationRequest < ApplicationOrganizer
   after do
     context.authorization_request.save(context: context.save_context) ||
       context.fail!
+
+    AutoInstructAuthorizationRequest.call(authorization_request: context.authorization_request)
   end
 end

--- a/config/authorization_definitions/aide_financiere.yml
+++ b/config/authorization_definitions/aide_financiere.yml
@@ -3,6 +3,7 @@ aide_financiere:
   description: "Versement d’aides financières aux organisations éligibles."
   provider: "dinum"
   kind: 'api'
+  auto_instruction: true
   link: "https://aide-financiere.gouv.fr"
   cgu_link: "https://aide-financiere.gouv.fr/cgu"
   access_link: "https://aide-financiere.gouv.fr/tokens/%{external_provider_id}"

--- a/docs/technique/moteur_eligibilite.md
+++ b/docs/technique/moteur_eligibilite.md
@@ -163,3 +163,24 @@ l’instructeur.
 Le jeu de seeds crée trois demandes `Aide financière` couvrant les trois verdicts
 (commune → `eligible`, EPIC → `likely_eligible`, société privée → `ineligible`)
 pour observer le badge sans chercher de SIRET réel.
+
+## Auto-instruction
+
+Une démarche peut **déléguer son instruction au moteur** via le flag de définition
+`auto_instruction: true` (défaut : désactivé — les autres démarches ne sont pas
+touchées). À la soumission, `SubmitAuthorizationRequest` appelle
+`AutoInstructAuthorizationRequest` une fois la demande persistée :
+
+```
+verdict eligible    → ApproveAuthorizationRequest (acteur : utilisateur système)
+verdict ineligible  → RefuseAuthorizationRequest  (acteur système, motif automatique)
+verdict likely_* / unknown → aucune action → revue humaine
+```
+
+Seuls les verdicts **certains** déclenchent une action ; la zone grise et
+l’indéterminé restent en revue humaine — c’est le garde-fou qui dispense, pour
+cette première version, d’un score de confiance (API-7000). L’acteur est un
+`User` « système » (les événements `approve`/`refuse` exigent un acteur ; on n’en
+crée pas de bot nommé `system_`). Les seeds `Aide financière` (opt-in) illustrent
+les trois issues : commune **validée**, EPIC en **revue**, société privée
+**refusée** automatiquement.

--- a/spec/interactors/auto_instruct_authorization_request_spec.rb
+++ b/spec/interactors/auto_instruct_authorization_request_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe AutoInstructAuthorizationRequest, type: :interactor do
+  subject(:auto_instruct) { described_class.call(authorization_request:) }
+
+  let(:authorization_request) do
+    create(:authorization_request, :aide_financiere, :submitted, fill_all_attributes: true, organization:)
+  end
+
+  let(:organization) { create(:organization, siret:) }
+
+  context 'when the organization is eligible (administration)' do
+    let(:siret) { '21920023500014' }
+
+    it 'auto-validates the request' do
+      expect { auto_instruct }.to change { authorization_request.reload.state }.from('submitted').to('validated')
+    end
+  end
+
+  context 'when the organization is ineligible' do
+    let(:siret) { '38012986600006' }
+
+    it 'auto-refuses the request with a reason' do
+      auto_instruct
+
+      expect(authorization_request.reload.state).to eq('refused')
+      expect(authorization_request.denials.last.reason).to be_present
+    end
+  end
+
+  context 'when the organization is in the gray zone (likely_eligible)' do
+    let(:siret) { '55204944700006' }
+
+    it 'leaves the request submitted for human review' do
+      auto_instruct
+
+      expect(authorization_request.reload.state).to eq('submitted')
+    end
+  end
+
+  context 'when the demarche does not opt into auto-instruction' do
+    let(:authorization_request) do
+      create(:authorization_request, :hubee_cert_dc, :submitted, fill_all_attributes: true, organization:)
+    end
+    let(:siret) { '21920023500014' }
+
+    it 'does nothing' do
+      auto_instruct
+
+      expect(authorization_request.reload.state).to eq('submitted')
+    end
+  end
+end

--- a/spec/models/authorization_definition_spec.rb
+++ b/spec/models/authorization_definition_spec.rb
@@ -271,4 +271,22 @@ RSpec.describe AuthorizationDefinition do
       end
     end
   end
+
+  describe '#auto_instruction?' do
+    it 'is false by default' do
+      definition = described_class.build('mon_api', name: 'Mon API', blocks: [], features: {})
+
+      expect(definition.auto_instruction?).to be(false)
+    end
+
+    it 'is true when enabled in the configuration' do
+      definition = described_class.build('mon_api', name: 'Mon API', blocks: [], features: {}, auto_instruction: true)
+
+      expect(definition.auto_instruction?).to be(true)
+    end
+
+    it 'is enabled on the aide_financiere definition' do
+      expect(described_class.find('aide_financiere').auto_instruction?).to be(true)
+    end
+  end
 end

--- a/spec/organizers/submit_authorization_request_spec.rb
+++ b/spec/organizers/submit_authorization_request_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe SubmitAuthorizationRequest do
         end
       end
 
+      context 'with an auto-instructed demarche (aide_financiere)' do
+        let(:authorization_request) { create(:authorization_request, :aide_financiere, :draft, fill_all_attributes: true, organization:) }
+        let(:organization) { create(:organization, siret:) }
+
+        context 'when the organization is eligible' do
+          let(:siret) { '21920023500014' }
+
+          it 'auto-validates right after submission' do
+            expect { submit_authorization_request }.to change { authorization_request.reload.state }.from('draft').to('validated')
+          end
+        end
+
+        context 'when the organization is in the gray zone' do
+          let(:siret) { '55204944700006' }
+
+          it 'stays submitted for human review' do
+            expect { submit_authorization_request }.to change { authorization_request.reload.state }.from('draft').to('submitted')
+          end
+        end
+      end
+
       context 'with invalid params' do
         let(:authorization_request) { create(:authorization_request, :api_entreprise, :draft, fill_all_attributes: true) }
 


### PR DESCRIPTION
Délègue l’instruction au moteur d’éligibilité pour les démarches qui s’y prêtent : à la soumission, un verdict certain tranche sans humain.

- `auto_instruction` : flag de définition opt-in (défaut désactivé) — démarches existantes inchangées, activé sur Aide financière
- `AutoInstructAuthorizationRequest` : eligible → validation, ineligible → refus motivé (acteur système) ; likely_* / unknown → revue humaine (garde-fou, pas besoin du score API-7000)
- Déclenché depuis `SubmitAuthorizationRequest` une fois la demande persistée ; seeds illustrant les 3 issues

Suite de API-7005 → https://linear.app/pole-api/issue/API-7005/bootstrap-moteur-de-regles
