### PR TITLE
Sécurise le tri du dashboard instruction contre l'injection SQL

### DIFF
--- a/app/facades/instruction/search/dashboard_search.rb
+++ b/app/facades/instruction/search/dashboard_search.rb
@@ -83,7 +83,28 @@ class Instruction::Search::DashboardSearch
   end
 
   def build_search_results
-    search_engine.result(distinct: true).except(:order).order("#{search_engine.sorts.first.name} #{search_engine.sorts.first.dir} NULLS LAST")
+    search_engine.result(distinct: true).except(:order).order(order_clause)
+  end
+
+  def order_clause
+    column, direction = sanitized_sort
+    search_engine.klass.arel_table[column].public_send(direction).nulls_last
+  end
+
+  def sanitized_sort
+    sort = search_engine.sorts.first
+    return parsed_default_sort unless sort && sortable_column?(sort.name)
+
+    [sort.name, sort.dir == 'desc' ? :desc : :asc]
+  end
+
+  def sortable_column?(name)
+    search_engine.klass.column_names.include?(name)
+  end
+
+  def parsed_default_sort
+    column, direction = default_sort.split
+    [column, direction == 'desc' ? :desc : :asc]
   end
 
   def default_sort

--- a/spec/facades/instruction/search/dashboard_demandes_search_spec.rb
+++ b/spec/facades/instruction/search/dashboard_demandes_search_spec.rb
@@ -103,4 +103,35 @@ RSpec.describe Instruction::Search::DashboardDemandesSearch do
       end
     end
   end
+
+  describe 'sorting' do
+    context 'with a malicious sort injected in the query' do
+      let(:params) { { search_query: { 's' => %q{'"()&%<zzz><ScRiPt asc} } } }
+
+      it 'does not inject raw SQL and returns results ordered safely' do
+        search = described_class.new(params: params, scope: scope)
+        expect { search.results.load }.not_to raise_error
+        expect(search.results).to include(authorization_request)
+      end
+    end
+
+    context 'with a sort on a non-existent column' do
+      let(:params) { { search_query: { 's' => 'evil_column asc' } } }
+
+      it 'falls back to the default sort without raising' do
+        search = described_class.new(params: params, scope: scope)
+        expect { search.results.load }.not_to raise_error
+      end
+    end
+
+    context 'with a legitimate column sort' do
+      let(:params) { { search_query: { 's' => 'last_submitted_at asc' } } }
+
+      it 'orders by the requested column' do
+        search = described_class.new(params: params, scope: scope)
+        expect { search.results.load }.not_to raise_error
+        expect(search.results).to include(authorization_request)
+      end
+    end
+  end
 end

--- a/spec/facades/instruction/search/dashboard_habilitations_search_spec.rb
+++ b/spec/facades/instruction/search/dashboard_habilitations_search_spec.rb
@@ -72,4 +72,35 @@ RSpec.describe Instruction::Search::DashboardHabilitationsSearch do
       end
     end
   end
+
+  describe 'sorting' do
+    context 'with a malicious sort injected in the query' do
+      let(:params) { { search_query: { 's' => %q{'"()&%<zzz><ScRiPt asc} } } }
+
+      it 'does not inject raw SQL and returns results ordered safely' do
+        search = described_class.new(params: params, scope: scope)
+        expect { search.results.load }.not_to raise_error
+        expect(search.results).to include(authorization)
+      end
+    end
+
+    context 'with a sort on a non-existent column' do
+      let(:params) { { search_query: { 's' => 'evil_column asc' } } }
+
+      it 'falls back to the default sort without raising' do
+        search = described_class.new(params: params, scope: scope)
+        expect { search.results.load }.not_to raise_error
+      end
+    end
+
+    context 'with a legitimate column sort' do
+      let(:params) { { search_query: { 's' => 'created_at asc' } } }
+
+      it 'orders by the requested column' do
+        search = described_class.new(params: params, scope: scope)
+        expect { search.results.load }.not_to raise_error
+        expect(search.results).to include(authorization)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

Sentry [`DATAPASS-REBORN-EV`](https://errors.data.gouv.fr/organizations/sentry/issues/DATAPASS-REBORN-EV) : le tri du dashboard instruction interpolait le **nom de colonne et la direction issus de Ransack** directement dans `.order()` :

```ruby
.order("#{search_engine.sorts.first.name} #{search_engine.sorts.first.dir} NULLS LAST")
```

Ces valeurs viennent du param utilisateur `search_query[s]`. L'injection SQL n'était stoppée **que** par le garde framework Rails `disallow_raw_sql!` — on ne veut pas en dépendre. Un nom de tri non autorisé provoquait un `500` (injection bloquée par Rails, ou colonne inexistante).

## Changement

Construction de l'`ORDER BY` via **Arel** (identifiant quoté) avec **repli sur le tri par défaut** quand la colonne demandée n'est pas une vraie colonne du modèle. Le fix est dans la classe de base `Instruction::Search::DashboardSearch` → couvre les deux sous-classes (`DashboardHabilitationsSearch`, `DashboardDemandesSearch`).

SQL généré vérifié :
- payload malicieux / colonne inexistante → `"authorizations"."created_at" DESC NULLS LAST` (repli, identifiant quoté, aucune interpolation)
- tri légitime `created_at asc` → `"authorizations"."created_at" ASC NULLS LAST` (préservé, `NULLS LAST` conservé)

## Tests

- Specs façade : **40 examples, 0 failures** (dont 4 nouveaux : injection, colonne inexistante, tri légitime × 2 modèles)
- Feature specs instruction (`search_demandes` + `search_habilitations`) : **28 examples, 0 failures**
- Rubocop clean

## Périmètre

Correctif ciblé. Le rescue global des inputs de scan (400/404/422) et la coupure du scan à la source (token staging, DPP-10) sont **hors périmètre** → projet Sécurité applicative.

Closes DPP-77
