### PR TITLE
Ajoute le formulaire API Entreprise Nexys Relation Usagers (MGDIS)

### DIFF
--- a/config/authorization_request_forms/api_entreprise.yml
+++ b/config/authorization_request_forms/api_entreprise.yml
@@ -541,6 +541,38 @@ api-entreprise-mgdis:
       - attestation_cotisations_conges_payes_chomage_intemperies_cibtp_cnetp
       - certifications_qualiopi_france_competences
 
+api-entreprise-mgdis-nexys-relation-usagers:
+  name: "Nexys Relation Usagers"
+  description: "Solution de gestion de la relation usagers fournie par l’éditeur MGDIS."
+  use_case: "portail_gru_instruction"
+  authorization_request: "APIEntreprise"
+  single_page_view: "api_entreprise_through_editor"
+  introduction: *introduction_api_entreprise_editor
+  service_provider_id: "mgdis"
+  static_blocks:
+    - name: "basic_infos"
+    - name: "personal_data"
+    - name: "legal"
+    - name: "scopes"
+  initialize_with:
+    intitule: "Nexys Relation Usagers de l’éditeur MGDIS"
+    description: |
+      Dans un objectif de modernisation de la relation avec les usagers, nous mettons en place un outil, à destination des agents de notre organisme, leur permettant de gérer les tiers (usagers, entreprises, associations) et leurs échanges avec l’administration.
+
+      La demande d’accès à API Entreprise est effectuée dans le but de faciliter l’identification et la mise à jour des tiers moraux (entreprises, entrepreneurs individuels, associations), à partir d’un SIRET ou d’un numéro RNA, sans avoir à demander ces informations aux usagers concernés.
+
+      La plateforme, mise en place pour permettre la gestion de la relation avec les usagers, s’appuie sur la solution « Nexys Relation Usagers » de l’éditeur MGDIS.
+    destinataire_donnees_caractere_personnel: "Agents gestionnaires de la relation usagers de l’organisme"
+    duree_conservation_donnees_caractere_personnel: 36
+    cadre_juridique_nature: "Décret n° 2019-31 du 18 janvier 2019 relatif aux échanges d’informations et de données entre administrations dans le cadre des démarches administratives et à l’expérimentation prévue par l’article 40 de la loi n° 2018-727 du 10 août 2018 pour un Etat au service d’une société de confiance"
+    cadre_juridique_url: "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000038029589/"
+    contact_technique_type: "organization"
+    contact_technique_email: *api_entreprise_mgdis_contact_email
+    contact_technique_phone_number: *api_entreprise_mgdis_contact_phone_number
+    contact_metier_type: "organization"
+    contact_metier_email: *api_entreprise_mgdis_contact_email
+    contact_metier_phone_number: *api_entreprise_mgdis_contact_phone_number
+
 api-entreprise-atexo:
   name: "Dématérialisation des marchés publics"
   description: "Outil de dématérialisation des appels d’offres des marchés publics - Solution LOCAL TRUST MPE"

--- a/config/locales/authorization_request_forms.fr.yml
+++ b/config/locales/authorization_request_forms.fr.yml
@@ -344,6 +344,7 @@ fr:
     api_entreprise_provigis: *api_entreprise_contacts_editeur
     api_entreprise_achat_solution: *api_entreprise_contacts_editeur
     api_entreprise_mgdis: *api_entreprise_contacts_editeur
+    api_entreprise_mgdis_nexys_relation_usagers: *api_entreprise_contacts_editeur
     api_entreprise_atexo: *api_entreprise_contacts_editeur
     api_entreprise_inetum:
       contact_technique:

--- a/features/habilitations/api_entreprise/choix_formulaire.feature
+++ b/features/habilitations/api_entreprise/choix_formulaire.feature
@@ -23,8 +23,9 @@ Fonctionnalité: Choix du type de formulalire pour API Entreprise
     Et que je choisis "Votre éditeur"
     Et que je clique sur "M"
     Et que je choisis "MGDIS"
-    Alors je vois 1 tuile
+    Alors je vois 2 tuiles
     Et je vois 1 tuile "Solution Portail des aides"
+    Et je vois 1 tuile "Nexys Relation Usagers"
 
   Scénario: Je choisis un éditeur inconnu de API Entreprise
     Quand je démarre une nouvelle demande d'habilitation "API Entreprise"
@@ -64,3 +65,11 @@ Fonctionnalité: Choix du type de formulalire pour API Entreprise
     Et que je choisis "SETEC"
     Alors je vois 1 tuile
     Et je vois 1 tuile "Dématérialisation des marchés publics"
+
+  Scénario: Je choisis un éditeur qui correspond au paramètre de cas d'usage de gestion de la relation usagers
+    Quand je démarre une nouvelle demande d'habilitation "API Entreprise" avec le paramètre "use_case" égal à "portail_gru_instruction"
+    Et que je choisis "Votre éditeur"
+    Et que je clique sur "M"
+    Et que je choisis "MGDIS"
+    Alors je vois 1 tuile
+    Et je vois 1 tuile "Nexys Relation Usagers"

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -395,6 +395,7 @@ FactoryBot.define do
       api-entreprise-provigis
       api-entreprise-achat-solution
       api-entreprise-mgdis
+      api-entreprise-mgdis-nexys-relation-usagers
       api-entreprise-atexo
       api-entreprise-setec-atexo
       api-entreprise-inetum


### PR DESCRIPTION
## Résumé

Ajoute un nouveau formulaire API Entreprise pour le produit « Nexys Relation Usagers » de l'éditeur MGDIS (second produit MGDIS, en plus de « Solution Portail des aides » qui existait déjà).

- Nouvelle entrée `api-entreprise-mgdis-nexys-relation-usagers` dans `config/authorization_request_forms/api_entreprise.yml`, réutilisant le modèle générique `AuthorizationRequest::APIEntreprise`, la vue partagée `api_entreprise_through_editor`, et le `service_provider` `mgdis` déjà enregistré — aucun nouveau modèle Ruby, vue ou migration.
- Volontairement aucune clé `scopes:` : `AuthorizationRequestForm#initialize_with` fusionne automatiquement les scopes open data flagués `included: true` (dont les 3 explicitement demandés : Sirene/Insee, Infogreffe RCS, DJEPVA), sans risque d'inclure une donnée protégée — comportement de plateforme commun à tous les formulaires éditeur API Entreprise.
- Contact métier/technique : réutilise à titre temporaire le contact générique MGDIS existant, en attente d'un contact dédié Nexys de la part de l'éditeur.
- Mise à jour du scénario Cucumber existant (MGDIS affiche désormais 2 tuiles) + nouveau scénario pour le filtre `use_case=portail_gru_instruction`.

Linear : API-7222

## Plan de test

- [x] `make e2e features/habilitations/api_entreprise/choix_formulaire.feature` — 9 scénarios, 9 passés
- [x] `make tests spec/acceptance/authorizations_configs_spec.rb` — 2 exemples, 0 échec
- [x] `make fix-lint` — 1169 fichiers inspectés, aucune infraction