### PR TITLE
explain roles in the roles index too

### DIFF
--- a/app/views/instruction/user_rights/_form.html.erb
+++ b/app/views/instruction/user_rights/_form.html.erb
@@ -26,11 +26,7 @@
       <%= t('instruction.user_rights.new.rights_section') %>
     </h2>
 
-    <%= dsfr_accordion t('instruction.user_rights.new.roles_help.title'),
-                       id: 'user-rights-roles-help',
-                       class: ['fr-mb-3w'] do %>
-      <%= render 'instruction/user_rights/roles_help' %>
-    <% end %>
+    <%= render 'instruction/user_rights/roles_help' %>
 
     <%= render Molecules::Instruction::UserRights::ReadonlyRightsListComponent.new(rights: readonly_rights) %>
 

--- a/app/views/instruction/user_rights/_roles_help.html.erb
+++ b/app/views/instruction/user_rights/_roles_help.html.erb
@@ -1,10 +1,14 @@
-<h3 class="fr-h6 fr-mb-1w"><%= t('instruction.user_rights.new.roles_help.scope_section') %></h3>
-<p class="fr-mb-3w"><%= t('instruction.user_rights.new.roles_help.scope_description') %></p>
+<%= dsfr_accordion t('instruction.user_rights.new.roles_help.title'),
+                       id: 'user-rights-roles-help',
+                       class: ['fr-mb-3w'] do %>
+  <h3 class="fr-h6 fr-mb-1w"><%= t('instruction.user_rights.new.roles_help.scope_section') %></h3>
+  <p class="fr-mb-3w"><%= t('instruction.user_rights.new.roles_help.scope_description') %></p>
 
-<h3 class="fr-h6 fr-mb-1w"><%= t('instruction.user_rights.new.roles_help.roles_section') %></h3>
-<dl class="fr-mb-0">
-  <% %w[reporter instructor manager developer].each do |role_type| %>
-    <dt class="fr-text--bold"><%= t("instruction.user_rights.roles.#{role_type}") %></dt>
-    <dd class="fr-ml-0 fr-mb-2w"><%= t("instruction.user_rights.new.roles_help.#{role_type}") %></dd>
-  <% end %>
-</dl>
+  <h3 class="fr-h6 fr-mb-1w"><%= t('instruction.user_rights.new.roles_help.roles_section') %></h3>
+  <dl class="fr-mb-0">
+    <% %w[reporter instructor manager developer].each do |role_type| %>
+      <dt class="fr-text--bold"><%= t("instruction.user_rights.roles.#{role_type}") %></dt>
+      <dd class="fr-ml-0 fr-mb-2w"><%= t("instruction.user_rights.new.roles_help.#{role_type}") %></dd>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/instruction/user_rights/index.html.erb
+++ b/app/views/instruction/user_rights/index.html.erb
@@ -13,6 +13,8 @@
     </div>
   </div>
 
+  <%= render "instruction/user_rights/roles_help" %>
+
   <% search_status_message = user_rights_search_status_message(@users, @search_term) %>
   <div data-controller="search-status">
     <p role="status" aria-atomic="true" class="fr-sr-only" data-search-status-target="liveRegion"><%= search_status_message %></p>


### PR DESCRIPTION
Suite à une remarque d'Arslane, je copie l'accordéon d'explication des rôles dans l'index des rôles.

---

L'accordéon fermé :

<img width="1301" height="564" alt="image" src="https://github.com/user-attachments/assets/dca78d81-7fe6-424c-98f7-23f9cea4cc8c" />

---

L'accordéon ouvert :

<img width="1301" height="850" alt="image" src="https://github.com/user-attachments/assets/d24b18d3-a783-4663-a468-c10c532617fd" />

Closes https://linear.app/pole-api/issue/DP-1922/expliquer-les-niveaux-de-droits-dans-lindex-des-droits