### PR TITLE
fix : instructor_drafts_enabled is false by default

### DIFF
--- a/app/components/molecules/instruction/authorization_definition/config_block_component.rb
+++ b/app/components/molecules/instruction/authorization_definition/config_block_component.rb
@@ -32,8 +32,8 @@ class Molecules::Instruction::AuthorizationDefinition::ConfigBlockComponent < At
     [
       boolean_row(t('.features.messaging'), feature_enabled?(:messaging)),
       boolean_row(t('.features.transfer'), feature_enabled?(:transfer)),
-      boolean_row(t('.features.instructor_drafts'), feature_enabled?(:instructor_drafts)),
-      boolean_row(t('.features.reopening'), feature_enabled?(:reopening))
+      boolean_row(t('.features.reopening'), feature_enabled?(:reopening)),
+      boolean_row(t('.features.instructor_drafts'), feature_enabled?(:instructor_drafts))
     ]
   end
 

--- a/app/models/authorization_definition.rb
+++ b/app/models/authorization_definition.rb
@@ -1,4 +1,12 @@
 class AuthorizationDefinition < StaticApplicationRecord
+  FEATURES_DEFAULTS = {
+    messaging: true,
+    message_templates: true,
+    reopening: true,
+    transfer: true,
+    instructor_drafts: false,
+  }.freeze
+
   attr_accessor :id,
     :name,
     :description,
@@ -92,12 +100,12 @@ class AuthorizationDefinition < StaticApplicationRecord
     I18n.transliterate([name_with_stage, provider&.name].compact_blank.join(' ')).downcase
   end
 
-  def feature?(name, default: true)
-    features.fetch(name.to_sym, default)
+  def feature?(name)
+    features.fetch(name.to_sym, FEATURES_DEFAULTS.fetch(name.to_sym))
   end
 
   def instructor_drafts_enabled?
-    feature?(:instructor_drafts, default: false)
+    feature?(:instructor_drafts)
   end
 
   EXTRA_STEPS = %i[intro before_submit_summary].freeze

--- a/app/policies/instruction/authorization_request_policy.rb
+++ b/app/policies/instruction/authorization_request_policy.rb
@@ -34,7 +34,7 @@ class Instruction::AuthorizationRequestPolicy < ApplicationPolicy
   end
 
   def messages?
-    feature_enabled?(:messages) &&
+    feature_enabled?(:messaging) &&
       show?
   end
 

--- a/spec/models/authorization_definition_spec.rb
+++ b/spec/models/authorization_definition_spec.rb
@@ -162,6 +162,36 @@ RSpec.describe AuthorizationDefinition do
     end
   end
 
+  describe '#feature?' do
+    let(:instance) { described_class.build('mon_api', name: 'Mon API', blocks: [], features:) }
+
+    context 'when the feature is set within the definition' do
+      let(:features) { { messaging: false, instructor_drafts: true } }
+
+      it 'returns the configured value' do
+        expect(instance.feature?(:messaging)).to be false
+        expect(instance.feature?(:instructor_drafts)).to be true
+      end
+    end
+
+    context 'when the feature is not set within the definition' do
+      let(:features) { {} }
+
+      it 'returns the default of the feature' do
+        expect(instance.feature?(:messaging)).to be true
+        expect(instance.feature?(:instructor_drafts)).to be false
+      end
+    end
+
+    context 'with an unknown feature' do
+      let(:features) { {} }
+
+      it 'raises an error' do
+        expect { instance.feature?(:unknown_feature) }.to raise_error(KeyError)
+      end
+    end
+  end
+
   describe '#support_email' do
     it 'is present on each definition' do
       described_class.all.each do |definition|


### PR DESCRIPTION
Lorsqu'un formulaire n'avait rien de configuré pour `instructor_drafts_enabled`, il apparaissait comme activé par défaut (comme toutes les autres "features") alors qu'il est désactivé par défaut.