### PR TITLE
Request HubEE tokens with the DATAPASS scope instead of ADMIN

### DIFF
--- a/app/services/hubee_api_client.rb
+++ b/app/services/hubee_api_client.rb
@@ -30,7 +30,7 @@ class HubEEAPIClient
       req.url hubee_auth_url
       req.headers['Authorization'] = "Basic #{encoded_client_id_and_secret}"
       req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
-      req.body = URI.encode_www_form({ grant_type: 'client_credentials', scope: 'ADMIN' })
+      req.body = URI.encode_www_form({ grant_type: 'client_credentials', scope: 'DATAPASS' })
     end
 
     @access_token = response.body['access_token']


### PR DESCRIPTION
DataPass only needs its own dedicated scope on the HubEE OAuth server; `ADMIN` was broader than required. One-line change in `HubEEAPIClient#access_token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)