### PR TITLE
Add a WIP page for emails of a definition

### DIFF
--- a/app/components/atoms/under_development_alert_component.html.erb
+++ b/app/components/atoms/under_development_alert_component.html.erb
@@ -1,0 +1,4 @@
+<div class="fr-alert fr-alert--info fr-col">
+  <h2 class="fr-h4"><%= title %></h2>
+  <p><%= message_html %></p>
+</div>

--- a/app/components/atoms/under_development_alert_component.rb
+++ b/app/components/atoms/under_development_alert_component.rb
@@ -1,0 +1,27 @@
+class Atoms::UnderDevelopmentAlertComponent < ApplicationComponent
+  CONTACT_EMAIL = 'datapass@api.gouv.fr'.freeze
+
+  def initialize(wip_action:)
+    @wip_action = wip_action
+  end
+
+  private
+
+  attr_reader :wip_action
+
+  def title
+    I18n.t('atoms.under_development_alert_component.title')
+  end
+
+  def message_html
+    I18n.t(
+      'atoms.under_development_alert_component.message_html',
+      wip_action:,
+      contact_link:
+    ).html_safe
+  end
+
+  def contact_link
+    link_to(CONTACT_EMAIL, "mailto:#{CONTACT_EMAIL}", class: 'fr-link')
+  end
+end

--- a/app/components/molecules/instruction/authorization_definition/titled_header_component.html.erb
+++ b/app/components/molecules/instruction/authorization_definition/titled_header_component.html.erb
@@ -1,5 +1,5 @@
 <%= render Molecules::Instruction::WideHeader.new(
-      logo_asset: authorization_definition.provider.logo,
+      logo_asset: authorization_definition.provider&.logo,
       title:,
       breadcrumbs:) do |component| %>
   <% component.with_subtitle_content do %>

--- a/app/components/molecules/instruction/authorization_definition/titled_header_component.rb
+++ b/app/components/molecules/instruction/authorization_definition/titled_header_component.rb
@@ -1,4 +1,4 @@
-class Molecules::Instruction::AuthorizationDefinition::EditHeaderComponent < ApplicationComponent
+class Molecules::Instruction::AuthorizationDefinition::TitledHeaderComponent < ApplicationComponent
   include Molecules::Instruction::Breadcrumb
 
   def initialize(authorization_definition:, title:)

--- a/app/controllers/instruction/authorization_definition_emails_controller.rb
+++ b/app/controllers/instruction/authorization_definition_emails_controller.rb
@@ -1,0 +1,14 @@
+class Instruction::AuthorizationDefinitionEmailsController < Instruction::FormManagementController
+  before_action :set_authorization_definition
+
+  def index
+    authorize [:instruction, @authorization_definition], :show?
+    @can_edit = policy([:instruction, @authorization_definition]).edit?
+  end
+
+  private
+
+  def set_authorization_definition
+    @authorization_definition = AuthorizationDefinition.find(params.expect(:authorization_definition_id))
+  end
+end

--- a/app/services/skip_links_implemented_checker.rb
+++ b/app/services/skip_links_implemented_checker.rb
@@ -92,6 +92,7 @@ class SkipLinksImplementedChecker
     instruction/authorization_definitions#edit
     instruction/forms#index
     instruction/forms#show
+    instruction/authorization_definition_emails#index
 
     admin#index
     admin/user_rights#index

--- a/app/views/instruction/authorization_definition_emails/index.html.erb
+++ b/app/views/instruction/authorization_definition_emails/index.html.erb
@@ -1,0 +1,11 @@
+<% action_label = @can_edit ? t('.title') : t('.title_readonly') %>
+<% set_title! t('page_titles.instruction_definition_emails', definition_name: @authorization_definition.name_with_stage, action: action_label) %>
+
+<%= render Molecules::Instruction::AuthorizationDefinition::TitledHeaderComponent.new(
+      authorization_definition: @authorization_definition,
+      title: action_label) %>
+
+<div class="fr-container fr-my-5w">
+  <%= render Atoms::UnderDevelopmentAlertComponent.new(
+        wip_action: t('.under_development.wip_action')) %>
+</div>

--- a/app/views/instruction/authorization_definitions/edit.html.erb
+++ b/app/views/instruction/authorization_definitions/edit.html.erb
@@ -1,7 +1,7 @@
 <% action_label = @can_edit ? t('.title') : t('.title_readonly') %>
 <% set_title! t('page_titles.instruction_definition_blocks', definition_name: @authorization_definition.name_with_stage, action: action_label) %>
 
