### PR TITLE
Revert HubEE OAuth scope to ADMIN

### DIFF
--- a/app/services/hubee_api_client.rb
+++ b/app/services/hubee_api_client.rb
@@ -30,7 +30,7 @@ class HubEEAPIClient
       req.url hubee_auth_url
       req.headers['Authorization'] = "Basic #{encoded_client_id_and_secret}"
       req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
-      req.body = URI.encode_www_form({ grant_type: 'client_credentials', scope: 'DATAPASS' })
+      req.body = URI.encode_www_form({ grant_type: 'client_credentials', scope: 'ADMIN' })
     end
 
     @access_token = response.body['access_token']


### PR DESCRIPTION
The DATAPASS scope HubEE asked for is misconfigured on their side and their team is on holiday. Back to ADMIN, the known-working scope, until they fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)