### PR TITLE
Ajoute la démarche DDMariage au formulaire HubEE DILA

### DIFF
--- a/app/bridges/hubee_dila_bridge.rb
+++ b/app/bridges/hubee_dila_bridge.rb
@@ -4,7 +4,8 @@ class HubEEDilaBridge < HubEEBaseBridge
     depot_dossier_pacs: 'depotDossierPACS',
     recensement_citoyen: 'recensementCitoyen',
     hebergement_tourisme: 'HebergementTourisme',
-    je_change_de_coordonnees: 'JeChangeDeCoordonnees'
+    je_change_de_coordonnees: 'JeChangeDeCoordonnees',
+    depot_dossier_mariage: 'DDMariage'
   }.freeze
 
   def on_approve

--- a/app/controllers/authenticated_user_controller.rb
+++ b/app/controllers/authenticated_user_controller.rb
@@ -11,7 +11,7 @@ class AuthenticatedUserController < ApplicationController
   allow_unauthenticated_access only: :bypass_login
 
   def authorization_definitions_feature_enabled?
-    current_user&.admin? || Rails.env.test?
+    FeatureFlag.enabled?(:authorization_definitions, user: current_user)
   end
 
   def bypass_login

--- a/app/form_builders/authorization_request_form_builder.rb
+++ b/app/form_builders/authorization_request_form_builder.rb
@@ -25,7 +25,7 @@ class AuthorizationRequestFormBuilder < DsfrFormBuilder
 
     info_wording = {
       title: wording_for("#{block}.info.title"),
-      content: wording_for("#{block}.info.content")&.html_safe,
+      content: interpolated_wording("#{block}.info.content"),
     }
 
     return unless info_wording
@@ -220,6 +220,14 @@ class AuthorizationRequestFormBuilder < DsfrFormBuilder
   end
 
   private
