### PR TITLE
Reword « Première date de transmission » → « Date de transmission »

### DIFF
--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -135,7 +135,7 @@ fr:
 
         communes_codes_insee: Communes (codes INSEE)
         echelon_bourse: Échelon de bourse minimum
-        premiere_date_transmission: Première date de transmission
+        premiere_date_transmission: Date de transmission
 
         france_connect:
           alternative_connexion: Attestation de connexion alternative à FranceConnect
@@ -215,7 +215,7 @@ fr:
         fc_alternative_connexion: Cochez si vous proposez une alternative à FranceConnect
         communes_codes_insee: "Saisissez un code INSEE par commune (ex : 75056 pour Paris). Cliquez sur « Ajouter une commune » pour en ajouter plusieurs."
         echelon_bourse: "L’extraction inclura tous les boursiers d’échelon supérieur ou égal à la valeur sélectionnée."
-        premiere_date_transmission: "Date à laquelle vous souhaitez recevoir la première extraction CNOUS."
+        premiere_date_transmission: "Date à laquelle vous souhaitez recevoir l'extraction CNOUS."
       message_template:
         title: "Privilégiez un titre court et explicite"
         content: "Variables disponibles : %{demande_url}, %{demande_intitule}, %{demande_id}"

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -19,7 +19,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     * je remplis "Communes (codes INSEE) n°1" avec "75056"
     * je remplis "Communes (codes INSEE) n°2" avec "69123"
     * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
-    * je remplis la première date de transmission avec une date future
+    * je remplis la date de transmission avec une date future
     * je clique sur "Suivant"
     * la page contient "Contact technique"
 
@@ -54,7 +54,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     * je remplis "Communes (codes INSEE) n°1" avec "75056"
     * je remplis "Communes (codes INSEE) n°2" avec "20000"
     * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
-    * je remplis la première date de transmission avec une date future
+    * je remplis la date de transmission avec une date future
     * je clique sur "Suivant"
 
     Alors le champ commune INSEE contenant "20000" est signalé en erreur
@@ -75,7 +75,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Et le périmètre ne propose pas de voir toutes les communes
 
     Quand je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
-    Et je remplis la première date de transmission avec une date future
+    Et je remplis la date de transmission avec une date future
     Et je clique sur "Suivant"
 
     * je renseigne les informations du contact technique
@@ -127,7 +127,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Quand je remplis "Communes (codes INSEE) n°1" avec "2A004"
     Et je remplis "Communes (codes INSEE) n°2" avec "01001"
     Et je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
-    Et je remplis la première date de transmission avec une date future
+    Et je remplis la date de transmission avec une date future
     Et je clique sur "Suivant"
 
     * je renseigne les informations du contact technique

--- a/features/step_definitions/cnous_data_extraction_criteria_steps.rb
+++ b/features/step_definitions/cnous_data_extraction_criteria_steps.rb
@@ -2,8 +2,8 @@ def cnous_future_transmission_date
   2.months.from_now.to_date
 end
 
-Quand('je remplis la première date de transmission avec une date future') do
-  fill_in 'Première date de transmission', with: cnous_future_transmission_date.iso8601, wait: true
+Quand('je remplis la date de transmission avec une date future') do
+  fill_in 'Date de transmission', with: cnous_future_transmission_date.iso8601, wait: true
 end
 
 Sachantque('l’API géo connaît la commune {string} nommée {string}') do |code, nom|


### PR DESCRIPTION
La transmission CNOUS est one-shot (décision 2026-05-26, DP-1726) — le libellé et le hint laissaient supposer des extractions récurrentes.

Le nom d'attribut `premiere_date_transmission` reste inchangé (clé jsonb existante, exposée à relais via l'API pull) — voir hors-périmètre du ticket.

Linear: [API-7072](https://linear.app/pole-api/issue/API-7072)

🤖 Generated with [Claude Code](https://claude.com/claude-code)