### PR TITLE
Corrige la suppression involontaire de droits lors d’un ajout

### DIFF
--- a/app/controllers/admin/user_rights_controller.rb
+++ b/app/controllers/admin/user_rights_controller.rb
@@ -20,7 +20,7 @@ class Admin::UserRightsController < AdminController
     @form = Instruction::UserRightForm.new(authority: @authority, **form_params)
     @target_user = User.find_by(email: @form.email)
     return render_email_not_found if @target_user.nil?
-    return render_failure(:new) unless @form.save_for(@target_user, actor: true_user)
+    return render_failure(:new) unless @form.save_for(@target_user, actor: true_user, additive: true)
 
     success_message(title: t('instruction.user_rights.create.success', email: @target_user.email))
     redirect_to admin_user_rights_path

--- a/app/controllers/instruction/user_rights_controller.rb
+++ b/app/controllers/instruction/user_rights_controller.rb
@@ -18,7 +18,7 @@ class Instruction::UserRightsController < InstructionController
     @form = Instruction::UserRightForm.new(authority: @authority, **form_params)
     @target_user = User.find_by(email: @form.email)
     return render_email_not_found if @target_user.nil?
-    return render_failure(:new) unless @form.save_for(@target_user, actor: current_user)
+    return render_failure(:new) unless @form.save_for(@target_user, actor: current_user, additive: true)
 
     success_message(title: t('instruction.user_rights.create.success', email: @target_user.email))
     redirect_to instruction_user_rights_path

--- a/app/forms/instruction/user_right_form.rb
+++ b/app/forms/instruction/user_right_form.rb
@@ -36,13 +36,14 @@ class Instruction::UserRightForm
   end
 
   def to_roles
-    rights.map { |r| "#{r[:scope]}:#{r[:role_type]}" }
+    rights.map { |r| role_string(r) }
   end
 
-  def save_for(target, actor:)
+  def save_for(target, actor:, additive: false)
     return false unless valid?
 
-    @organizer_result = Instruction::UpdateUserRights.call(authority: authority, actor: actor, user: target, new_roles: to_roles)
+    new_roles = additive ? to_roles | existing_modifiable_roles_for(target) : to_roles
+    @organizer_result = Instruction::UpdateUserRights.call(authority: authority, actor: actor, user: target, new_roles: new_roles)
     @organizer_result.success?
   end
 
@@ -56,6 +57,14 @@ class Instruction::UserRightForm
 
   def email_required?
     user.nil?
+  end
+
+  def existing_modifiable_roles_for(target)
+    Instruction::UserRightsView.new(authority: authority, user: target).modifiable.map { |r| role_string(r) }
+  end
+
+  def role_string(right)
+    "#{right[:scope]}:#{right[:role_type]}"
   end
 
   def normalize_right(entry)

--- a/features/instructeurs/gestion_des_droits/j_ajoute_des_droits.feature
+++ b/features/instructeurs/gestion_des_droits/j_ajoute_des_droits.feature
@@ -73,3 +73,14 @@ Fonctionnalité: Instruction — Gestion des droits — ajouter des droits à un
     Et que je clique sur "Valider les modifications"
     Alors il y a un message de succès contenant "mis à jour"
     Et l'utilisateur "existant@gouv.fr" a les rôles "dinum:api_particulier:reporter,dinum:api_entreprise:instructor"
+
+  Scénario: Je préserve les rôles existants dans mon périmètre en ajoutant un droit
+    Sachant que je suis un manager "API Particulier"
+    Quand il y a l'utilisateur "collegue@gouv.fr" avec le rôle "Rapporteur" pour "API Particulier"
+    Et que je me rends sur la page d'ajout de droits
+    Et que je remplis "Email de l’utilisateur" avec "collegue@gouv.fr"
+    Et que je sélectionne "API Entreprise" pour "Portée des droits"
+    Et que je sélectionne "Instructeur" pour "Rôle"
+    Et que je clique sur "Valider les modifications"
+    Alors il y a un message de succès contenant "mis à jour"
+    Et l'utilisateur "collegue@gouv.fr" a les rôles "dinum:api_particulier:reporter,dinum:api_entreprise:instructor"

--- a/spec/forms/instruction/user_right_form_spec.rb
+++ b/spec/forms/instruction/user_right_form_spec.rb
@@ -125,6 +125,42 @@ RSpec.describe Instruction::UserRightForm do
     end
   end
 
+  describe '#save_for' do
+    let(:manager) { create(:user, roles: %w[dinum:api_entreprise:manager dinum:api_particulier:manager]) }
+
+    context 'when additive is true and the target already has a managed role out of the submitted set' do
+      it 'preserves the existing managed role and adds the submitted one' do
+        target = create(:user, roles: ['dinum:api_particulier:reporter'])
+        form = described_class.new(
+          authority: Rights::ManagerAuthority.new(manager),
+          email: target.email,
+          rights: [valid_right(role_type: 'instructor')]
+        )
+
+        form.save_for(target, actor: manager, additive: true)
+
+        expect(target.reload.roles).to match_array(
+          %w[dinum:api_particulier:reporter dinum:api_entreprise:instructor]
+        )
+      end
+    end
+
+    context 'when additive is false' do
+      it 'replaces the managed roles with the submitted ones' do
+        target = create(:user, roles: ['dinum:api_particulier:reporter'])
+        form = described_class.new(
+          authority: Rights::ManagerAuthority.new(manager),
+          email: target.email,
+          rights: [valid_right(role_type: 'instructor')]
+        )
+
+        form.save_for(target, actor: manager)
+
+        expect(target.reload.roles).to eq(%w[dinum:api_entreprise:instructor])
+      end
+    end
+  end
+
   describe 'rights normalization' do
     it 'accepts hashes with string keys' do
       form = described_class.new(


### PR DESCRIPTION
TL;DR : Quand un manager utilise "Ajouter des droits à un utilisateur sans droits" pour rajouter des droits à un utilisateur qui a _déjà_ des droits dans son périmètre, ça remplaçait les droits existants dans son périmètre par les nouveaux.

---

Le formulaire « Ajouter des droits » (create) ne pré-remplit pas les rôles existants de l’utilisateur cible : il démarre avec une seule ligne vide et l’email est saisi à la main, donc au moment du submit seule la ligne ajoutée est envoyée. Or ce flux alimente le même organizer que l’édition (MergeManagedRoles), qui remplace l’intégralité des rôles gérables par le manager. Résultat : ajouter un rôle effaçait tous les autres rôles de l’utilisateur situés dans le périmètre du manager.

C’est exactement le scénario de DP-1926 : l’ajout d’un rôle instructeur a retiré api_particulier:manager et api_entreprise:reporter (dans le périmètre), tout en préservant les rôles hors périmètre.

Le flux d’ajout devient additif : save_for accepte un paramètre `additive` qui fusionne les rôles gérables déjà présents sur l’utilisateur avec les rôles soumis avant d’appeler l’organizer. Le flux d’édition conserve la sémantique de remplacement, si bien que retirer un droit via le formulaire d’édition fonctionne toujours.

Le même correctif est appliqué au flux d’ajout admin, porteur du même bug latent.

Closes https://linear.app/pole-api/issue/DP-1926/bug-ajouter-un-role-via-linterface-instructeur-en-a-retire