+
+  def interpolated_wording(key)
+    content = wording_for(key)
+    return content if content.blank?
+
+    content = ERB.new(content).result(binding) if content.include?('<%')
+    content.html_safe
+  end
 
   def cgu_check_box_label(label_opts = {})
     label_text = [

--- a/app/models/authorization_definition/scope.rb
+++ b/app/models/authorization_definition/scope.rb
@@ -11,6 +11,7 @@ class AuthorizationDefinition::Scope
     @included = properties.fetch(:included, false)
     @disabled = properties.fetch(:disabled, false)
     @deprecated = properties.fetch(:deprecated, {})
+    @feature_flag = properties.fetch(:feature_flag, nil)
   end
 
   def included?
@@ -34,6 +35,7 @@ class AuthorizationDefinition::Scope
   end
 
   def available?(request)
+    return false if behind_disabled_feature_flag?
     return false if entity_created_after_deprecation_date?(request)
     return false if hidden_by_config?(request)
 
@@ -63,6 +65,10 @@ class AuthorizationDefinition::Scope
   end
 
   private
+
+  def behind_disabled_feature_flag?
+    @feature_flag.present? && !FeatureFlag.enabled?(@feature_flag)
+  end
 
   def displayed_by_config?(request)
     display_config = request.form.scopes_config[:displayed]

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,0 +1,11 @@
+module FeatureFlag
+  RULES = {
+    authorization_definitions: ->(user: nil, **) { user&.admin? || Rails.env.test? }
+  }.freeze
+
+  def self.enabled?(name, **context)
+    rule = RULES[name.to_sym]
+
+    rule.nil? || rule.call(**context)
+  end
+end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,5 +1,6 @@
 module FeatureFlag
   RULES = {
+    depot_dossier_mariage: ->(**) { !Rails.env.production? },
     authorization_definitions: ->(user: nil, **) { user&.admin? || Rails.env.test? }
   }.freeze
 

--- a/config/authorization_definitions/hubee.yml
+++ b/config/authorization_definitions/hubee.yml
@@ -42,4 +42,7 @@ hubee_dila:
     - name: "JCC - Déclaration de Changement de Coordonnées"
       value: "je_change_de_coordonnees"
       group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
-
+    - name: "DDMariage - Pré-dépôt de dossier de mariage"
+      value: "depot_dossier_mariage"
+      group: "Démarches en ligne auxquelles vous souhaitez abonner votre commune"
+      feature_flag: depot_dossier_mariage

--- a/config/authorization_request_forms/others.yml
+++ b/config/authorization_request_forms/others.yml
@@ -19,7 +19,9 @@ hubee-dila:
     <br />
     ● RCO - Recensement Citoyen Obligatoire
     <br />
-    ● JCC - Déclaration de Changement de Coordonnées
+    ● JCC - Déclaration de Changement de Coordonnées<% if FeatureFlag.enabled?(:depot_dossier_mariage) %>
+    <br />
+    ● DDMariage - Pré-dépôt de dossier de mariage<% end %>
   authorization_request: "HubEEDila"
   service_provider_id: hubee
   scopes:
@@ -28,6 +30,7 @@ hubee-dila:
     - recensement_citoyen
     - hebergement_tourisme
     - je_change_de_coordonnees
+    - depot_dossier_mariage
 
 api-captchetat:
   authorization_request: "APICaptchEtat"

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -290,7 +290,13 @@ fr:
               de la direction de l’information légale et administrative (DILA) qui en
               étudiera la faisabilité juridique (demande réalisée via le portail du
               Hub d’Échange de l’État).
-            </p>
+            </p><% if FeatureFlag.enabled?(:depot_dossier_mariage) %>
+            <p>
+              <strong>DDMariage - Pré-dépôt de dossier de mariage</strong> : Ce service permet à
+              des usagers souhaitant contracter un mariage de compléter en ligne les informations
+              nécessaires à cette union et de télécharger leurs pièces justificatives constituant
+              leur dossier. L’ensemble est envoyé à la commune chargée de célébrer le mariage.
+            </p><% end %>
 
     api_pro_sante_connect:
       scopes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 * [Modal dynamique](./technique/modal.md)
 * [Guide sur les scopes](./technique/modification_scopes.md)
 * [Configuration des scopes de formulaire (scopes_config)](./technique/scopes_config.md)
+* [Feature flags](./technique/feature_flags.md)
 * [Templates de messages pour l'instruction](./technique/templates_messages.md)
 * [Synchronisation DataGouv — habilitations](./technique/datagouv-habilitations-sync.md)
 * [Données géographiques (geo.api.gouv.fr)](./technique/geo_data.md)

--- a/docs/technique/feature_flags.md
+++ b/docs/technique/feature_flags.md
@@ -1,0 +1,74 @@
+# Feature flags
+
+Le module `FeatureFlag` (`app/models/feature_flag.rb`) centralise les **drapeaux de
+déploiement progressif** : masquer une fonctionnalité tant qu'elle n'est pas prête,
+ou la réserver à certains environnements ou profils d'utilisateur.
+
+C'est la **source unique de vérité** pour ces décisions. Avant, chaque flag était
+dispersé (une condition `Rails.env.production?` dans une vue, une méthode ad hoc dans
+un contrôleur…). On regroupe tout ici pour que l'équipe ait une vision d'ensemble et
+un seul endroit à modifier.
+
+## Principe
+
+Un flag est une **règle nommée** : un lambda qui renvoie `true` (fonctionnalité
+visible) ou `false` (masquée). Les règles vivent dans la constante `RULES`.
+
+```ruby
+module FeatureFlag
+  RULES = {
+    depot_dossier_mariage: ->(**) { !Rails.env.production? },
+    authorization_definitions: ->(user: nil, **) { user&.admin? || Rails.env.test? }
+  }.freeze
+
+  def self.enabled?(name, **context)
+    rule = RULES[name.to_sym]
+
+    rule.nil? || rule.call(**context)
+  end
+end
+```
+
+- **Nom inconnu → activé.** `enabled?` renvoie `true` si le flag n'existe pas dans
+  `RULES`. Retirer une règle « allume » donc définitivement la fonctionnalité : c'est
+  la manière propre de clôturer un rollout (on supprime la règle quand la
+  fonctionnalité est livrée partout).
+- **Contexte optionnel.** Certaines règles dépendent d'un contexte (l'utilisateur
+  courant, par exemple). On le passe en mots-clés : `enabled?(:mon_flag, user:)`. Les
+  règles qui n'en ont pas besoin l'ignorent grâce au `**` final.
+
+## Utilisation
+
+### Depuis du code Ruby
+
+```ruby
+FeatureFlag.enabled?(:depot_dossier_mariage)                  # règle par environnement
+FeatureFlag.enabled?(:authorization_definitions, user: current_user)  # règle avec contexte
+```
+
+Dans un contrôleur, exposer le flag à la vue via `helper_method` peut rendr son utilisation plus lisible :
+
+```ruby
+helper_method :authorization_definitions_feature_enabled?
+
+def authorization_definitions_feature_enabled?
+  FeatureFlag.enabled?(:authorization_definitions, user: current_user)
+end
+```
+
+## Ajouter un flag
+
+1. Ajouter une règle dans `RULES` (`app/models/feature_flag.rb`), en donnant un nom
+   explicite et un lambda de décision.
+2. Appeler `FeatureFlag.enabled?(:mon_flag)` (avec le contexte nécessaire) partout où
+   la fonctionnalité doit être conditionnée : Ruby, ERB de config, scope `feature_flag:`.
+3. Couvrir la règle par un test dans `spec/models/feature_flag_spec.rb`.
+4. Quand la fonctionnalité est livrée définitivement partout, **retirer la règle**
+   (et les appels devenus inutiles) : un nom absent de `RULES` est toujours activé.
+
+## Ce que ce module n'est pas
+
+À ne pas confondre avec `AuthorizationDefinition#feature?(name)` (clé `features:` dans
+le YAML d'une définition, ex. `instructor_drafts`). Ce dernier est une **capacité
+configurée par formulaire**, pas un drapeau de déploiement global. Les deux concepts
+sont indépendants.

--- a/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
+++ b/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
@@ -11,6 +11,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation Démarches du bouquet d
     * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
     * je coche "RCO - Recensement Citoyen Obligatoire"
     * je coche "JCC - Déclaration de Changement de Coordonnées"
+    * je coche "DDMariage - Pré-dépôt de dossier de mariage"
 
     * je remplis les informations du contact "Administrateur local" avec :
       | Nom    | Prénom | Email               | Téléphone   | Fonction              |
@@ -33,11 +34,12 @@ Fonctionnalité: Soumission d'une demande d'habilitation Démarches du bouquet d
     Et je suis sur la page "Démarches du bouquet de services (service-public.fr)"
 
   Scénario: Je remplis une demande d’habilitation avec un champ du contact manquant
-    Quand je démarre une nouvelle demande d’habilitation "Démarches du bouquet de services (service-public.fr)"
+    Quand je démarre une nouvelle demande d'habilitation "Démarches du bouquet de services (service-public.fr)"
     * je coche "AEC - Acte d’Etat Civil"
     * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
     * je coche "RCO - Recensement Citoyen Obligatoire"
     * je coche "JCC - Déclaration de Changement de Coordonnées"
+    * je coche "DDMariage - Pré-dépôt de dossier de mariage"
 
     * je remplis les informations du contact "Administrateur local" avec :
       | Nom    | Prénom | Email               | Téléphone   | Fonction de l'administrateur local |

--- a/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
+++ b/features/habilitations/page_unique/portail_hubee_demarches_dila.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation Démarches du bouquet d
     Et que je me connecte
 
   Scénario: Je soumets une demande d’habilitation valide
-    Quand je démarre une nouvelle demande d’habilitation "Démarches du bouquet de services (service-public.fr)"
+    Quand je démarre une nouvelle demande d'habilitation "Démarches du bouquet de services (service-public.fr)"
     * je coche "AEC - Acte d’Etat Civil"
     * je coche "DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs"
     * je coche "RCO - Recensement Citoyen Obligatoire"

--- a/spec/form_builders/authorization_request_form_builder_spec.rb
+++ b/spec/form_builders/authorization_request_form_builder_spec.rb
@@ -50,6 +50,28 @@ RSpec.describe AuthorizationRequestFormBuilder, type: :helper do
     end
   end
 
+  describe '#interpolated_wording' do
+    subject { builder.send(:interpolated_wording, 'scopes.info.content') }
+
+    let(:authorization_request) { build(:authorization_request, :hubee_dila) }
+
+    context 'when the depot_dossier_mariage feature flag is enabled' do
+      it 'renders the DDMariage documentation paragraph' do
+        allow(FeatureFlag).to receive(:enabled?).with(:depot_dossier_mariage).and_return(true)
+
+        expect(subject).to include('DDMariage')
+      end
+    end
+
+    context 'when the depot_dossier_mariage feature flag is disabled' do
+      it 'hides the DDMariage documentation paragraph' do
+        allow(FeatureFlag).to receive(:enabled?).with(:depot_dossier_mariage).and_return(false)
+
+        expect(subject).not_to include('DDMariage')
+      end
+    end
+  end
+
   describe '#cgu_label_text' do
     context 'when france_connect cgu is required' do
       let(:authorization_request) do

--- a/spec/models/authorization_definition/scope_spec.rb
+++ b/spec/models/authorization_definition/scope_spec.rb
@@ -228,6 +228,32 @@ RSpec.describe AuthorizationDefinition::Scope do
       end
     end
 
+    context 'when scope is behind a feature flag' do
+      let(:scope) do
+        described_class.new(
+          name: 'Test Scope',
+          value: 'test_scope',
+          feature_flag: 'depot_dossier_mariage'
+        )
+      end
+
+      context 'when the feature flag is enabled' do
+        it 'stays available' do
+          allow(FeatureFlag).to receive(:enabled?).with('depot_dossier_mariage').and_return(true)
+
+          expect(subject).to be true
+        end
+      end
+
+      context 'when the feature flag is disabled' do
+        it 'is not available' do
+          allow(FeatureFlag).to receive(:enabled?).with('depot_dossier_mariage').and_return(false)
+
+          expect(subject).to be false
+        end
+      end
+    end
+
     context 'when hide option is configured' do
       context 'when scope is in hide list' do
         let(:scopes_config) { { hide: %w[test_scope other_scope] } }

--- a/spec/models/feature_flag_spec.rb
+++ b/spec/models/feature_flag_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe FeatureFlag do
+  describe '.enabled?' do
+    context 'when the flag is unknown' do
+      it 'returns true' do
+        expect(described_class.enabled?(:unknown_flag)).to be true
+      end
+    end
+
+    context 'when the flag is authorization_definitions' do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+      end
+
+      context 'when the user is an admin' do
+        it 'returns true' do
+          user = instance_double(User, admin?: true)
+
+          expect(described_class.enabled?(:authorization_definitions, user:)).to be true
+        end
+      end
+
+      context 'when the user is not an admin' do
+        it 'returns false' do
+          user = instance_double(User, admin?: false)
+
+          expect(described_class.enabled?(:authorization_definitions, user:)).to be false
+        end
+      end
+
+      context 'when no user is given' do
+        it 'returns false' do
+          expect(described_class.enabled?(:authorization_definitions)).to be false
+        end
+      end
+
+      context 'when the environment is test' do
+        it 'returns true regardless of the user' do
+          allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('test'))
+
+          expect(described_class.enabled?(:authorization_definitions)).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/models/feature_flag_spec.rb
+++ b/spec/models/feature_flag_spec.rb
@@ -6,6 +6,32 @@ RSpec.describe FeatureFlag do
       end
     end
 
+    context 'when the flag is depot_dossier_mariage' do
+      context 'when the environment is production' do
+        it 'returns false' do
+          allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+
+          expect(described_class.enabled?(:depot_dossier_mariage)).to be false
+        end
+      end
+
+      context 'when the environment is not production' do
+        it 'returns true' do
+          allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('staging'))
+
+          expect(described_class.enabled?(:depot_dossier_mariage)).to be true
+        end
+      end
+    end
+
+    context 'when the flag is given as a string' do
+      it 'resolves it as a symbol' do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+
+        expect(described_class.enabled?('depot_dossier_mariage')).to be false
+      end
+    end
+
     context 'when the flag is authorization_definitions' do
       before do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))


### PR DESCRIPTION
Permet aux communes de s’abonner à la démarche « Pré-dépôt de dossier de mariage » (code DILA DDMariage) depuis le formulaire « Démarches du bouquet de services (service-public.fr) ».

La case, son libellé dans l’introduction et sa description dans le bloc « En quoi consistent ces démarches » sont ajoutés, et le scope est mappé vers le processCode HubEE DDMariage à l’approbation.