### PR TITLE
Restore HubEE OAuth scope to DATAPASS

### DIFF
--- a/app/services/hubee_api_client.rb
+++ b/app/services/hubee_api_client.rb
@@ -30,7 +30,7 @@ class HubEEAPIClient
       req.url hubee_auth_url
       req.headers['Authorization'] = "Basic #{encoded_client_id_and_secret}"
       req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
-      req.body = URI.encode_www_form({ grant_type: 'client_credentials', scope: 'ADMIN' })
+      req.body = URI.encode_www_form({ grant_type: 'client_credentials', scope: 'DATAPASS' })
     end
 
     @access_token = response.body['access_token']


### PR DESCRIPTION
⏳ **Waiting for hubee team update to merge this PR**

Restores the DATAPASS scope (API-7125) once HubEE fixes their Keycloak configuration — planned for Monday 2026-08-10. Reverts the temporary fallback to ADMIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)