### PR TITLE
Corrige la proactivité CNOUS : le bridge HubEE utilise le contact métier

### DIFF
--- a/app/bridges/hubee_proactivite_bridge.rb
+++ b/app/bridges/hubee_proactivite_bridge.rb
@@ -20,11 +20,11 @@ class HubEEProactiviteBridge < HubEEBaseBridge
 
   def local_administrator_data
     {
-      email: authorization_request.contact_technique_email,
-      firstName: authorization_request.contact_technique_given_name,
-      lastName: authorization_request.contact_technique_family_name,
-      function: authorization_request.contact_technique_job_title,
-      phoneNumber: authorization_request.contact_technique_phone_number.gsub(/[\s.-]/, ''),
+      email: authorization_request.contact_metier_email,
+      firstName: authorization_request.contact_metier_given_name,
+      lastName: authorization_request.contact_metier_family_name,
+      function: authorization_request.contact_metier_job_title,
+      phoneNumber: authorization_request.contact_metier_phone_number.to_s.gsub(/[\s.-]/, ''),
     }
   end
 end

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -84,7 +84,7 @@ class Seeds
         { 'name' => 'cnous_data_extraction_criteria' },
         { 'name' => 'contacts' },
       ],
-      contact_types: ['contact_technique'],
+      contact_types: ['contact_metier'],
       features: { 'messaging' => true, 'transfer' => true, 'reopening' => true },
       scopes: [],
       custom_labels: {}

--- a/app/models/habilitation_type.rb
+++ b/app/models/habilitation_type.rb
@@ -24,6 +24,7 @@ class HabilitationType < ApplicationRecord
   validates :contact_types, presence: true, if: :contacts_block_selected?
   validates :scopes, presence: true, if: :scopes_block_selected?
   validate :validate_each_scope, if: :scopes_block_selected?
+  validate :cnous_proactivite_requires_contact_metier, if: :cnous_proactivite_block_selected?
 
   after_create :ensure_default_form_template!
   before_destroy :ensure_no_authorization_requests
@@ -105,6 +106,16 @@ class HabilitationType < ApplicationRecord
 
   def contacts_block_selected?
     block_name_list.include?('contacts')
+  end
+
+  def cnous_proactivite_block_selected?
+    block_name_list.include?('cnous_data_extraction_criteria')
+  end
+
+  def cnous_proactivite_requires_contact_metier
+    return if contacts_block_selected? && contact_types.to_a.include?('contact_metier')
+
+    errors.add(:base, :cnous_proactivite_requires_contact_metier)
   end
 
   def validate_each_scope

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -282,6 +282,7 @@ fr:
           attributes:
             base:
               has_authorization_requests: "ne peut pas être supprimé car des demandes d’habilitation existent pour ce type"
+              cnous_proactivite_requires_contact_metier: "le bloc « Proactivité CNOUS » nécessite un bloc « Contacts » incluant le contact métier (utilisé comme administrateur local HubEE)"
             name:
               unreachable_uid: "génère un identifiant technique inaccessible (le nom doit commencer par une lettre, ex: « Espace agent de l'Annuaire des Entreprises »)"
             slug:

--- a/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
+++ b/features/habilitations/boursiers_test_cnous_data_extraction_criteria_block.feature
@@ -21,14 +21,14 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     * je sélectionne "Échelon 5 et au-dessus" pour "Échelon de bourse minimum"
     * je remplis la date de transmission avec une date future
     * je clique sur "Suivant"
-    * la page contient "Contact technique"
+    * la page contient "Contact métier"
 
     * je clique sur "Précédent"
     * le bouton de suppression de la commune "75056" est annoncé par son code aux lecteurs d’écran
     * chaque champ commune INSEE est annoncé avec sa position aux lecteurs d’écran
     * je clique sur "Suivant"
 
-    * je renseigne les informations du contact technique
+    * je renseigne les informations du contact métier
     * je clique sur "Suivant"
 
     * j'adhère aux conditions générales
@@ -78,7 +78,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Et je remplis la date de transmission avec une date future
     Et je clique sur "Suivant"
 
-    * je renseigne les informations du contact technique
+    * je renseigne les informations du contact métier
     * je clique sur "Suivant"
 
     * j'adhère aux conditions générales
