### PR TITLE
[TS] Corrige la doc webhooks : la politique de retry ne désactive pas le webhook après 5 échecs

### DIFF
--- a/docs/developers/tutorials/webhooks.md
+++ b/docs/developers/tutorials/webhooks.md
@@ -166,9 +166,9 @@ L'historique des appels est visible sur [/developpeurs/webhooks](/developpeurs/w
 
 ### Politique de retry
 
-En cas de réponse non-2xx (ou d'absence de réponse), l'appel est rejoué automatiquement selon un back-off exponentiel. Après **5 échecs consécutifs**, le webhook est **automatiquement désactivé** — les événements suivants ne sont plus envoyés tant qu'il n'est pas réactivé manuellement depuis l'interface.
+En cas de réponse non-2xx (ou d'absence de réponse), l'appel est rejoué automatiquement selon un back-off polynomial, **sans limite de tentatives**, jusqu'à obtention d'une réponse 2xx. Après **5 tentatives échouées** sur un même envoi, un **email d'alerte** est envoyé à tous les développeurs du type d'habilitation, mais le webhook **reste actif** et les tentatives se poursuivent. Un webhook n'est désactivé automatiquement que lorsque son URL est modifiée ; vous pouvez aussi le désactiver manuellement depuis l'interface.
 
-Les détails exacts (délais entre tentatives, nombre maximal de tentatives par appel, codes qui déclenchent un retry) sont dans la [documentation webhooks](/developpeurs/webhooks/documentation). Activez une alerte interne sur les codes non-2xx pour ne pas découvrir une désactivation par hasard.
+Les détails exacts (délais entre tentatives, codes qui déclenchent un retry) sont dans la [documentation webhooks](/developpeurs/webhooks/documentation). Activez une alerte interne sur les codes non-2xx pour ne pas découvrir un endpoint cassé par hasard.
 
 ## Événements disponibles
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -27,7 +27,7 @@ DataPass propose un système de webhooks permettant de recevoir des notification
 - **Historique complet** : Consultez tous les appels effectués avec leurs statuts, codes HTTP et réponses
 - **Rejeu manuel** : Rejouez un appel qui a échoué directement depuis l'interface
 - **Test automatique** : Les webhooks sont automatiquement testés lors de leur création
-- **Désactivation automatique** : Les webhooks défaillants sont automatiquement désactivés après 5 échecs consécutifs
+- **Alerte en cas d'échec** : Après 5 tentatives échouées, tous les développeurs du type d'habilitation reçoivent un email d'alerte (les tentatives se poursuivent ensuite selon le back-off)
 - **API de polling** : Interrogez l'historique des appels via l'API REST avec filtres temporels
 
 ---
@@ -531,25 +531,25 @@ En cas d'échec, DataPass utilise un **backoff polynomial** pour réessayer l'en
 
 *(voir la table complète dans la documentation technique)*
 
-### Désactivation automatique après 5 échecs
+### Email d'alerte après 5 échecs
 
-Après **5 tentatives échouées consécutives**, le webhook est automatiquement :
+Après **5 tentatives échouées consécutives** pour un même envoi, un **email d'alerte** est automatiquement envoyé à **tous les développeurs du type d'habilitation**. Il contient :
 
-1. **Désactivé** : Il ne recevra plus de notifications
-2. **Email de notification** : Tous les développeurs du type d'habilitation reçoivent un email contenant :
-   - Le type d'habilitation concerné
-   - L'URL du webhook
-   - Le dernier code d'erreur HTTP
-   - Un lien direct vers la gestion du webhook
+- Le type d'habilitation concerné
+- L'URL du webhook
+- Un lien direct vers l'historique des appels du webhook
 
-### Réactivation après désactivation
+Le webhook **n'est pas désactivé** : les tentatives se poursuivent selon le back-off polynomial (voir ci-dessus), sans limite, jusqu'à obtention d'une réponse 2xx. Cette alerte vous invite à vérifier et corriger votre endpoint au plus vite.
 
-Pour réactiver un webhook désactivé automatiquement :
+> **Désactivation** : la seule désactivation automatique a lieu lorsque vous **modifiez l'URL** d'un webhook — il faut alors le retester puis le réactiver. Vous pouvez également désactiver un webhook manuellement à tout moment depuis l'interface.
+
+### Corriger un webhook défaillant
+
+Si vous recevez un email d'alerte :
 
 1. Vérifiez et corrigez le problème sur votre endpoint
-2. Testez le webhook manuellement depuis l'interface
-3. Si le test réussit, activez le webhook
-4. Les nouvelles notifications seront à nouveau envoyées
+2. Les tentatives en cours reprendront d'elles-mêmes dès que votre endpoint répondra en 2xx
+3. Les appels déjà épuisés peuvent être rejoués manuellement depuis l'historique des appels
 
 ---
 


### PR DESCRIPTION
## Pourquoi

La documentation webhooks décrivait une **désactivation automatique du webhook
après 5 échecs consécutifs**. C’est faux, et ça peut induire les développeurs FD
en erreur (croire leur webhook coupé après quelques 5xx transitoires).

Comportement réel :
- back-off **polynomial, sans limite de tentatives**, jusqu’à obtention d’une
  réponse 2xx ;
- après 5 tentatives échouées sur un même envoi, un **email d’alerte** est envoyé
  aux développeurs du type d’habilitation — mais le webhook **reste actif** et les
  tentatives se poursuivent ;
- la seule désactivation **automatique** a lieu quand l’**URL du webhook est
  modifiée** (désactivation manuelle possible par ailleurs depuis l’interface).

## Ce que fait la PR

Fix **purement documentaire**, aucun changement de code.

- `docs/developers/tutorials/webhooks.md` — section « Politique de retry »
  réécrite (back-off sans limite, email d’alerte, webhook actif, désactivation
  auto uniquement au changement d’URL).
- `docs/webhooks.md` — liste des fonctionnalités mise à jour + section
  « Désactivation automatique après 5 échecs » → « Email d’alerte après 5 échecs »
  (contenu de l’email, poursuite des tentatives) + nouvelle section
  « Corriger un webhook défaillant » (reprise auto dès 2xx + rejeu manuel depuis
  l’historique).

## Notes

- Repéré au passage (règle du boy scout).

Closes DPP-74
