### PR TITLE
Renomme les solutions logiciel Familea Diabolo et Mikado

### DIFF
--- a/config/authorization_request_forms/api_particulier.yml
+++ b/config/authorization_request_forms/api_particulier.yml
@@ -29,7 +29,7 @@ api-particulier:
 # 1. Contact technique renseigné et non modifiable
 # 2. Scopes modifiables
 api-particulier-familea: &api_particulier_familea
-  name: Domino web 2.0
+  name: Diabolo
   description: &api_particulier_form_description_petite_enfance |
     Gestion des structures de petites enfances, enfance et jeunesse
   authorization_request: APIParticulier
@@ -66,7 +66,7 @@ api-particulier-familea: &api_particulier_familea
       - cnaf_enfants
       - cnaf_adresse
   initialize_with:
-    intitule: Domino web 2.0 | Gestion des structures de petites enfances, enfance et jeunesse
+    intitule: Diabolo | Gestion des structures de petites enfances, enfance et jeunesse
     description: |
       Gestion des structures de petite enfance, enfance, jeunesse pour la facturation de la cantine le service periscolaire et extrascolaire
     cadre_juridique_nature: &api_particulier_cadre_juridique_nature_socle_general "- Cadre légal général : L’article L114-8 du Code des relations entre le public et l’administration définit le cadre juridique général en vertu duquel les administrations sont tenues d’échanger les données requises dans le cadre des démarches engagées par les usagers."
@@ -2639,7 +2639,7 @@ api-particulier-carte-plus-petite-enfance:
       - params
 
 api-particulier-familea-petite-enfance: &api_particulier_familea_petite_enfance
-  name: Domino Web 2.0 Petite enfance
+  name: Mikado
   description: Tarification PSU dans les établissements d'acceuil du jeune enfant
   authorization_request: APIParticulier
   use_case: tarification_eaje

--- a/docs/api_particulier/cadres_juridiques.md
+++ b/docs/api_particulier/cadres_juridiques.md
@@ -45,10 +45,10 @@ Chaque cadre est factorisé en une ancre YAML unique, réutilisée par tous les 
 | `docaposte` | FAST | `api-particulier-docaposte-fast` |
 | `e1os` | Epéris | `api-particulier-e1os` |
 | `ecorestauration` | Loyfeey | `api-particulier-ecorestauration-loyfeey` |
-| `familea` | Domino web 2.0 | `api-particulier-familea` |
-| `familea` | Domino web 2.0 | `api-particulier-abelium` |
-| `familea` | Domino Web 2.0 Petite enfance | `api-particulier-familea-petite-enfance` |
-| `familea` | Domino Web 2.0 Petite enfance | `api-particulier-abelium-petite-enfance` |
+| `familea` | Diabolo | `api-particulier-familea` |
+| `familea` | Diabolo | `api-particulier-abelium` |
+| `familea` | Mikado | `api-particulier-familea-petite-enfance` |
+| `familea` | Mikado | `api-particulier-abelium-petite-enfance` |
 | `ganesh_education` | Ganesh Education | `api-particulier-ganesh-education` |
 | `jcdeveloppement` | FamilyClic | `api-particulier-jcdeveloppement-familyclic` |
 | `jdealise` | Cantine de France | `api-particulier-cantine-de-france` |

--- a/features/habilitations/api_particulier/soumission_multiples_etapes.feature
+++ b/features/habilitations/api_particulier/soumission_multiples_etapes.feature
@@ -224,7 +224,7 @@ Fonctionnalité: Soumission d'une demande d'habilitation API Particulier (en plu
 
     Exemples:
       | Nom du formulaire   | Nom de l'éditeur          |
-      | Domino web 2.0      | Familea                   |
+      | Diabolo             | Familea                   |
       | City Family         | Mushroom Software         |
       | NFI                 | Nord France Informatique  |
       | Proxima.ENF         | AGEDI                     |

--- a/features/habilitations_avec_des_options_sur_les_scopes.feature
+++ b/features/habilitations_avec_des_options_sur_les_scopes.feature
@@ -31,7 +31,7 @@ Fonctionnalité: Demandes d'habilitation ayant des configurations sur les scopes
 
   Scénario: Je consulte la page des scopes d'une demande d'habilitation où il y a des options de désactivation et d'affichage
 
-    Quand je veux remplir une demande pour "API Particulier" via le formulaire "Domino web 2.0" de l'éditeur "Familea"
+    Quand je veux remplir une demande pour "API Particulier" via le formulaire "Diabolo" de l'éditeur "Familea"
     Et que je clique sur "Débuter ma demande"
     Et que je clique sur "Suivant"
 


### PR DESCRIPTION
L’éditeur Familea souhaite que ses deux logiciels soient affichés sous leurs noms commerciaux :
- api-particulier-familea : « Domino web 2.0 » devient « Diabolo »
- api-particulier-familea-petite-enfance : « Domino Web 2.0 Petite enfance » devient « Mikado »

Les blocs Abelium héritent des ancres YAML Familea, leurs noms suivent donc le même renommage (documentation des cadres juridiques mise à jour en conséquence).

Ref API-7107