### PR TITLE
Afficher le scope AEEH sur les formulaires éditeur enfance

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -65,6 +65,7 @@ api-particulier-familea: &api_particulier_familea
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Domino web 2.0 | Gestion des structures de petites enfances, enfance et jeunesse
     description: |
@@ -119,6 +120,7 @@ api-particulier-arpege-concerto:
     displayed:
       - cnaf_quotient_familial
       - cnaf_allocataires
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Tarification sur Quotient Familial des prestations Périscolaire
     description: |
@@ -154,6 +156,7 @@ api-particulier-cantine-de-france:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule:
       Récupération du Quotient Familial ainsi que les informations administratives
@@ -196,6 +199,7 @@ api-particulier-agora-plus:
       - cnaf_quotient_familial
       - cnaf_allocataires
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule:
       Dématérialisation du calcul du quotient/taux d'effort pour les structures
@@ -236,6 +240,7 @@ api-particulier-amiciel-malice:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule:
@@ -345,6 +350,7 @@ api-particulier-city-family-mushroom-software:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Calcul du quotient familial pour la facturations des crèches, du périscolaire, du scolaire et de l’extrascolaire
     description: Gestion des activités enfance, jeunesse, petite enfance (facturations des crèches, du périscolaire, du scolaire et de l’extrascolaire). Portail famille et back-office
@@ -392,6 +398,7 @@ api-particulier-civil-enfance-ciril-group:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
 
       # Scopes FranceConnect
       - family_name
@@ -434,6 +441,7 @@ api-particulier-cosoluce-fluo:
       - cnaf_quotient_familial
     displayed:
       - cnaf_quotient_familial
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Récupération des données CNAF pour les services municipaux
     description: Logiciel utilisé par des agents habilités pour la facturation des cantines
@@ -466,6 +474,7 @@ api-particulier-nfi:
       - cnaf_allocataires
       - cnaf_adresse
       - cnaf_enfants
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Gestion de la relation client sur le portail famille
     description: |