@@ -130,7 +130,7 @@ Fonctionnalité: Soumission d'une demande Boursiers CNOUS avec le bloc cnous_dat
     Et je remplis la date de transmission avec une date future
     Et je clique sur "Suivant"
 
-    * je renseigne les informations du contact technique
+    * je renseigne les informations du contact métier
     * je clique sur "Suivant"
 
     * j'adhère aux conditions générales

--- a/features/step_definitions/habilitation_types_steps.rb
+++ b/features/step_definitions/habilitation_types_steps.rb
@@ -24,7 +24,7 @@ Sachantque("un type d'habilitation {string} expose le bloc {string}") do |name, 
       { 'name' => block_name },
       { 'name' => 'contacts' },
     ],
-    contact_types: ['contact_technique'],
+    contact_types: ['contact_metier'],
   )
 end
 

--- a/spec/bridges/hubee_proactivite_bridge_spec.rb
+++ b/spec/bridges/hubee_proactivite_bridge_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HubEEProactiviteBridge do
   let!(:habilitation_type) do
     create(:habilitation_type,
       name: 'Test proactividad',
-      contact_types: ['contact_technique'],
+      contact_types: ['contact_metier'],
       blocks: [{ 'name' => 'basic_infos' }, { 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }])
   end
   let(:organization) { create(:organization, siret: '21920023500014') }
@@ -19,7 +19,7 @@ RSpec.describe HubEEProactiviteBridge do
   end
   let(:organization_payload) do
     build(:hubee_organization_payload, organization:,
-      email: 'jean.dupont.contact_technique@gouv.fr',
+      email: 'jean.dupont.contact_metier@gouv.fr',
       phoneNumber: '0836656565')
   end
   let(:subscription_response) { build(:hubee_subscription_response_payload, id: hubee_subscription_id) }
@@ -49,14 +49,14 @@ RSpec.describe HubEEProactiviteBridge do
       perform
     end
 
-    it 'sends the contact technique as the HubEE local administrator' do
+    it 'sends the contact metier as the HubEE local administrator' do
       expect(hubee_api_client).to receive(:create_subscription).with(
         hash_including(
           localAdministrator: {
-            email: 'jean.dupont.contact_technique@gouv.fr',
-            firstName: 'Jean Contact technique',
-            lastName: 'Dupont Contact technique',
-            function: 'Agent Contact technique',
+            email: 'jean.dupont.contact_metier@gouv.fr',
+            firstName: 'Jean Contact metier',
+            lastName: 'Dupont Contact metier',
+            function: 'Agent Contact metier',
             phoneNumber: '0836656565',
           }
         )

--- a/spec/interactors/execute_authorization_request_bridge_spec.rb
+++ b/spec/interactors/execute_authorization_request_bridge_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ExecuteAuthorizationRequestBridge do
         create(:habilitation_type,
           name: 'Test proactividad',
           blocks: [{ 'name' => 'basic_infos' }, { 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }],
-          contact_types: ['contact_technique'])
+          contact_types: ['contact_metier'])
       end
       let(:authorization_request) { AuthorizationRequest.const_get(habilitation_type.uid.classify).new }
 

--- a/spec/models/concerns/authorization_extensions/cnous_data_extraction_criteria_spec.rb
+++ b/spec/models/concerns/authorization_extensions/cnous_data_extraction_criteria_spec.rb
@@ -3,7 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe AuthorizationExtensions::CnousDataExtractionCriteria do
-  let(:habilitation_type) { create(:habilitation_type, blocks: [{ 'name' => 'cnous_data_extraction_criteria' }]) }
+  let(:habilitation_type) do
+    create(:habilitation_type,
+      blocks: [{ 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }],
+      contact_types: ['contact_metier'])
+  end
   let(:klass) { AuthorizationRequest.const_get(habilitation_type.uid.classify) }
 
   def organization_with(categorie:, commune: '92023')

--- a/spec/models/habilitation_type_spec.rb
+++ b/spec/models/habilitation_type_spec.rb
@@ -116,6 +116,37 @@ RSpec.describe HabilitationType do
     end
   end
 