-<%= render Molecules::Instruction::AuthorizationDefinition::EditHeaderComponent.new(
+<%= render Molecules::Instruction::AuthorizationDefinition::TitledHeaderComponent.new(
       authorization_definition: @authorization_definition,
       title: action_label) %>
 
@@ -53,9 +53,7 @@
   <% end %>
 
   <%= render Molecules::SidePanelComponent.new(id: side_panel_id) do %>
-    <div class="fr-alert fr-alert--info fr-col">
-      <h2 class="fr-h4"><%= t('.side_panel.under_development.title') %></h1>
-      <p><%= t('.side_panel.under_development.message_html') %></p>
-    </div>
+    <%= render Atoms::UnderDevelopmentAlertComponent.new(
+          wip_action: t('.side_panel.under_development.wip_action')) %>
   <% end %>
 </div>

--- a/app/views/instruction/authorization_definitions/show.html.erb
+++ b/app/views/instruction/authorization_definitions/show.html.erb
@@ -40,8 +40,8 @@
         <%= render Atoms::ActionCardComponent.new(
               title: can_edit ? t('.actions_block.emails.title') : t('.actions_block.emails.title_readonly'),
               description: can_edit ? t('.actions_block.emails.description') : t('.actions_block.emails.description_readonly'),
-              link: '#'
-              ) %>
+              link: instruction_authorization_definition_emails_path(@authorization_definition),
+              icon: 'fr-icon-mail-line') %>
       </div>
     </div>
   </section>

--- a/app/views/instruction/forms/show.html.erb
+++ b/app/views/instruction/forms/show.html.erb
@@ -64,9 +64,7 @@
   <% end %>
 
   <%= render Molecules::SidePanelComponent.new(id: side_panel_id) do %>
-    <div class="fr-alert fr-alert--info fr-col">
-      <h2 class="fr-h4"><%= t('.side_panel.under_development.title') %></h2>
-      <p><%= t('.side_panel.under_development.message_html') %></p>
-    </div>
+    <%= render Atoms::UnderDevelopmentAlertComponent.new(
+          wip_action: t('.side_panel.under_development.wip_action')) %>
   <% end %>
 </div>

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -8,6 +8,9 @@ fr:
       title: Configuration
       "true": Oui
       "false": Non
+    under_development_alert_component:
+      title: Fonctionnalité en cours de développement.
+      message_html: "Pour %{wip_action}, contactez-nous sur %{contact_link}."
   molecules:
     instruction:
       authorization_definition:

--- a/config/locales/instruction.fr.yml
+++ b/config/locales/instruction.fr.yml
@@ -63,10 +63,15 @@ fr:
         before_submit: Checkboxes en fin de résumé
         side_panel:
           under_development:
-            title: Fonctionnalité en cours de développement.
-            message_html: Pour modifier votre formulaire, contactez-nous sur <a class="fr-link" href="mailto:datapass@api.gouv.fr">datapass@api.gouv.fr</a>.
+            wip_action: modifier votre formulaire
       forms_header_component:
         title: Cas d'usage
+    authorization_definition_emails:
+      index:
+        title: Gérer les emails automatiques
+        title_readonly: Voir les emails automatiques
+        under_development:
+          wip_action: modifier les emails automatiques de ce formulaire
     forms:
       index:
         empty: Aucun cas d'usage disponible.
@@ -92,8 +97,7 @@ fr:
         prefill_subtitle: Pour adapter un formulaire à un cas d'usage et faciliter la demande, pré-remplissez les valeurs et adaptez les textes de ses étapes.
         side_panel:
           under_development:
-            title: Fonctionnalité en cours de développement.
-            message_html: Pour modifier ce cas d'usage, contactez-nous sur <a class="fr-link" href="mailto:datapass@api.gouv.fr">datapass@api.gouv.fr</a>.
+            wip_action: modifier ce cas d'usage
     dashboard:
       authorization_requests:
         search:

--- a/config/locales/page_titles.fr.yml
+++ b/config/locales/page_titles.fr.yml
@@ -39,6 +39,7 @@ fr:
     instruction_definitions: Formulaires - Instruction
     instruction_definition: "%{definition_name} - Formulaires - Instruction"
     instruction_definition_blocks: "%{definition_name} - %{action}"
+    instruction_definition_emails: "%{definition_name} - %{action}"
     instruction_definition_forms: "Cas d'usage - %{definition_name} - Formulaires - Instruction"
     instruction_definition_form_show: "%{form_name} - Cas d'usage - %{definition_name} - Formulaires - Instruction"
     instruction_show: "Instruction %{definition_name} - %{authorization_request_name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
 
     resources :authorization_definitions, only: %i[index show edit], path: 'formulaires' do
       resources :forms, only: %i[index show], path: 'cas_d_usage', controller: 'forms'