@@ -500,6 +509,7 @@ api-particulier-technocarte-ile:
     displayed:
       - cnaf_quotient_familial
       - cnaf_allocataires
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule:
       Récupération du Quotient Familial pour le service Enfance (Périscolaire,
@@ -543,6 +553,7 @@ api-particulier-waigeo-myperischool:
       - cnaf_allocataires
       - cnaf_adresse
       - cnaf_enfants
+      - cnav_allocation_enfant_handicape
 
       # Scopes FranceConnect
       - family_name
@@ -585,6 +596,7 @@ api-particulier-3d-ouest:
     displayed:
       - cnaf_quotient_familial
       - cnaf_allocataires
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule:
@@ -627,6 +639,7 @@ api-particulier-agedi-proxima-enf:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule: Tarification service enfance et récupération des quotients familiaux
@@ -668,6 +681,7 @@ api-particulier-ecorestauration-loyfeey:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule: Tarification sur Quotient Familial des cantines
@@ -707,6 +721,7 @@ api-particulier-jcdeveloppement-familyclic:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule: Tarification sur Quotient Familial des cantines
@@ -749,6 +764,7 @@ api-particulier-aiga:
       - openid
     displayed:
       - cnaf_quotient_familial
+      - cnav_allocation_enfant_handicape
 
       # Scopes FranceConnect
       - family_name
@@ -1091,6 +1107,7 @@ api-particulier-bl-enfance-berger-levrault:
       - cnaf_quotient_familial
     displayed:
       - cnaf_quotient_familial
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Tarification sur Quotient Familial des activités scolaires, périscolaires et loisirs
     description: |
@@ -1125,6 +1142,7 @@ api-particulier-noethys:
       - cnaf_allocataires
       - cnaf_adresse
       - cnaf_enfants
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Récupération du Quotient Familial pour le service enfance (Périscolaire, centre de loisirs)
     description: |
@@ -1159,6 +1177,7 @@ api-particulier-carte-plus:
       - cnaf_allocataires
       - cnaf_adresse
       - cnaf_enfants
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Récupération du Quotient Familial pour le service enfance (Périscolaire, centre de loisirs)
     description: |
@@ -1198,6 +1217,7 @@ api-particulier-resagenda:
       - cnaf_allocataires
       - cnaf_adresse
       - cnaf_enfants
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Récupération du Quotient Familial pour le service enfance (Périscolaire, centre de loisirs)
     description: |
@@ -1281,6 +1301,7 @@ api-particulier-jvs-mairistem:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule: Facturation des familles pour les services périscolaires et loisirs
@@ -1373,6 +1394,7 @@ api-particulier-ypok-ykidz:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
 
       # Scopes FranceConnect
       - family_name
@@ -1446,6 +1468,7 @@ api-particulier-e1os:
       - cnaf_quotient_familial
     displayed:
       - cnaf_quotient_familial
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule: Facturation des familles pour les services scolaire et cantine
@@ -1476,6 +1499,7 @@ api-particulier-acheteza:
       - cnaf_quotient_familial
     displayed:
       - cnaf_quotient_familial
+      - cnav_allocation_enfant_handicape
 
   initialize_with:
     intitule: Facturation des familles pour les services scolaire et cantine
@@ -1902,6 +1926,7 @@ api-particulier-entrouvert-publik:
       - cnaf_quotient_familial
       - cnaf_allocataires
       - cnaf_enfants
+      - cnav_allocation_enfant_handicape
 
       # Scopes FranceConnect
       - family_name
@@ -2888,6 +2913,7 @@ api-particulier-andyvie:
       - cnaf_allocataires
       - cnaf_enfants
       - cnaf_adresse
+      - cnav_allocation_enfant_handicape
   initialize_with:
     intitule: Tarification des services municipaux à l’enfance
     description: |

--- a/spec/acceptance/authorizations_configs_spec.rb
+++ b/spec/acceptance/authorizations_configs_spec.rb
@@ -38,4 +38,38 @@ RSpec.describe 'Authorizations config files' do
       end
     end
   end
+
+  describe 'AEEH scope on tarification municipale enfance editor forms' do
+    subject(:editor_forms) do
+      AuthorizationRequestForm.all.select do |form|
+        form.use_case.to_s == 'tarification_municipale_enfance' && form.service_provider.present?
+      end
+    end
+
+    let(:aeeh_scope) { 'cnav_allocation_enfant_handicape' }
+
+    def scope_displayed?(form, scope_value)
+      hidden = form.scopes_config[:hide]
+      return false if hidden.present? && hidden.include?(scope_value)
+
+      displayed = form.scopes_config[:displayed]
+      displayed.blank? || displayed.include?(scope_value)
+    end
+
+    it 'targets every editor form of the use case' do
+      expect(editor_forms).not_to be_empty
+    end
+
+    it 'displays the scope on each editor form' do
+      editor_forms.each do |form|
+        expect(scope_displayed?(form, aeeh_scope)).to be_truthy, "Form: #{form.uid} does not display #{aeeh_scope}"
+      end
+    end
+
+    it 'never pre-checks the scope' do
+      editor_forms.each do |form|
+        expect(form.initialize_with[:scopes] || []).not_to include(aeeh_scope), "Form: #{form.uid} pre-checks #{aeeh_scope}"
+      end
+    end
+  end
 end

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe AuthorizationRequest do
       context 'with displayed config on form' do
         let(:authorization_request) { create(:authorization_request, :api_particulier_familea) }
 
-        it { expect(available_scopes.map(&:value)).to match_array(%w[cnaf_quotient_familial cnaf_allocataires cnaf_enfants cnaf_adresse]) }
+        it { expect(available_scopes.map(&:value)).to match_array(%w[cnaf_quotient_familial cnaf_allocataires cnaf_enfants cnaf_adresse cnav_allocation_enfant_handicape]) }
       end
     end
 


### PR DESCRIPTION
## Contexte

[DP-1844](https://linear.app/pole-api/issue/DP-1844/ajouter-une-api-sur-tous-les-datapass-editeur-du-cas-dusage) — sur les cas d’usage « Tarification sociale des services municipaux à l’enfance », le scope `cnav_allocation_enfant_handicape` (Statut AEEH) doit **apparaître** sans être **pré coché**.

**Critère retenu :** cas d’usage `tarification_municipale_enfance` **avec un `service_provider_id` rempli** (= les formulaires éditeur). Le critère tombe juste : sur les 33 cas d’usage `tarification_municipale_enfance`, 32 ont un `service_provider_id`, et le seul sans est le formulaire générique `api-particulier-tarification-municipale-enfance`… qui avait **déjà** le scope dans l’état demandé. Il a servi de **référence**, pas de cible.

## Ce que fait la PR

- `config/authorization_request_forms/api_particulier.yml` : **+26 lignes**, 26 blocs `scopes_config.displayed` modifiés, couvrant **27 cas d’usage** (`abelium` hérite de tout le `scopes_config` de `familea` via la clé de fusion `<<:`, donc une seule édition couvre les deux). Aucune autre ligne touchée.
- Ajout dans **`displayed` uniquement** — ni dans `disabled` (qui verrouillerait la case), ni dans `initialize_with.scopes` (qui la pré cocherait).
- Rien à créer côté définition : le scope existe déjà dans `config/authorization_definitions/api_particulier.yml`, sans `feature_flag` ni `included: true`.

## Cas d’usage modifiés (27)

### Scopes cochables — 11

La case apparaît décochée et le demandeur peut la cocher : **effet fonctionnel réel**.

| Cas d’usage | Logiciel | Éditeur |
|---|---|---|
| `api-particulier-familea` | Domino web 2.0 | familea |
| `api-particulier-abelium` | Domino web 2.0 | familea *(hérité de `familea` via `<<:`)* |
| `api-particulier-agedi-proxima-enf` | Proxima.ENF | agedi |
| `api-particulier-andyvie` | Recreo | andyvie |
| `api-particulier-carte-plus` | Carte Plus | carte_plus |
| `api-particulier-city-family-mushroom-software` | City Family | mushroom_software |
| `api-particulier-jcdeveloppement-familyclic` | FamilyClic | jcdeveloppement |
| `api-particulier-nfi` | NFI | nfi |
| `api-particulier-noethys` | Noethys | noethys |
| `api-particulier-resagenda` | Res’Agenda | resagenda |
| `api-particulier-ypok-ykidz` | Ykidz | ypok |

### Scopes figés — 16

La case apparaît décochée mais **n’est pas cochable** — voir « Points à confirmer » ci-dessous.

| Cas d’usage | Logiciel | Éditeur |
|---|---|---|
| `api-particulier-3d-ouest` | Logiciel Enfance | 3d_ouest |
| `api-particulier-acheteza` | AchetezA | acheteza |
| `api-particulier-agora-plus` | Agora Plus | agora_plus |
| `api-particulier-aiga` | iNoé | aiga |
| `api-particulier-amiciel-malice` | Malice | amiciel |
| `api-particulier-arpege-concerto` | Concerto | arpege |
| `api-particulier-bl-enfance-berger-levrault` | BL Enfance | berger_levrault |
| `api-particulier-cantine-de-france` | Cantine de France | jdealise |
| `api-particulier-civil-enfance-ciril-group` | Civil Enfance | ciril_group |
| `api-particulier-cosoluce-fluo` | Fluo | cosoluce |
| `api-particulier-e1os` | Epéris | e1os |
| `api-particulier-ecorestauration-loyfeey` | Loyfeey | ecorestauration |
| `api-particulier-entrouvert-publik` | Publik Famille | entrouvert |
| `api-particulier-jvs-mairistem` | Mairistem | jvs_mairistem |
| `api-particulier-technocarte-ile` | ILE - Kiosque famille | technocarte |
| `api-particulier-waigeo-myperischool` | MyPérischool | waigeo |

### Non modifiés car déjà conformes — 6

| Cas d’usage | Pourquoi aucune modification |
|---|---|
| `api-particulier-docaposte-fast` | Pas de liste `displayed` → affiche déjà tous les scopes, AEEH compris, décoché |
| `api-particulier-odyssee-informatique-pandore` | idem |
| `api-particulier-qiis-eticket` | idem |
| `api-particulier-teamnet-axel` | idem |
| `api-particulier-sigec-maelis` | idem |
| `api-particulier-tarification-municipale-enfance` | Formulaire générique (sans `service_provider_id`) : avait déjà le scope |

27 modifiés + 6 déjà conformes = les **33** cas d’usage `tarification_municipale_enfance`.

## Points à confirmer @Miryad

**1. Sur les 16 cas d’usage « scopes figés », la case AEEH restera non cochable.**

Sur ces formulaires, le bloc `scopes` est déclaré dans `static_blocks` (et non dans `steps`) : le décorateur le marque `editable: false` et le form builder rend toutes les cases en lecture seule. La demande est donc **littéralement satisfaite** (la case apparaît, non cochée), mais **sans effet fonctionnel** : l’habilitation ne pourra jamais contenir l’AEEH sur ces 16 formulaires.

Si le besoin est que le demandeur puisse **réellement** cocher l’AEEH chez ces éditeurs, il faut sortir `scopes` de `static_blocks` → cela change le contrat passé avec l’éditeur → à cadrer avec eux dans un ticket distinct. Dis-nous ce qui est attendu.

**2. Périmètre limité au cas d’usage enfance.**

Lu au pied de la lettre, « tous les cas d’usage qui ont le `service_provider_id` rempli » viserait **63 formulaires**, tous cas d’usage confondus : `tarification_eaje` (14), `tarification_transports` (5), `ccas` (4), `aides_facultatives` (3), `cantines-colleges-lycees-tarification` (3), `stationnement_residentiel` (2). Mettre l’AEEH sur du stationnement résidentiel ou de la gestion RH n’a pas de sens, et le ticket dit « du cas d’usage enfance » → périmètre restreint à `tarification_municipale_enfance`. À confirmer, l’élargissement est trivial.

## Test plan

- [x] `bundle exec rspec spec/acceptance spec/models` → **810 examples, 0 failures**
- [x] `bundle exec rubocop` → clean
- [x] Nouvel invariant dans `spec/acceptance/authorizations_configs_spec.rb` : sur les 32 formulaires éditeur du cas d’usage, l’AEEH est affiché et **jamais** pré coché (+ garde-fou « ensemble non vide » pour éviter un test qui passe à vide)
- [x] Invariant mutation-testé : en annulant la modification YAML, l’exemple « displays the scope on each editor form » échoue bien
- [x] `spec/models/authorization_request_spec.rb` : `#available_scopes` de `familea` attendait 4 scopes, en attend 5. Échec légitime — le test vérifie que la config `displayed` est respectée, pas que `familea` a 4 scopes. L’exemple voisin `#disabled_scopes` passe toujours avec le seul `cnaf_quotient_familial`, ce qui confirme que l’AEEH est affiché **sans** être verrouillé
- [x] Aucun fichier `docs/` ni feature cucumber ne référence ces formulaires

🤖 Generated with [Claude Code](https://claude.com/claude-code)