+  describe 'validation: cnous proactivite block requires contact_metier' do
+    context 'when cnous_data_extraction_criteria block is selected' do
+      it 'is invalid without a contacts block' do
+        habilitation_type.blocks = [{ 'name' => 'cnous_data_extraction_criteria' }]
+        expect(habilitation_type).not_to be_valid
+        expect(habilitation_type.errors[:base]).to be_present
+      end
+
+      it 'is invalid when contacts block does not include contact_metier' do
+        habilitation_type.blocks = [{ 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }]
+        habilitation_type.contact_types = ['contact_technique']
+        expect(habilitation_type).not_to be_valid
+        expect(habilitation_type.errors[:base]).to be_present
+      end
+
+      it 'is valid when contacts block includes contact_metier' do
+        habilitation_type.blocks = [{ 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }]
+        habilitation_type.contact_types = ['contact_metier']
+        expect(habilitation_type).to be_valid
+      end
+    end
+
+    context 'when cnous_data_extraction_criteria block is not selected' do
+      it 'is valid without contact_metier' do
+        habilitation_type.blocks = [{ 'name' => 'basic_infos' }]
+        habilitation_type.contact_types = []
+        expect(habilitation_type).to be_valid
+      end
+    end
+  end
+
   describe 'validation: scopes block requires scopes' do
     context 'when scopes block is selected' do
       before { habilitation_type.blocks = [{ 'name' => 'scopes' }] }

--- a/spec/serializers/api/v1/authorization_request_serializer_spec.rb
+++ b/spec/serializers/api/v1/authorization_request_serializer_spec.rb
@@ -34,7 +34,11 @@ RSpec.describe API::V1::AuthorizationRequestSerializer, type: :serializer do
   describe 'geographic perimeter contract (relais)' do
     subject(:data) { described_class.new(authorization_request).serializable_hash[:data] }
 
-    let(:habilitation_type) { create(:habilitation_type, blocks: [{ 'name' => 'cnous_data_extraction_criteria' }]) }
+    let(:habilitation_type) do
+      create(:habilitation_type,
+        blocks: [{ 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }],
+        contact_types: ['contact_metier'])
+    end
     let(:klass) { AuthorizationRequest.const_get(habilitation_type.uid.classify) }
     let(:organization) do
       etablissement = {

--- a/spec/services/dynamic_authorization_request_registrar_spec.rb
+++ b/spec/services/dynamic_authorization_request_registrar_spec.rb
@@ -132,7 +132,11 @@ RSpec.describe DynamicAuthorizationRequestRegistrar do
       context 'when submitted' do
         subject(:valid?) { demande.valid?(:submit) }
 
-        let(:habilitation_type) { create(:habilitation_type, blocks: [{ 'name' => 'cnous_data_extraction_criteria' }]) }
+        let(:habilitation_type) do
+          create(:habilitation_type,
+            blocks: [{ 'name' => 'cnous_data_extraction_criteria' }, { 'name' => 'contacts' }],
+            contact_types: ['contact_metier'])
+        end
         let(:klass) { AuthorizationRequest.const_get(habilitation_type.uid.classify) }
         let(:demande) { klass.new(**params) }
         let(:params) { {} }


### PR DESCRIPTION
## Problème

Des habilitations Boursiers CNOUS validées en prod n'ont généré **aucune subscription HubEE**, alors que le bridge doit les créer automatiquement à l'approbation. Relancer le job manuellement ne changeait rien.

**Cause :** `HubEEProactiviteBridge#local_administrator_data` lisait en dur `contact_technique_*`, mais le type Boursiers collecte `contact_metier` (+ DPO). Les accesseurs `contact_technique_*` n'étant pas générés, le job levait une `NoMethodError` et retentait à l'infini (Sentry seulement à la 5ᵉ tentative) → même crash à chaque relance.

## Correctif

- **Bridge** : lit désormais `contact_metier_*` (décision métier : l'administrateur local HubEE = contact métier), avec garde `.to_s` sur le téléphone.
- **Prévention** : validation sur `HabilitationType` — un type incluant `cnous_data_extraction_criteria` doit avoir un bloc `contacts` avec `contact_metier`, pour échouer à la création dans l'admin plutôt qu'au moment de l'approbation.
- Specs, fixtures, seed et feature cucumber CNOUS réalignés sur `contact_metier`.

## Reprise prod (après déploiement)

Vérifier HubEE (`find_subscriptions`) pour les demandes concernées, puis `HubEEProactiviteBridge.perform_later(ar, :approve)` — données `contact_metier` déjà présentes, pas de re-saisie.

## Tests

113 examples 0 failures · rubocop clean. La feature CNOUS est `@javascript` (validée en CI).