+      resources :emails, only: :index, path: 'emails_automatiques', controller: 'authorization_definition_emails'
     end
 
     resources :message_templates, only: %i[index new create edit update destroy], path: 'modeles-messages'

--- a/features/instructeurs/gestion_des_formulaires/gestion_des_emails.feature
+++ b/features/instructeurs/gestion_des_formulaires/gestion_des_emails.feature
@@ -1,0 +1,28 @@
+# language: fr
+
+Fonctionnalité: Gestion des emails automatiques d'un formulaire
+  En tant qu'instructeur, je peux consulter la page des emails automatiques
+  d'un formulaire.
+
+  Contexte:
+    Soit un fournisseur de données "DINUM" existe
+    Sachant que je suis un rapporteur "API Entreprise"
+    Et que je me connecte
+
+  Scénario: J'accède à la page des emails automatiques depuis le détail du formulaire
+    Quand je me rends sur le formulaire "API Entreprise"
+    Et je clique sur "Voir les emails automatiques"
+    Alors la page contient "Voir les emails automatiques"
+    Et la page contient "API Entreprise"
+
+  Scénario: La page affiche un message indiquant que la fonctionnalité est en cours de développement
+    Quand je me rends sur le formulaire "API Entreprise"
+    Et je clique sur "Voir les emails automatiques"
+    Alors la page contient "Fonctionnalité en cours de développement"
+    Et la page contient "datapass@api.gouv.fr"
+
+  Scénario: Un manager voit le lien « Gérer les emails automatiques »
+    Sachant que je suis un manager "API Entreprise"
+    Quand je me rends sur le formulaire "API Entreprise"
+    Et je clique sur "Gérer les emails automatiques"
+    Alors la page contient "Gérer les emails automatiques"

--- a/spec/components/previews/atoms/under_development_alert_component_preview.rb
+++ b/spec/components/previews/atoms/under_development_alert_component_preview.rb
@@ -1,0 +1,5 @@
+class Atoms::UnderDevelopmentAlertComponentPreview < ApplicationPreview
+  def default
+    render Atoms::UnderDevelopmentAlertComponent.new(wip_action: 'modifier votre formulaire')
+  end
+end

--- a/spec/components/previews/molecules/instruction/authorization_definition/edit_header_component_preview.rb
+++ b/spec/components/previews/molecules/instruction/authorization_definition/edit_header_component_preview.rb
@@ -1,9 +1,0 @@
-class Molecules::Instruction::AuthorizationDefinition::EditHeaderComponentPreview < ApplicationPreview
-  def default
-    authorization_definition = AuthorizationDefinition.find('api_entreprise')
-    render Molecules::Instruction::AuthorizationDefinition::EditHeaderComponent.new(
-      authorization_definition:,
-      title: I18n.t('instruction.authorization_definitions.edit.title')
-    )
-  end
-end

--- a/spec/components/previews/molecules/instruction/authorization_definition/titled_header_component_preview.rb
+++ b/spec/components/previews/molecules/instruction/authorization_definition/titled_header_component_preview.rb
@@ -1,0 +1,17 @@
+class Molecules::Instruction::AuthorizationDefinition::TitledHeaderComponentPreview < ApplicationPreview
+  def default
+    authorization_definition = AuthorizationDefinition.find('api_entreprise')
+    render Molecules::Instruction::AuthorizationDefinition::TitledHeaderComponent.new(
+      authorization_definition:,
+      title: I18n.t('instruction.authorization_definitions.edit.title')
+    )
+  end
+
+  def emails
+    authorization_definition = AuthorizationDefinition.find('api_entreprise')
+    render Molecules::Instruction::AuthorizationDefinition::TitledHeaderComponent.new(
+      authorization_definition:,
+      title: I18n.t('instruction.authorization_definition_emails.index.title')
+    )
+  end
+end


### PR DESCRIPTION
Dans la page d'un formulaire, on a un lien qui ne fait rien pour "Voir/gérer les emails automatiques". Comme je commence à donner accès à la page à Miryad, je veux corriger ça.

A la place, on y met un lien vers cette nouvelle page :

<img width="1449" height="815" alt="image" src="https://github.com/user-attachments/assets/2d42da53-c1e8-429a-8ba4-dfda5c23851f" />

# Factorisations

Il y a 2 factorisations de faites dans cette PR :
- Le wide_header de formulaires/edit et formulaires/email
- L'alerte "Fonctionnalité en cours de dévellopement"

---

Closes https://linear.app/pole-api/issue/DP-1849/wip-page-for-emails