### PR TITLE
Purge france_connect_authorization_id au retrait de la modalité FC

### DIFF
--- a/app/models/concerns/authorization_extensions/france_connect.rb
+++ b/app/models/concerns/authorization_extensions/france_connect.rb
@@ -10,7 +10,9 @@ module AuthorizationExtensions::FranceConnect
 
     validates :france_connect_authorization_id,
       inclusion: { in: ->(authorization_request) { authorization_request.organization.valid_authorizations_of(AuthorizationRequest::FranceConnect).pluck(:id).map(&:to_s) } },
-      if: -> { france_connect_authorization_id.present? }
+      if: -> { with_france_connect? && france_connect_authorization_id.present? }
+
+    before_save :remove_france_connect_authorization_id_unless_with_france_connect
   end
 
   def france_connect_authorization
@@ -27,5 +29,9 @@ module AuthorizationExtensions::FranceConnect
 
   def requires_france_connect_authorization?
     need_complete_validation?(:france_connect)
+  end
+
+  def remove_france_connect_authorization_id_unless_with_france_connect
+    self.france_connect_authorization_id = nil unless with_france_connect?
   end
 end

--- a/spec/models/authorization_request/api_particulier_spec.rb
+++ b/spec/models/authorization_request/api_particulier_spec.rb
@@ -313,4 +313,40 @@ RSpec.describe AuthorizationRequest::APIParticulier do
       end
     end
   end
+
+  describe 'france_connect_authorization_id cleanup on save' do
+    subject(:authorization_request) { create(:authorization_request, :api_particulier) }
+
+    context 'when the france_connect modality is not selected' do
+      before do
+        authorization_request.modalities = %w[params]
+        authorization_request.france_connect_authorization_id = '999999'
+        authorization_request.save!
+      end
+
+      it 'clears the residual france_connect_authorization_id' do
+        expect(authorization_request.reload.france_connect_authorization_id).to be_nil
+      end
+    end
+
+    context 'when the france_connect modality is selected with a valid authorization' do
+      let(:france_connect_authorization) do
+        create(
+          :authorization_request, :france_connect, :validated,
+          applicant: authorization_request.applicant,
+          organization: authorization_request.organization
+        ).latest_authorization
+      end
+
+      before do
+        authorization_request.modalities = %w[france_connect]
+        authorization_request.france_connect_authorization_id = france_connect_authorization.id.to_s
+        authorization_request.save!
+      end
+
+      it 'keeps the france_connect_authorization_id' do
+        expect(authorization_request.reload.france_connect_authorization_id).to eq(france_connect_authorization.id.to_s)
+      end
+    end
+  end
 end

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -638,7 +638,7 @@ RSpec.describe AuthorizationRequest do
     end
 
     context 'when linked by france_connect_authorization_id (auto-generated)' do
-      let(:authorization_request) { create(:authorization_request, :api_particulier, :validated, organization:) }
+      let(:authorization_request) { create(:authorization_request, :api_particulier, :validated, modalities: %w[france_connect], organization:) }
       let!(:fc_child_authorization) do
         create(:authorization,
           request: authorization_request,


### PR DESCRIPTION
AuthorizationExtensions::FranceConnect (APIParticulier, APIDroitsCNAM, APIIndemnitesJournalieresCNAM) conservait un france_connect_authorization_id résiduel dans les données de la demande même après désélection de la modalité france_connect.

Sa validation d'inclusion était always-on (gated uniquement par la présence de l'id) : tout save ultérieur revérifiait donc l'id résiduel contre les habilitations FranceConnect validées de l'organisation. Une demande sans la modalité FC mais traînant un id résiduel ne pouvait alors plus être sauvegardée ni transférée vers une organisation dépourvue de cette habilitation FC, échouant avec « L'habilitation FranceConnect n'est pas incluse dans la liste des habilitations validées de votre organisation ».

On aligne le comportement sur DGFIP APIImpotParticulierModalities :
- la validation d'inclusion est gated par with_france_connect?, elle ne se déclenche donc plus sur un id résiduel quand la modalité est inactive ;
- un hook before_save nilifie l'id quand with_france_connect? est faux.

with_france_connect? vaut true par défaut dans le concern : les modèles CNAM toujours-FC gardent leur comportement, seul APIParticulier — qui l'override selon la modalité sélectionnée — bénéficie du nettoyage.